### PR TITLE
Fix: Remove `overflow: hidden` from the document body after highlighting (#254)

### DIFF
--- a/src/utils/extractors/youtube.ts
+++ b/src/utils/extractors/youtube.ts
@@ -17,7 +17,8 @@ export class YoutubeExtractor extends BaseExtractor {
 
 	extract(): ExtractorResult {
 		const videoData = this.getVideoData();
-		const formattedDescription = this.formatDescription(videoData.description || '');
+		const description = videoData.description || '';
+		const formattedDescription = this.formatDescription(description);
 		const contentHtml = `<iframe width="560" height="315" src="https://www.youtube.com/embed/${this.getVideoId()}?si=_m0qv33lAuJFoGNh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe><br>${formattedDescription}`;
 
 		return {
@@ -33,7 +34,7 @@ export class YoutubeExtractor extends BaseExtractor {
 				site: 'YouTube',
 				image: Array.isArray(videoData.thumbnailUrl) ? videoData.thumbnailUrl[0] || '' : '',
 				published: videoData.uploadDate ? convertDate(new Date(videoData.uploadDate)) : '',
-				description: videoData.description.slice(0, 200).trim() || '',
+				description: description.slice(0, 200).trim(),
 			}
 		};
 	}


### PR DESCRIPTION
Fix: Remove 'overflow: hidden' from document body after highlighting (#254)

## Description
This pull request fixes a bug where the `overflow: hidden` CSS rule persists on the document body after using the highlight option in the Web Clipper. This causes unintended layout issues that remain on the page even after the highlighting operation is complete.

## Environment
- OS: Reproduced on Windows 11 23H2
- Browser: Firefox 133.0
- Web Clipper version: 0.10.5
- Obsidian version: 1.7.7

## Current Solution
The current fix simply removes the `overflow: hidden` style from the document body once highlighting is complete. While this resolves the immediate issue, there may definitely be more optimal approaches 😄 

## Testing
1. Visit xing.com (or any other web page)
2. Use highlight option
3. Verify `overflow: hidden` is properly removed after highlighting finishes
4. Confirm page layout returns to normal

Fixes #254