### PR TITLE
Fix ENAMETOOLONG by trimming basename to 250 characters

### DIFF
--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -44,7 +44,7 @@ export function sanitizeFileName(fileName: string): string {
 	// Common operations for all platforms
 	sanitized = sanitized
 		.replace(/^\.+/, '') // Remove leading periods
-		.slice(0, 255); // Trim to 255 characters
+		.slice(0, 250); // Trim to 250 characters, leaving room to append ' 1.md'
 
 	// Ensure the file name is not empty
 	if (sanitized.length === 0) {


### PR DESCRIPTION
Background:

If the title of a web page is long, there is code in `src/utils/string-utils.ts` that trims the title to 255 characters.

However, this code doesn't take into account that Obsidian will add `.md` (or in the case of a duplicate filename, ` 1.md`) to the title to create the filename.

The result: on long titles, Obsidian will hit an ENAMETOOLONG error and won't save the page.

This PR changes the trim to 250 characters, leaving room for Obsidian to add `.md`, ` 1.md`, or incremented single digits up to ` 9.md`.

I didn't trim more, because 250 is a nice round number, and because single digits allows saving up to 10 pages with the same title, which seems a reasonable limit. But the limit could easily be changed to 249 or 248.

For reference, filename length limits for Windows, Mac, Linux are typically 255 characters. (Additionally, Windows has a 260-character file path limit, but that can be overridden by the operator if need be. This patch doesn't address long file paths, only long filenames.)

My testing environment:

- Obsidian 1.7.3
- Apple M1 Max CPU
- macOS Sonoma 14.7
- Chrome 129.0.6668.60 (Official Build) (arm64)
- URL with long title: https://x.com/stevenbjohnson/status/1840844268065456456

With the given environment, the original code resulted in an ENAMETOOLONG error in Obsidian. With the new code, the same page can be saved up until the suffix reaches ` 9.md`.