### PR TITLE
:bug: fix: anthropic provider in interpreter.ts

### DIFF
--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -64,7 +64,7 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 				...headers,
 				'api-key': provider.apiKey
 			};
-		} else if (provider.id === 'anthropic') {
+		} else if (provider.name.toLowerCase().includes('anthropic')) {
 			requestBody = {
 				model: model.providerModelId,
 				max_tokens: 800,
@@ -142,7 +142,7 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 		lastRequestTime = now;
 
 		let llmResponseContent: string;
-		if (provider.id === 'anthropic') {
+		if (provider.name.toLowerCase().includes('anthropic')) {
 			llmResponseContent = data.content[0]?.text || JSON.stringify(data);
 		} else if (provider.name.toLowerCase().includes('ollama')) {
 			const messageContent = data.message?.content;


### PR DESCRIPTION
# Fix Anthropic Provider Detection in Firefox

## Problem
The clipper was failing to properly detect Anthropic-based models in Firefox due to strict provider ID matching.

## Solution
Modified the provider detection logic to check for 'anthropic' in the provider name (case-insensitive) instead of exact ID matching. This makes the detection more robust across different environments.

Changes:
- Replace `provider.id === 'anthropic'` with `provider.name.toLowerCase().includes('anthropic')`
- This change affects both provider detection conditions in the code

## Testing
Verified working in Firefox 133.0 (aarch64) with Anthropic models:
![Screenshot 2024-12-09 at 1 38 31 AM](https://github.com/user-attachments/assets/1afa5bba-c927-4b5b-b3f0-a656ea94be27)
