### PR TITLE
Update replace filter to support non-capturing groups in regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-clipper",
-	"version": "0.10.6",
+	"version": "0.10.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-clipper",
-			"version": "0.10.6",
+			"version": "0.10.8",
 			"dependencies": {
 				"@mozilla/readability": "^0.5.0",
 				"@types/mozilla-readability": "^0.2.1",

--- a/src/utils/filters/replace.ts
+++ b/src/utils/filters/replace.ts
@@ -1,6 +1,8 @@
 import { createParserState, processCharacter, parseRegexPattern } from '../parser-utils';
 
 export const replace = (str: string, param?: string): string => {
+	//console.log('replace', { str, param });
+
 	if (!param) {
 		return str;
 	}
@@ -15,7 +17,7 @@ export const replace = (str: string, param?: string): string => {
 	for (let i = 0; i < param.length; i++) {
 		const char = param[i];
 
-		if (char === ',' && !state.inQuote && !state.inRegex && 
+		if (char === ',' && !state.inQuote && !state.inRegex &&
 			state.curlyDepth === 0 && state.parenDepth === 0) {
 			replacements.push(state.current.trim());
 			state.current = '';
@@ -28,9 +30,11 @@ export const replace = (str: string, param?: string): string => {
 		replacements.push(state.current.trim());
 	}
 
+	//console.log('replacements', replacements);
+
 	// Apply each replacement in sequence
 	return replacements.reduce((acc, replacement) => {
-		let [search, replace] = replacement.split(/(?<!\\):/).map(p => {
+		let [search, replace] = replacement.split(/(?<!\\)(?<![\(\?])(?!\?):/).map(p => {
 			// Remove surrounding quotes but preserve escaped characters
 			return p.trim().replace(/^["']|["']$/g, '');
 		});

--- a/src/utils/filters/replace.ts
+++ b/src/utils/filters/replace.ts
@@ -34,7 +34,7 @@ export const replace = (str: string, param?: string): string => {
 
 	// Apply each replacement in sequence
 	return replacements.reduce((acc, replacement) => {
-		let [search, replace] = replacement.split(/(?<!\\)(?<![\(\?])(?!\?):/).map(p => {
+		let [search, replace] = replacement.split(/(?<!\\|\(\?):/).map(p => {
 			// Remove surrounding quotes but preserve escaped characters
 			return p.trim().replace(/^["']|["']$/g, '');
 		});

--- a/src/utils/filters/replace.ts
+++ b/src/utils/filters/replace.ts
@@ -1,8 +1,6 @@
 import { createParserState, processCharacter, parseRegexPattern } from '../parser-utils';
 
 export const replace = (str: string, param?: string): string => {
-	//console.log('replace', { str, param });
-
 	if (!param) {
 		return str;
 	}
@@ -29,8 +27,6 @@ export const replace = (str: string, param?: string): string => {
 	if (state.current) {
 		replacements.push(state.current.trim());
 	}
-
-	//console.log('replacements', replacements);
 
 	// Apply each replacement in sequence
 	return replacements.reduce((acc, replacement) => {

--- a/src/utils/filters/replace.ts
+++ b/src/utils/filters/replace.ts
@@ -34,7 +34,7 @@ export const replace = (str: string, param?: string): string => {
 
 	// Apply each replacement in sequence
 	return replacements.reduce((acc, replacement) => {
-		let [search, replace] = replacement.split(/(?<!\\|\(\?):/).map(p => {
+		let [search, replace] = replacement.split(/(?<=[^\\]["']):(?=["'])/).map(p => {
 			// Remove surrounding quotes but preserve escaped characters
 			return p.trim().replace(/^["']|["']$/g, '');
 		});


### PR DESCRIPTION
Non-capturing groups are defined by: (?:...)

The colon was being used as a splitter and breaking the non-capturing group in the replace regex.

This has been fixed by preventing a split if the colon is preceded by (?

