### PR TITLE
Filter chain

### DIFF
--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -5,6 +5,7 @@ import { Readability } from '@mozilla/readability';
 import { applyFilters } from './filters';
 import browser from './browser-polyfill';
 import { convertDate } from './date-utils';
+import { debugLog } from './debug';
 
 export function extractReadabilityContent(doc: Document): ReturnType<Readability['parse']> {
 	const reader = new Readability(doc, {keepClasses:true})
@@ -34,11 +35,10 @@ async function processSelector(tabId: number, match: string, currentUrl: string)
 	// Convert content to string if it's an array
 	const contentString = Array.isArray(content) ? JSON.stringify(content) : content;
 	
-	if (filtersString) {
-		return applyFilters(contentString, filtersString, currentUrl);
-	}
+	debugLog('ContentExtractor', 'Applying filters:', { selector, filterString: filtersString });
+	const filteredContent = applyFilters(contentString, filtersString, currentUrl);
 	
-	return contentString;
+	return filteredContent;
 }
 
 async function processSchema(match: string, variables: { [key: string]: string }, currentUrl: string): Promise<string> {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -78,69 +78,120 @@ function parseFilterString(filterString: string): string[] {
 	let current = '';
 	let depth = 0;
 	let inQuote = false;
+	let escapeNext = false;
 
 	// Iterate through each character in the filterString
 	for (let i = 0; i < filterString.length; i++) {
 		const char = filterString[i];
 
-		// Toggle quote state if we encounter an unescaped quote
-		if (char === '"' && filterString[i - 1] !== '\\') {
+		if (escapeNext) {
+			current += char;
+			escapeNext = false;
+		} else if (char === '\\') {
+			current += char;
+			escapeNext = true;
+		} else if (char === '"' && !escapeNext) {
 			inQuote = !inQuote;
-		}
-
-		// Track parentheses depth when not inside quotes
-		if (!inQuote) {
+			current += char;
+		} else if (!inQuote) {
 			if (char === '(') depth++;
 			if (char === ')') depth--;
-		}
-
-		// If we encounter a colon at depth 0 and not in quotes, and it's the first colon
-		if (char === ':' && depth === 0 && !inQuote && parts.length === 0) {
-			// Add the current accumulated string as a part (filter name)
-			parts.push(current.trim());
-			current = ''; // Reset current
+			
+			if (char === ':' && depth === 0 && parts.length === 0) {
+				parts.push(current.trim());
+				current = '';
+			} else {
+				current += char;
+			}
 		} else {
-			// Otherwise, add the character to the current string
 			current += char;
 		}
 	}
 
-	// Add any remaining characters as the last part
 	if (current) {
 		parts.push(current.trim());
 	}
 
-	// If we have parameters, split them by the pipe character
+	// If we have parameters, split them by comma, respecting quotes and escaped characters
 	if (parts.length > 1) {
 		const [filterName, ...params] = parts;
-		const splitParams = params.join(':').split('|').map(param => param.trim());
-		return [filterName, ...splitParams];
-	}
-
-	// If only one part is found, check if it's a function-like syntax
-	if (parts.length === 1) {
-		const match = parts[0].match(/^(\w+)\s*\((.*)\)$/);
-		if (match) {
-			// If it matches, split the parameters by pipe and return
-			const params = match[2].split('|').map(param => param.trim());
-			return [match[1], ...params];
-		}
+		const splitParams = params.join(':').split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/);
+		return [filterName, ...splitParams.map(param => param.trim())];
 	}
 
 	return parts;
 }
 
+// This function splits the filter string into individual filter names, accounting for escaped pipes and quotes
+function splitFilterString(filterString: string): string[] {
+	const filters: string[] = [];
+	let current = '';
+	let inQuote = false;
+	let escapeNext = false;
+	let depth = 0;
+
+	// Iterate through each character in the filterString
+	for (let i = 0; i < filterString.length; i++) {
+		const char = filterString[i];
+
+		if (escapeNext) {
+			// If the previous character was a backslash, add this character as-is
+			current += char;
+			escapeNext = false;
+		} else if (char === '\\') {
+			// If this is a backslash, set escapeNext flag to true
+			current += char;
+			escapeNext = true;
+		} else if (char === '"' && !escapeNext) {
+			// If this is an unescaped quote, toggle the inQuote flag
+			current += char;
+			inQuote = !inQuote;
+		} else if (char === '(' && !inQuote) {
+			// If this is an opening parenthesis outside of quotes, increase depth
+			current += char;
+			depth++;
+		} else if (char === ')' && !inQuote) {
+			// If this is a closing parenthesis outside of quotes, decrease depth
+			current += char;
+			depth--;
+		} else if (char === '|' && !inQuote && depth === 0) {
+			// If this is a pipe character outside of quotes and parentheses,
+			// it's a filter separator. Add the current filter and reset.
+			filters.push(current.trim());
+			current = '';
+		} else {
+			// For any other character, simply add it to the current filter
+			current += char;
+		}
+	}
+
+	// Add the last filter if there's anything left in current
+	if (current) {
+		filters.push(current.trim());
+	}
+
+	return filters;
+}
+
 export function applyFilters(value: string | any[], filterString: string, currentUrl?: string): string {
+	debugLog('Filters', 'applyFilters called with:', { value, filterString, currentUrl });
+
+	if (!filterString) {
+		debugLog('Filters', 'Empty filter string, returning original value');
+		return typeof value === 'string' ? value : JSON.stringify(value);
+	}
+
 	let processedValue = value;
 
-	// Split the filter string into individual filter names
-	const filterNames = filterString.split('|').filter(Boolean);
+	// Split the filter string into individual filter names, accounting for escaped pipes and quotes
+	const filterNames = splitFilterString(filterString);
+	debugLog('Filters', 'Split filter string:', filterNames);
 
 	// Reduce through all filter names, applying each filter sequentially
 	const result = filterNames.reduce((result, filterName) => {
 			// Parse the filter string into name and parameters
 			const [name, ...params] = parseFilterString(filterName);
-			debugLog('Filters', `Applying filter: ${name}, Params:`, params);
+			debugLog('Filters', `Parsed filter: ${name}, Params:`, params);
 
 			// Get the filter function from the filters object
 			const filter = filters[name];
@@ -154,7 +205,7 @@ export function applyFilters(value: string | any[], filterString: string, curren
 				}
 				
 				// Apply the filter and get the output
-				const output = filter(stringInput, ...params);
+				const output = filter(stringInput, params.join(':'));
 				
 				debugLog('Filters', `Filter ${name} output:`, output);
 

--- a/src/utils/filters/callout.ts
+++ b/src/utils/filters/callout.ts
@@ -7,14 +7,17 @@ export const callout = (str: string, param?: string): string => {
 		// Remove outer parentheses if present
 		param = param.replace(/^\((.*)\)$/, '$1');
 		
-		// Split by comma, but respect quoted strings
-		const params = param.split(/,(?=(?:(?:[^"]*"){2})*[^"]*$)/).map(p => p.trim().replace(/^"|"$/g, ''));
+		// Split by comma, but respect both single and double quoted strings
+		const params = param.split(/,(?=(?:(?:[^"']*["'][^"']*["'])*[^"']*$))/).map(p => {
+			// Trim whitespace and remove surrounding quotes (both single and double)
+			return p.trim().replace(/^(['"])(.*)\1$/, '$2');
+		});
 		
 		if (params.length > 0) type = params[0] || type;
 		if (params.length > 1) title = params[1] || title;
 		if (params.length > 2) {
-			if (params[2] === 'true') foldState = '-';
-			else if (params[2] === 'false') foldState = '+';
+			if (params[2].toLowerCase() === 'true') foldState = '-';
+			else if (params[2].toLowerCase() === 'false') foldState = '+';
 		}
 	}
 

--- a/src/utils/filters/date.ts
+++ b/src/utils/filters/date.ts
@@ -6,10 +6,20 @@ dayjs.extend(customParseFormat);
 dayjs.extend(advancedFormat);
 
 export const date = (str: string, param?: string): string => {
-	// Remove outer parentheses if present and split by comma, respecting quotes
-	const paramMatches = param ? param.replace(/^\(|\)$/g, '').match(/(?:[^\s"]+|"[^"]*")+/g) : null;
-	const params = paramMatches || [];
-	const [outputFormat, inputFormat] = params.map(p => p.replace(/^"|"$/g, '').trim());
+	if (!param) {
+		return dayjs(str).format('YYYY-MM-DD');
+	}
+
+	// Remove outer parentheses if present
+	param = param.replace(/^\((.*)\)$/, '$1');
+	
+	// Split by comma, but respect both single and double quoted strings
+	const params = param.split(/,(?=(?:(?:[^"']*["'][^"']*["'])*[^"']*$))/).map(p => {
+		// Trim whitespace and remove surrounding quotes (both single and double)
+		return p.trim().replace(/^(['"])(.*)\1$/, '$2');
+	});
+
+	const [outputFormat, inputFormat] = params;
 
 	let date;
 	if (inputFormat) {
@@ -25,6 +35,5 @@ export const date = (str: string, param?: string): string => {
 		return str;
 	}
 
-	// Use outputFormat if provided, otherwise use 'YYYY-MM-DD' as default
-	return date.format(outputFormat || 'YYYY-MM-DD');
+	return date.format(outputFormat);
 };

--- a/src/utils/filters/date_modify.ts
+++ b/src/utils/filters/date_modify.ts
@@ -15,8 +15,11 @@ export const date_modify = (str: string, param?: string): string => {
 		return str;
 	}
 
+	// Remove outer parentheses if present
+	param = param.replace(/^\((.*)\)$/, '$1');
+	
 	// Remove any surrounding quotes and trim whitespace
-	param = param.replace(/^["']|["']$/g, '').trim();
+	param = param.replace(/^(['"])(.*)\1$/, '$2').trim();
 
 	// Updated regex to allow for optional spaces and plural units
 	const regex = /^([+-])\s*(\d+)\s*(\w+)s?$/;
@@ -36,7 +39,5 @@ export const date_modify = (str: string, param?: string): string => {
 		date = date.subtract(numericAmount, unit as any);
 	}
 
-	// Use 'YYYY-MM-DD' as default format, but allow for custom format
-	const format = param.split(',')[1]?.trim() || 'YYYY-MM-DD';
-	return date.format(format);
+	return date.format('YYYY-MM-DD');
 };

--- a/src/utils/filters/image.ts
+++ b/src/utils/filters/image.ts
@@ -1,9 +1,18 @@
 import { escapeMarkdown } from '../string-utils';
 
-export const image = (str: string, altText?: string): string => {
+export const image = (str: string, param?: string): string => {
 	if (!str.trim()) {
 		return str;
 	}
+
+	let altText = '';
+	if (param) {
+		// Remove outer parentheses if present
+		param = param.replace(/^\((.*)\)$/, '$1');
+		// Remove surrounding quotes (both single and double)
+		altText = param.replace(/^(['"])(.*)\1$/, '$2');
+	}
+
 	try {
 		const data = JSON.parse(str);
 		
@@ -17,19 +26,21 @@ export const image = (str: string, altText?: string): string => {
 		};
 
 		if (Array.isArray(data)) {
-			const result = data.flatMap(item => {
+			const result = data.map(item => {
 				if (typeof item === 'object' && item !== null) {
 					return processObject(item);
 				}
-				return item ? `![${altText || ''}](${escapeMarkdown(String(item))})` : '';
+				return item ? `![${altText}](${escapeMarkdown(String(item))})` : '';
 			});
-			return JSON.stringify(result);
+			return result.join('\n');
 		} else if (typeof data === 'object' && data !== null) {
-			return JSON.stringify(processObject(data));
+			return processObject(data).join('\n');
 		}
 	} catch (error) {
-		// If parsing fails, treat it as a single string
-		return `![${altText || ''}](${escapeMarkdown(str)})`;
+		// If parsing fails, treat it as a single URL string
+		return `![${altText}](${escapeMarkdown(str)})`;
 	}
+
+	// Add this line to satisfy the linter
 	return str;
 };

--- a/src/utils/filters/join.ts
+++ b/src/utils/filters/join.ts
@@ -7,9 +7,15 @@ export const join = (str: string, param?: string): string => {
 		return str;
 	}
 
-	if (Array.isArray(array)) {
-		const separator = param ? JSON.parse(`"${param}"`) : ',';
-		return array.join(separator);
+	if (!Array.isArray(array)) {
+		return str;
 	}
-	return str;
+
+	let separator = ',';
+	if (param) {
+		// Remove outer quotes if present
+		separator = param.replace(/^(['"])(.*)\1$/, '$2');
+	}
+
+	return array.join(separator);
 };

--- a/src/utils/filters/replace.ts
+++ b/src/utils/filters/replace.ts
@@ -10,8 +10,11 @@ export const replace = (str: string, param?: string): string => {
 	const replacements = param.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/).map(p => p.trim());
 
 	return replacements.reduce((acc, replacement) => {
-		const [search, replace] = replacement.split(':').map(p => p.trim().replace(/^["']|["']$/g, ''));
+		const [search, replace] = replacement.split(':').map(p => {
+			// Remove surrounding quotes and unescape characters
+			return p.trim().replace(/^["']|["']$/g, '').replace(/\\(.)/g, '$1');
+		});
 		// Use an empty string if replace is undefined or an empty string
-		return acc.split(search).join(replace || '');
+		return acc.replace(new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), replace || '');
 	}, str);
 };

--- a/src/utils/filters/replace.ts
+++ b/src/utils/filters/replace.ts
@@ -3,18 +3,30 @@ export const replace = (str: string, param?: string): string => {
 		return str;
 	}
 
-	// Remove outer parentheses if present
-	param = param.replace(/^\((.*)\)$/, '$1');
+	// Check if it's a single replacement or multiple
+	if (param.includes(',')) {
+		// Multiple replacements
+		// Remove outer parentheses if present
+		param = param.replace(/^\((.*)\)$/, '$1');
 
-	// Split the param into individual replacements
-	const replacements = param.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/).map(p => p.trim());
+		// Split the param into individual replacements, respecting nested parentheses
+		const replacements = param.match(/(?:[^,()]|\([^()]*\))+/g) || [];
 
-	return replacements.reduce((acc, replacement) => {
-		const [search, replace] = replacement.split(':').map(p => {
+		return replacements.reduce((acc, replacement) => {
+			const [search, replace] = replacement.split(':').map(p => {
+				// Remove surrounding quotes and unescape characters
+				return p.trim().replace(/^["']|["']$/g, '').replace(/\\(.)/g, '$1');
+			});
+			// Use an empty string if replace is undefined or an empty string
+			return acc.replace(new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), replace || '');
+		}, str);
+	} else {
+		// Single replacement
+		const [search, replace] = param.split(':').map(p => {
 			// Remove surrounding quotes and unescape characters
 			return p.trim().replace(/^["']|["']$/g, '').replace(/\\(.)/g, '$1');
 		});
 		// Use an empty string if replace is undefined or an empty string
-		return acc.replace(new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), replace || '');
-	}, str);
+		return str.replace(new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), replace || '');
+	}
 };

--- a/src/utils/filters/split.ts
+++ b/src/utils/filters/split.ts
@@ -1,11 +1,12 @@
 export const split = (str: string, param?: string): string => {
 	if (!param) {
-		console.error('Split filter requires a separator parameter');
 		return JSON.stringify([str]);
 	}
 
-	// Remove quotes from the param if present
-	param = param.replace(/^["']|["']$/g, '');
+	// Remove outer parentheses if present
+	param = param.replace(/^\((.*)\)$/, '$1');
+	// Remove surrounding quotes (both single and double)
+	param = param.replace(/^(['"])(.*)\1$/, '$2');
 
 	// If param is a single character, use it directly
 	const separator = param.length === 1 ? param : new RegExp(param);

--- a/src/utils/filters/strip_attr.ts
+++ b/src/utils/filters/strip_attr.ts
@@ -1,6 +1,6 @@
 export const strip_attr = (html: string, keepAttributes: string = ''): string => {
-	// Remove any surrounding quotes from keepAttributes
-	keepAttributes = keepAttributes.replace(/^['"](.*)['"]$/, '$1');
+	// Remove any surrounding quotes and unescape internal quotes
+	keepAttributes = keepAttributes.replace(/^['"](.*)['"]$/, '$1').replace(/\\"/g, '"');
 	
 	const keepAttributesList = keepAttributes.split(',').map(attr => attr.trim()).filter(Boolean);
 
@@ -10,7 +10,9 @@ export const strip_attr = (html: string, keepAttributes: string = ''): string =>
 		}
 
 		const keepAttrs = keepAttributesList.map(attr => {
-			const regex = new RegExp(`\\s${attr}\\s*=\\s*("[^"]*"|'[^']*')`, 'i');
+			// Escape special regex characters in the attribute name
+			const escapedAttr = attr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			const regex = new RegExp(`\\s${escapedAttr}\\s*=\\s*("[^"]*"|'[^']*')`, 'i');
 			const attrMatch = match.match(regex);
 			return attrMatch ? attrMatch[0] : '';
 		}).filter(Boolean).join(' ');

--- a/src/utils/filters/strip_attr.ts
+++ b/src/utils/filters/strip_attr.ts
@@ -1,6 +1,6 @@
 export const strip_attr = (html: string, keepAttributes: string = ''): string => {
-	// Remove any surrounding quotes and unescape internal quotes
-	keepAttributes = keepAttributes.replace(/^['"](.*)['"]$/, '$1').replace(/\\"/g, '"');
+	// Remove any surrounding quotes (both single and double) and unescape internal quotes
+	keepAttributes = keepAttributes.replace(/^(['"])(.*)\1$/, '$2').replace(/\\(['"])/g, '$1');
 	
 	const keepAttributesList = keepAttributes.split(',').map(attr => attr.trim()).filter(Boolean);
 

--- a/src/utils/filters/strip_tags.ts
+++ b/src/utils/filters/strip_tags.ts
@@ -1,6 +1,6 @@
 export const strip_tags = (html: string, keepTags: string = ''): string => {
-	// Remove any surrounding quotes and unescape internal quotes
-	keepTags = keepTags.replace(/^['"](.*)['"]$/, '$1').replace(/\\"/g, '"');
+	// Remove any surrounding quotes (both single and double) and unescape internal quotes
+	keepTags = keepTags.replace(/^(['"])(.*)\1$/, '$2').replace(/\\(['"])/g, '$1');
 	
 	const keepTagsList = keepTags.split(',').map(tag => tag.trim()).filter(Boolean);
 

--- a/src/utils/filters/strip_tags.ts
+++ b/src/utils/filters/strip_tags.ts
@@ -1,6 +1,6 @@
 export const strip_tags = (html: string, keepTags: string = ''): string => {
-	// Remove any surrounding quotes from keepTags
-	keepTags = keepTags.replace(/^['"](.*)['"]$/, '$1');
+	// Remove any surrounding quotes and unescape internal quotes
+	keepTags = keepTags.replace(/^['"](.*)['"]$/, '$1').replace(/\\"/g, '"');
 	
 	const keepTagsList = keepTags.split(',').map(tag => tag.trim()).filter(Boolean);
 
@@ -11,7 +11,8 @@ export const strip_tags = (html: string, keepTags: string = ''): string => {
 		result = html.replace(/<\/?[^>]+(>|$)/g, '');
 	} else {
 		// Create a regex that matches all tags except those in keepTagsList
-		const regex = new RegExp(`<(?!\\/?(?:${keepTagsList.join('|')})\\b)[^>]+>`, 'gi');
+		const escapedTags = keepTagsList.map(tag => tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+		const regex = new RegExp(`<(?!\\/?(?:${escapedTags})\\b)[^>]+>`, 'gi');
 		result = html.replace(regex, '');
 	}
 

--- a/src/utils/filters/template.ts
+++ b/src/utils/filters/template.ts
@@ -9,6 +9,11 @@ export const template = (input: string | any[], param?: string): string => {
 		return typeof input === 'string' ? input : JSON.stringify(input);
 	}
 
+	// Remove outer parentheses if present
+	param = param.replace(/^\((.*)\)$/, '$1');
+	// Remove surrounding quotes (both single and double)
+	param = param.replace(/^(['"])(.*)\1$/, '$2');
+
 	let obj: any[] = [];
 	if (typeof input === 'string') {
 		try {
@@ -36,16 +41,10 @@ function replaceTemplateVariables(obj: any, template: string): string {
 	debugLog('Template', 'Replacing template variables for:', obj);
 	debugLog('Template', 'Template:', template);
 
-	// Remove the outer quotes if they exist
-	template = template.replace(/^"(.*)"$/, '$1');
-	debugLog('Template', 'Template after quote removal:', template);
-
 	// If obj is a string that looks like an object, try to parse it
 	if (typeof obj === 'string') {
 		try {
-			// Remove any outer parentheses and parse
-			const objString = obj.replace(/^\(|\)$/g, '').trim();
-			obj = parseObjectString(objString);
+			obj = parseObjectString(obj);
 			debugLog('Template', 'Parsed object:', obj);
 		} catch (error) {
 			debugLog('Template', 'Failed to parse object string:', obj);

--- a/src/utils/filters/wikilink.ts
+++ b/src/utils/filters/wikilink.ts
@@ -1,7 +1,16 @@
-export const wikilink = (str: string, alias?: string): string => {
+export const wikilink = (str: string, param?: string): string => {
 	if (!str.trim()) {
 		return str;
 	}
+
+	let alias = '';
+	if (param) {
+		// Remove outer parentheses if present
+		param = param.replace(/^\((.*)\)$/, '$1');
+		// Remove surrounding quotes (both single and double)
+		alias = param.replace(/^(['"])(.*)\1$/, '$2');
+	}
+
 	try {
 		const data = JSON.parse(str);
 		


### PR DESCRIPTION
Fixes:

- Support escaping pipes in filters e.g. `replace:"\|",""`
- Support single and double quotes in filters where applicable
- Improved parsing of filters and params