### PR TITLE
Add new footnote check in the markdown filter

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -378,13 +378,16 @@ export function createMarkdownContent(content: string, url: string) {
 	// Update the reference list rule
 	turndownService.addRule('referenceList', {
 		filter: (node: Node): boolean => {
-			if (node instanceof HTMLElement) {
+			if (node instanceof HTMLOListElement) {
 				return (
-					(node.nodeName === 'OL' && node.classList.contains('references')) ||
-					(node.nodeName === 'OL' && node.classList.contains('footnotes-list')) ||
-					(node.nodeName === 'UL' && node.classList.contains('ltx_biblist')) ||
-					(node.nodeName === 'OL' && node.parentElement?.classList?.contains('footnotes') === true)
+					node.classList.contains('references') ||
+					node.classList.contains('footnotes-list') ||
+					node.parentElement?.classList?.contains('footnote') === true ||
+					node.parentElement?.classList?.contains('footnotes') === true
 				);
+			}
+			if (node instanceof HTMLUListElement) {
+				return node.classList.contains('ltx_biblist')
 			}
 			return false;
 		},


### PR DESCRIPTION
`markdown` filter now correctly gets the footnotes of #293

Tested with `{{selectorHtml:.posts-item-body|markdown}}`

Changes:
Added a new check for `footnote` class in parentElement.
Refactored the type guard to reduce the number of checks.


Also, it looks like you're removing Readability, so I didn't check for a fix in `{{content}}`.