### PR TITLE
Handle <br /> nodes in preformattedCode

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -526,8 +526,14 @@ export function createMarkdownContent(content: string, url: string) {
 				} else if (element instanceof HTMLElement) {
 					let text = '';
 					element.childNodes.forEach(child => {
-						if (child instanceof HTMLElement && child.classList.contains('ec-line')) {
-							text += extractStructuredText(child) + '\n';
+						if (child instanceof HTMLElement) {
+							if (child.classList.contains('ec-line')) {
+								text += extractStructuredText(child) + '\n';
+							} else if (child.tagName === 'BR') {
+								text += '\n';
+							} else {
+								text += extractStructuredText(child);
+							}
 						} else {
 							text += extractStructuredText(child);
 						}


### PR DESCRIPTION
Fixes #145 

In preformatted code blocks highlighted by hljs, there are `<br />` elements used to break up newlines. These weren't getting handled by `extractStructuredText`, so I added a handler for it.

When working on this, I noticed another issue: it appears that comments are getting stripped from hljs code blocks 😱  if you try the clipper out on the medium article linked in #145, you can see that aside from newlines, comments are missing. This seems a little more tricky, because by the time the `content` makes it's way to the preformattedCode rule, it's already missing comments.

I can open up a separate ticket for that if it would be helpful :)