### PR TITLE
feat(i18n): Add i18n for shortcuts

### DIFF
--- a/src/utils/hotkeys.ts
+++ b/src/utils/hotkeys.ts
@@ -1,4 +1,5 @@
 import browser from './browser-polyfill';
+import { getMessage } from './i18n';
 
 interface Command {
 	name: string;
@@ -6,11 +7,20 @@ interface Command {
 	shortcut: string | null;
 }
 
-export async function getCommands(): Promise<Command[]> {
+// Mapping from command name in manifest to message key in messages.json
+const commandNameToMessageKey: { [key: string]: string } = {
+	// chrome default command
+	'_execute_action': 'commandOpenClipper',
+	'quick_clip': 'commandQuickClip',
+	'toggle_highlighter': 'commandToggleHighlighter',
+	'toggle_reader': 'commandToggleReader'
+};
+
+export async function getCommands (): Promise<Command[]> {
 	const commands = await browser.commands.getAll();
 	return commands.map(cmd => ({
 		name: cmd.name || '',
-		description: cmd.description || 'Open clipper',
+		description: getMessage(commandNameToMessageKey[cmd.name || ''] || 'Open clipper'),
 		shortcut: cmd.shortcut || null
 	}));
 }


### PR DESCRIPTION

Improve internationalization support for shortcuts commands.

## Code Changed
* Added a `commandNameToMessageKey` mapping to associate command names from the manifest with message keys in `messages.json`. This enables dynamic lookup of localized descriptions.
* Updated the `description` field in the `getCommands` function to use the `getMessage` function for retrieving localized text based on the new mapping.

### Before
- The shortcuts commands **did not change** based on the selected language.
<img width="500" alt="SCR-20250423-nzkd" src="https://github.com/user-attachments/assets/19487a68-ee84-40d2-aaa8-078114c68155" />

### After
<img width="500" alt="SCR-20250423-nyiv" src="https://github.com/user-attachments/assets/d8bb776a-0c35-429d-85f9-b14809d0cbf5" />


