### PR TITLE
Add option to automatically copy to clipboard

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -141,6 +141,9 @@ browser.commands.onCommand.addListener(async (command, tab) => {
 		await ensureContentScriptLoaded(tab.id);
 		toggleHighlighterMode(tab.id);
 	}
+	if (command === "copy_to_clipboard" && tab && tab.id) {
+		await browser.tabs.sendMessage(tab.id, { action: "copyToClipboard" });
+	}
 });
 
 const debouncedUpdateContextMenu = debounce(async (tabId: number) => {

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -619,6 +619,9 @@ async function handleClip() {
 		// Only close the window if it's not running in side panel mode
 		if (!isSidePanel) {
 			setTimeout(() => window.close(), 500);
+			if (generalSettings.autoCopyToClipboard) {
+				await copyToClipboard(fileContent);
+			}
 		}
 	} catch (error) {
 		console.error('Error in handleClip:', error);

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -194,6 +194,7 @@ export function initializeGeneralSettings(): void {
 		initializeExportImportAllSettingsButtons();
 		initializeHighlighterSettings();
 		initializeExportHighlightsButton();
+		initializeAutoCopyToClipboardToggle();
 		await initializeUsageChart();
 
 		// Initialize feedback modal close button
@@ -222,6 +223,7 @@ function saveSettingsFromForm(): void {
 	const highlighterToggle = document.getElementById('highlighter-toggle') as HTMLInputElement;
 	const alwaysShowHighlightsToggle = document.getElementById('highlighter-visibility') as HTMLInputElement;
 	const highlightBehaviorSelect = document.getElementById('highlighter-behavior') as HTMLSelectElement;
+	const autoCopyToClipboardToggle = document.getElementById('auto-copy-clipboard-toggle') as HTMLInputElement;
 
 	const updatedSettings = {
 		...generalSettings, // Keep existing settings
@@ -231,7 +233,8 @@ function saveSettingsFromForm(): void {
 		silentOpen: silentOpenToggle?.checked ?? generalSettings.silentOpen,
 		highlighterEnabled: highlighterToggle?.checked ?? generalSettings.highlighterEnabled,
 		alwaysShowHighlights: alwaysShowHighlightsToggle?.checked ?? generalSettings.alwaysShowHighlights,
-		highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior
+		highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior,
+		autoCopyToClipboard: autoCopyToClipboardToggle?.checked ?? generalSettings.autoCopyToClipboard
 	};
 
 	saveSettings(updatedSettings);
@@ -314,6 +317,12 @@ function initializeResetDefaultTemplateButton(): void {
 	if (resetDefaultTemplateBtn) {
 		resetDefaultTemplateBtn.addEventListener('click', resetDefaultTemplate);
 	}
+}
+
+function initializeAutoCopyToClipboardToggle(): void {
+	initializeSettingToggle('auto-copy-clipboard-toggle', generalSettings.autoCopyToClipboard, (checked) => {
+		saveSettings({ autoCopyToClipboard: checked });
+	});
 }
 
 export function resetDefaultTemplate(): void {

--- a/src/popup.html
+++ b/src/popup.html
@@ -85,19 +85,6 @@
 									Share...
 								</div>
 							</div>
-							<div class="menu-item" id="auto-copy-toggle">
-								<div class="menu-item-icon">
-									<i data-lucide="clipboard"></i>
-								</div>
-								<div class="menu-item-title" data-i18n="autoCopyToClipboard">
-									Auto copy to clipboard
-								</div>
-								<div class="menu-item-control">
-									<div class="checkbox-container">
-										<input type="checkbox" id="auto-copy-checkbox" />
-									</div>
-								</div>
-							</div>
 						</div>
 					</div>
 					<div class="share-btn">

--- a/src/popup.html
+++ b/src/popup.html
@@ -85,6 +85,19 @@
 									Share...
 								</div>
 							</div>
+							<div class="menu-item" id="auto-copy-toggle">
+								<div class="menu-item-icon">
+									<i data-lucide="clipboard"></i>
+								</div>
+								<div class="menu-item-title" data-i18n="autoCopyToClipboard">
+									Auto copy to clipboard
+								</div>
+								<div class="menu-item-control">
+									<div class="checkbox-container">
+										<input type="checkbox" id="auto-copy-checkbox" />
+									</div>
+								</div>
+							</div>
 						</div>
 					</div>
 					<div class="share-btn">

--- a/src/settings.html
+++ b/src/settings.html
@@ -200,6 +200,17 @@
 										<button type="button" id="import-all-settings-btn" data-i18n="import">Import</button>
 									</div>
 								</div>
+								<div class="setting-item mod-horizontal normal-only">
+									<div class="setting-item-info">
+										<label for="auto-copy-clipboard-toggle">Auto copy to clipboard</label>
+										<div class="setting-item-description">Automatically copy clipped content to the clipboard.</div>
+									</div>
+									<div class="setting-item-control">
+										<div class="checkbox-container">
+											<input type="checkbox" id="auto-copy-clipboard-toggle" />
+										</div>
+									</div>
+								</div>
 							</div>
 						</form>
 					</div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -72,6 +72,7 @@ export interface Settings {
 	};
 	history: HistoryEntry[];
 	ratings: Rating[];
+	autoCopyToClipboard: boolean;
 }
 
 export interface ModelConfig {

--- a/src/utils/obsidian-note-creator.ts
+++ b/src/utils/obsidian-note-creator.ts
@@ -1,7 +1,7 @@
 import browser from './browser-polyfill';
 import { escapeDoubleQuotes, sanitizeFileName } from '../utils/string-utils';
 import { Template, Property } from '../types/types';
-import { generalSettings } from './storage-utils';
+import { generalSettings, incrementStat } from './storage-utils';
 
 export async function generateFrontmatter(properties: Property[]): Promise<string> {
 	let frontmatter = '---\n';
@@ -71,6 +71,13 @@ export async function saveToObsidian(
 	vault: string,
 	behavior: Template['behavior'],
 ): Promise<void> {
+	// If autoCopyToClipboard is enabled, only copy to clipboard and don't save to Obsidian
+	if (generalSettings.autoCopyToClipboard) {
+		await navigator.clipboard.writeText(fileContent);
+		await incrementStat('copyToClipboard', vault, path);
+		return; // Exit early before creating Obsidian URL or opening Obsidian
+	}
+
 	let obsidianUrl: string;
 
 	const isDailyNote = behavior === 'append-daily' || behavior === 'prepend-daily';

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -1,6 +1,7 @@
 import browser from './browser-polyfill';
 import { Settings, ModelConfig, PropertyType, HistoryEntry, Provider, Rating } from '../types/types';
 import { debugLog } from './debug';
+import { copyToClipboard } from 'core/popup';
 
 export type { Settings, ModelConfig, PropertyType, HistoryEntry, Provider, Rating };
 
@@ -27,7 +28,8 @@ export let generalSettings: Settings = {
 		share: 0
 	},
 	history: [],
-	ratings: []
+	ratings: [],
+	autoCopyToClipboard: false
 };
 
 export function setLocalStorage(key: string, value: any): Promise<void> {
@@ -44,6 +46,7 @@ interface StorageData {
 		betaFeatures?: boolean;
 		legacyMode?: boolean;
 		silentOpen?: boolean;
+		autoCopyToClipboard?: boolean;
 	};
 	vaults?: string[];
 	highlighter_settings?: {
@@ -98,6 +101,7 @@ interface LegacyStorageData {
 		betaFeatures?: boolean;
 		legacyMode?: boolean;
 		silentOpen?: boolean;
+		autoCopyToClipboard?: boolean;
 	};
 	vaults?: string[];
 	highlighter_settings?: {
@@ -229,6 +233,7 @@ export async function loadSettings(): Promise<Settings> {
 		interpreterAutoRun: false,
 		defaultPromptContext: '',
 		propertyTypes: [],
+		autoCopyToClipboard: false,
 		stats: {
 			addToObsidian: 0,
 			saveFile: 0,
@@ -236,7 +241,7 @@ export async function loadSettings(): Promise<Settings> {
 			share: 0
 		},
 		history: [],
-		ratings: []
+		ratings: [],
 	};
 
 	if (await needsMigration(data)) {
@@ -274,7 +279,8 @@ export async function loadSettings(): Promise<Settings> {
 		propertyTypes: data.property_types || defaultSettings.propertyTypes,
 		stats: data.stats || defaultSettings.stats,
 		history: data.history || defaultSettings.history,
-		ratings: data.ratings || defaultSettings.ratings
+		ratings: data.ratings || defaultSettings.ratings,
+		autoCopyToClipboard: data.general_settings?.autoCopyToClipboard ?? defaultSettings.autoCopyToClipboard	
 	};
 
 	generalSettings = loadedSettings;
@@ -293,7 +299,8 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 			showMoreActionsButton: generalSettings.showMoreActionsButton,
 			betaFeatures: generalSettings.betaFeatures,
 			legacyMode: generalSettings.legacyMode,
-			silentOpen: generalSettings.silentOpen
+			silentOpen: generalSettings.silentOpen,
+			autoCopyToClipboard: generalSettings.autoCopyToClipboard
 		},
 		highlighter_settings: {
 			highlighterEnabled: generalSettings.highlighterEnabled,


### PR DESCRIPTION
Add option to automatically copy generated content to clipboard

* Add a new setting in `src/core/popup.ts` to enable automatic copying to the clipboard
* Implement the automatic copy to clipboard functionality in `src/core/popup.ts`
* Update the `handleClip` function in `src/core/popup.ts` to check the new setting
* Add a new keyboard hotkey for copying to the clipboard in `src/background.ts`
* Implement the functionality to handle the new hotkey in `src/background.ts`
* Add a new setting in the popup interface in `src/popup.html` to enable automatic copying to the clipboard
* Add a new property to the `Settings` interface in `src/types/types.ts` for the automatic copy to clipboard setting

