### PR TITLE
Proposal: Addressing Attribute Capture Issue and Syntax Ambiguity

### DIFF
--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -19,20 +19,21 @@ export function extractReadabilityContent(doc: Document): ReturnType<Readability
 }
 
 async function processSelector(tabId: number, match: string, currentUrl: string): Promise<string> {
-	const selectorRegex = /{{(selector|selectorHtml):(.*?)(?:\|(.*?))?}}/;
+	const selectorRegex = /{{(selector|selectorHtml):([^{\|]*?)(?:{(.*?)}\s*)?(?:\|(.*?))?}}/;
 	const matches = match.match(selectorRegex);
 	if (!matches) {
 		console.error('Invalid selector format:', match);
 		return match;
 	}
 
-	const [, selectorType, selector, filtersString] = matches;
+	const [, selectorType, selector, attribute, filtersString] = matches;
 	const extractHtml = selectorType === 'selectorHtml';
 
 	try {
 		const response = await browser.tabs.sendMessage(tabId, { 
 			action: "extractContent", 
 			selector: selector,
+			attribute: attribute,
 			extractHtml: extractHtml
 		}) as { content: string };
 
@@ -122,7 +123,7 @@ function getNestedProperty(obj: any, path: string): any {
 }
 
 export async function replaceVariables(tabId: number, text: string, variables: { [key: string]: string }, currentUrl: string): Promise<string> {
-	const regex = /{{(?:schema:)?(?:selector:)?(?:prompt:)?(.*?)}}/g;
+	const regex = /{{(?:schema:)?(?:selector:)?(?:prompt:)?(.*)}}/g;
 	const matches = text.match(regex);
 
 	if (matches) {


### PR DESCRIPTION
### Overview:
While using the extension, I encountered an issue where the attribute capture functionality does not seem to work as described in the provided example:

```
{{selector:img:src}}
```

### Issue 1: Attribute Capture Not Working
The extension fails to capture the attribute (`src` in this case), which hinders its usage in scenarios that rely on this feature.

![image](https://github.com/user-attachments/assets/2cae5c0f-6772-454c-99e2-cfd8059e92df)
![image](https://github.com/user-attachments/assets/a0aee3d5-93cb-4e36-91a2-8176bef1daf4)

The simple reason the current version does not work is that we didn’t parse the attribute or pass the variable in the `processSelector` function from the file `src/utils/content-extractor.ts`.

However, parsing the attribute might be difficult, we don't know if the string is an attribute or a pseudo-class.

### Issue 2: Syntax Ambiguity
The current syntax introduces ambiguity, particularly when using colons (`:`), which conflict with common CSS pseudo-classes, such as:

```
img:nth-child(2)
```

This can lead to confusion and difficulty distinguishing between pseudo-classes and attributes.

### Proposed Solution:
To address both the functionality and the ambiguity, I propose the following revised syntax for capturing attributes:

```
{{selector:img{src}}}
```

This approach uses curly braces (`{}`) to denote attributes, eliminating any conflict with pseudo-classes while ensuring proper attribute capture.

![image](https://github.com/user-attachments/assets/52dd5749-08f3-4dbd-99ce-b33aa5526c3d)

Another example:

![image](https://github.com/user-attachments/assets/300de865-bd68-4136-a5ba-7aa029694cbe)
![image](https://github.com/user-attachments/assets/e02310a6-4c51-4370-97cb-4231642cb8bb)

### Next Steps:
If this syntax feels unfamiliar or if there are other preferences, feel free to change it to another syntax. My main objective is to help resolve the attribute capture issue and improve clarity in the syntax.