### PR TITLE
fix: Weird font in Japanese (#204)

### DIFF
--- a/src/highlighter.scss
+++ b/src/highlighter.scss
@@ -56,7 +56,7 @@ body.obsidian-highlighter-active {
 	align-items: center;
 	gap: 4px;
 	z-index: 9999999999;
-	font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
+	font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 	font-size: var(--obsidian-highlighter-menu-font-size) !important;
 	font-weight: 600 !important;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2) !important;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -59,7 +59,7 @@
 	--font-smaller: var(--font-ui-smaller);
 	--font-small: var(--font-ui-small);
 
-	--font-default: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
+	--font-default: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 	--font-monospace-default: ui-monospace, SFMono-Regular, "Cascadia Mono", "Roboto Mono", "DejaVu Sans Mono", "Liberation Mono", Menlo, Monaco, "Consolas", "Source Code Pro", monospace;
 
 


### PR DESCRIPTION
Remove Microsoft YaHei Light which displays Japanese characters strangely.

Microsoft YaHei Light is only for Chinese and is rather harmful for other languages.

There should be no problem displaying Chinese. This is because the sans-serif specification will still be used.