### PR TITLE
fix: `x.com` pattern (fixes #290)

### DIFF
--- a/src/utils/extractor-registry.ts
+++ b/src/utils/extractor-registry.ts
@@ -22,7 +22,7 @@ export class ExtractorRegistry {
 		this.register({
 			patterns: [
 				'twitter.com',
-				'x.com'
+				/\/x\.com\/.*/,
 			],
 			extractor: TwitterExtractor
 		});


### PR DESCRIPTION
fix the `x.com` pattern is being recognized in all domains ending with `x.com`.

#290, the domain `vox.com` was being recognized as a twitter extractor (`vo[x.com]`)