### PR TITLE
Eliminate gaps/blank lines in HTML for proper rendering in Note

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -109,8 +109,11 @@ declare global {
 				});
 			});
 
-			// Get the modified HTML without scripts, styles, and style attributes
-			const cleanedHtml = doc.documentElement.outerHTML;
+			// Get the modified HTML without scripts, styles, style attributes, and blank lines (for rendering)
+			const cleanedHtml = doc.documentElement.outerHTML
+				.split('\n')
+				.filter(line => line.trim() !== '')
+				.join('\n');
 
 			const response: ContentResponse = {
 				author: defuddled.author,


### PR DESCRIPTION
I noticed that additional blank lines in the fully processed HTML was creating rendering issues within the Obsidian note. This pull request simply adds an additional step to ensure all gaps are removed so that it properly renders.