### PR TITLE
Fix: Convert class "markdown-alert" into "callout"

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -909,6 +909,36 @@ export function createMarkdownContent(content: string, url: string) {
 		return tableClone.outerHTML;
 	}
 
+	turndownService.addRule('markdownAlert', {
+		filter: (node) => {
+			return (
+				node.nodeName.toLowerCase() === 'div' && 
+				node.classList.contains('markdown-alert')
+			);
+		},
+		replacement: (content, node) => {
+			const element = node as HTMLElement;
+			
+			// Get alert type from the class (e.g., markdown-alert-note -> NOTE)
+			const alertClasses = Array.from(element.classList);
+			const typeClass = alertClasses.find(c => c.startsWith('markdown-alert-') && c !== 'markdown-alert');
+			const type = typeClass ? typeClass.replace('markdown-alert-', '').toUpperCase() : 'NOTE';
+
+			// Find the title element and content
+			const titleElement = element.querySelector('.markdown-alert-title');
+			const contentElement = element.querySelector('p:not(.markdown-alert-title)');
+			
+			// Extract content, removing the title from it if present
+			let alertContent = content;
+			if (titleElement && titleElement.textContent) {
+				alertContent = contentElement?.textContent || content.replace(titleElement.textContent, '');
+			}
+
+			// Format as Obsidian callout
+			return `\n> [!${type}]\n> ${alertContent.trim().replace(/\n/g, '\n> ')}\n`;
+		}
+	});
+
 	try {
 		let markdown = turndownService.turndown(processedContent);
 		debugLog('Markdown', 'Markdown conversion successful');


### PR DESCRIPTION
### Summary
This PR addresses automatically extracting `markdown-alert`(s) into callouts, just like from class `alert is-info`
Issue link: https://github.com/obsidianmd/obsidian-clipper/issues/209

### Changes Introduced
- Added additional rule in `TurnDownService` for handling `markdown-alert` syntax as an edge case

### Testing Done:
- Compiled and ran web clipper in chrome://extensions in Developer Mode
- Fed HTML doc with test data in `<body>`
```
<div class="markdown-alert markdown-alert-note" dir="auto">
    <p class="markdown-alert-title" dir="auto">
        <svg class="octicon octicon-info" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
            <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
        </svg>Note</p>
    <p dir="auto">I <em>guess</em> it has something to do with really large table (with spaces) in this file, as if the long line (with <code class="notranslate">&lt;br&gt;</code>) is removed, and trimmed down, issue does not occur. If I disable front matter complement, the issue/freeze/lag does not occur.</p>
</div>
```
- Ran web-clipper
- Inspect results. Expected output:
```
> (NOTE]
> I guess it has something to do with really large table (with spaces) in this file, as if the long line (with <br>) s removed, and trimmed down, issue does not occur. if I disable front matter complement, the issue/freeze/lag does not occur.
```

### Screenshot:
![Screenshot 2025-02-15 at 2 25 35 PM](https://github.com/user-attachments/assets/850f4b92-67e7-406f-94cf-cb1cff509c99)

P.S. Long time user of this product. Love everything y'all do - Devin