### PR TITLE
Make highlight overlays sticky on nonstandard scrolling

### DIFF
--- a/src/utils/each-frame.ts
+++ b/src/utils/each-frame.ts
@@ -1,0 +1,28 @@
+// Runs func once (deduplicated) per frame until duration is over
+// Returned function resets timer
+export function toRunEachFrame<T extends (...args: any[]) => any>(func: T, duration: number): (...args: Parameters<T>) => void {
+    let endTime: number | null = null;
+    let callbackId: number | null = null;
+
+    function applyIfNotEnded(timestamp: number) {
+        if (!endTime) {
+            endTime = timestamp + duration;
+        }
+        if (timestamp < endTime) {
+            func();
+            callbackId = requestAnimationFrame(applyIfNotEnded);
+        }
+    }
+
+    function resetEndTime() {
+        if (callbackId != null) {
+            cancelAnimationFrame(callbackId);
+        }
+        if (endTime != null) {
+            endTime = null;
+        }
+        callbackId = requestAnimationFrame(applyIfNotEnded);
+    }
+
+    return resetEndTime;
+}

--- a/src/utils/each-frame.ts
+++ b/src/utils/each-frame.ts
@@ -1,6 +1,6 @@
 // Runs func once (deduplicated) per frame until duration is over
 // Returned function resets timer
-export function toRunEachFrame<T extends (...args: any[]) => any>(func: T, duration: number): (...args: Parameters<T>) => void {
+export function toRunEachFrame<T extends (...args: any[]) => any>(func: T, duration: number, finalCallDelay?: number): (...args: Parameters<T>) => void {
     let endTime: number | null = null;
     let callbackId: number | null = null;
 
@@ -11,6 +11,10 @@ export function toRunEachFrame<T extends (...args: any[]) => any>(func: T, durat
         if (timestamp < endTime) {
             func();
             callbackId = requestAnimationFrame(applyIfNotEnded);
+        } else {
+            if (finalCallDelay !== undefined) {
+                setTimeout(func, finalCallDelay);
+            }
         }
     }
 

--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -11,6 +11,7 @@ import {
 	updateHighlighterMenu
 } from './highlighter';
 import { throttle } from './throttle';
+import { toRunEachFrame } from './each-frame';
 import { getElementByXPath, isDarkColor } from './dom-utils';
 
 let hoverOverlay: HTMLElement | null = null;
@@ -346,34 +347,8 @@ function watchScrollableElements() {
 		return style.overflowY === 'auto' || style.overflowY === 'scroll' || style.overflowX === 'auto' || style.overflowX === 'scroll';
 	}
 
-	function toApplyEachFrameUntil(fn: () => void, duration: number) {
-		let endTime: number | null = null;
-		let callbackId: number | null = null;
-
-		function applyIfNotEnded(timestamp: number) {
-			if (!endTime) {
-				endTime = timestamp + duration
-			}
-			if (timestamp < endTime) {
-				fn();
-				callbackId = requestAnimationFrame(applyIfNotEnded);
-			}
-		}
-
-		function resetEndTime() {
-			if (callbackId != null) {
-				cancelAnimationFrame(callbackId);
-			}
-			if (endTime != null) {
-				endTime = null;
-			}
-			callbackId = requestAnimationFrame(applyIfNotEnded)
-		}
-
-		return resetEndTime;
-	}
-
-	const updateHighlightsEachFrame = toApplyEachFrameUntil(updateHighlightOverlayPositions, 200)
+	// 200ms duration required for long custom scrolling animations (e.g. Grok)
+	const updateHighlightsEachFrame = toRunEachFrame(updateHighlightOverlayPositions, 200);
 
 	const handleScroll = () => {
 		updateHighlightsEachFrame();

--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -348,7 +348,7 @@ function watchScrollableElements() {
 	}
 
 	// 200ms duration required for long custom scrolling animations (e.g. Grok)
-	const updateHighlightsEachFrame = toRunEachFrame(updateHighlightOverlayPositions, 200);
+	const updateHighlightsEachFrame = toRunEachFrame(updateHighlightOverlayPositions, 200, 1000);
 
 	const handleScroll = () => {
 		updateHighlightsEachFrame();


### PR DESCRIPTION
Fixes #263 

When scrolling inside an internal scrollable element or on pages with custom scrolling behavior, highlight overlays would desync from their target element. This fixes the issue by watching for relevant events and reattaching the overlays for a short period. One final attempt is delayed to catch even longer scrolling animations.

If performance suffers on low-end devices, `toRunEachFrame(updateHighlightOverlayPositions, 200, 1000)` can be changed to a simple `requestAnimationFrame(updateHighlightOverlayPositions)` to fix internal element scrolling (such as Obsidian web pages), but pages that intercept `wheel` events and do custom scrolling (like Grok) will remain desynced. If performance is not an issue, `toRunEachFrame` can be changed to run for a longer period or indefinitely.

