### PR TITLE
Add `selection` and `selectionHtml` variables 

### DIFF
--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -17,24 +17,26 @@ Preset variables are automatically generated based on the page content. These ty
 
 The main content variable is `{{content}}`, which contains the article content, or the [[Highlight web pages|highlights]], or the selection if there is any selected text on the page. Note that `{{content}}` attempts to extract the main content of the page, which may not always be what you want. In that case, you can use other preset variables or selector variables to extract the content you need.
 
-| Variable          | Description                                                                            |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| `{{author}}`      | Author of the page                                                                     |
-| `{{content}}`     | Article content, [[Highlight web pages\|highlights]], or selection, in Markdown format |
-| `{{contentHtml}}` | Article content, [[Highlight web pages\|highlights]], or selection, in HTML format     |
-| `{{date}}`        | Current date, can be formatted using the `date` filter                                 |
-| `{{description}}` | Description or excerpt                                                                 |
-| `{{domain}}`      | Domain                                                                                 |
-| `{{favicon}}`     | Favicon URL                                                                            |
-| `{{fullHtml}}`    | Unprocessed HTML for the full page content                                             |
-| `{{highlights}}`  | [[Highlight web pages\|Highlights]] with text and timestamps                           |
-| `{{image}}`       | Social share image URL                                                                 |
-| `{{published}}`   | Published date, can be formatted using the `date` filter                               |
-| `{{site}}`        | Site name or publisher                                                                 |
-| `{{title}}`       | Title of the page                                                                      |
-| `{{time}}`        | Current date and time                                                                  |
-| `{{url}}`         | Current URL                                                                            |
-| `{{words}}`       | Word count                                                                             |
+| Variable            | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `{{author}}`        | Author of the page                                                                     |
+| `{{content}}`       | Article content, [[Highlight web pages\|highlights]], or selection, in Markdown format |
+| `{{contentHtml}}`   | Article content, [[Highlight web pages\|highlights]], or selection, in HTML format     |
+| `{{selection}}`     | Selection in Markdown format                                                           |
+| `{{selectionHtml}}` | Selection in HTML format                                                               |
+| `{{date}}`          | Current date, can be formatted using the `date` filter                                 |
+| `{{description}}`   | Description or excerpt                                                                 |
+| `{{domain}}`        | Domain                                                                                 |
+| `{{favicon}}`       | Favicon URL                                                                            |
+| `{{fullHtml}}`      | Unprocessed HTML for the full page content                                             |
+| `{{highlights}}`    | [[Highlight web pages\|Highlights]] with text and timestamps                           |
+| `{{image}}`         | Social share image URL                                                                 |
+| `{{published}}`     | Published date, can be formatted using the `date` filter                               |
+| `{{site}}`          | Site name or publisher                                                                 |
+| `{{title}}`         | Title of the page                                                                      |
+| `{{time}}`          | Current date and time                                                                  |
+| `{{url}}`           | Current URL                                                                            |
+| `{{words}}`         | Word count                                                                             |
 
 ## Prompt variables
 

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -125,6 +125,7 @@ export async function initializePageContent(
 		}
 
 		const markdownBody = createMarkdownContent(content, currentUrl);
+		const selectedMarkdown = selectedHtml ? markdownBody : createMarkdownContent(selectedHtml, currentUrl)
 
 		// Convert each highlight to markdown individually and create an object with text, timestamp, and notes (if not empty)
 		const highlightsData = highlights.map(highlight => {
@@ -148,6 +149,8 @@ export async function initializePageContent(
 			'{{author}}': author.trim(),
 			'{{content}}': markdownBody.trim(),
 			'{{contentHtml}}': content.trim(),
+			'{{selection}}': selectedMarkdown.trim(),
+			'{{selectionHtml}}': selectionHtml.trim(),
 			'{{date}}': dayjs().format('YYYY-MM-DDTHH:mm:ssZ').trim(),
 			'{{time}}': dayjs().format('YYYY-MM-DDTHH:mm:ssZ').trim(),
 			'{{description}}': description.trim(),


### PR DESCRIPTION
This PR adds new, separate variables containing only the content selected by the user (if any) in both markdown and HTML format. Currently, the `content` variable contains the selection if there is one, and otherwise the page contents or highlights. 

I wanted my clipper template to capture selected text, but not default to clipping the entire page contents if there isn't a selection, so thought adding a separate variable for just the selection would be the way to go. 