### PR TITLE
Fix Markdown link formatting and spacing issues (#260)

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -759,7 +759,7 @@ export function createMarkdownContent(content: string, url: string) {
 		// Format space around Markdown links
 		markdown = markdown
 			// Add a space before links that directly follow text
- 			.replace(/(?<=[^!\s])(\[[^\]]+\]\(([^)]+)\))/g, ' $1')
+			.replace(/(?<=[^!\s(),])(\[[^\]]+\]\(([^)]+)\))/g, ' $1')
 			// Remove multiple spaces after links and replace them with a single space
 			.replace(/(?<!!)(\[[^\]]+\]\s*\([^)]+\))\s+/g, '$1 ')
 


### PR DESCRIPTION
This pull request addresses Issue #260 by fixing formatting issues in inline links and improving the handling of spaces around links in text.

## Changes Made

1. **Removed Extra Spaces in Links**  
   Unnecessary spaces within inline links have been removed to ensure proper formatting:  
   - **Before:** `[

2

](https://pubmed.ncbi.nlm.nih.gov/27572733/)`
- **After:** `[2](https://pubmed.ncbi.nlm.nih.gov/27572733/)`

2. **Added Space Before Links**  
   A space is now added when a link directly follows a block of text, improving readability:  
   - **Before:** `text[1](https://example.com)`
   - **After:** `text [1](https://example.com)`

3. **Replaced Multiple Spaces After Links**  
   Consecutive spaces after links are replaced by a single space to maintain clean formatting:
   - **Before:**  
     `native cellular environments [1](https://blog.delmic.com/subtomogram-averaging-in-the-cryo-et-workflow)

[2](https://pubmed.ncbi.nlm.nih.gov/27572733/).`
   - **After:**  
     `native cellular environments [1](https://blog.delmic.com/subtomogram-averaging-in-the-cryo-et-workflow) [2](https://pubmed.ncbi.nlm.nih.gov/27572733/).`
     
I welcome any feedback or suggestions to improve this pr.


![CleanShot 2024-12-15 at 22 56 25@2x](https://github.com/user-attachments/assets/bf8330a6-689c-4d2c-884e-8d6885fe918a)
![CleanShot 2024-12-15 at 22 57 17@2x](https://github.com/user-attachments/assets/d2f629bc-ebfb-4a64-bbc9-3755dd950be5)

