### PR TITLE
Add clipboardWrite permissions to Firefox manifest

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -6,6 +6,7 @@
 	"description": "Save content from the web in a private and durable format that you can access offline. The official browser extension for Obsidian.",
 	"permissions": [
 		"activeTab",
+		"clipboardWrite",
 		"contextMenus",
 		"storage",
 		"scripting"


### PR DESCRIPTION
When debugging #132 I noticed that [this code path](https://github.com/obsidianmd/obsidian-clipper/blob/a325fa782d74300508db76ad0600d09ddc6f6c47/src/utils/obsidian-note-creator.ts#L115) was always being taken and emitting the `Clipboard write was blocked due to lack of user activation` exception.

Adding the [clipboardWrite](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#clipboardwrite) permission let it successfully use the clipboard.