### PR TITLE
Fix: Sidebar behaviour for Vivaldi

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -326,7 +326,7 @@
 		"message": "Failed to save provider. Please try again."
 	},
 	"firefoxPermissionRequired": {
-		"message": "Additional permissions required. To open Web Clipper from the highlighter, go to about:config and set this to true:\\n\\nextensions.openPopupWithoutUserGesture.enabled"
+		"message": "Additional permissions required. To open Web Clipper from the highlighter, go to about:config and set this to true: extensions.openPopupWithoutUserGesture.enabled"
 	},
 	"feedback": {
 		"message": "Feedback"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -106,6 +106,18 @@
 			}
 		}
 	},
+	"clipperOpenMode": {
+		"message": "Clipper UI open mode"
+	},
+	"clipperOpenModeDescription": {
+		"message": "Choose how the clipper UI opens. The default is to open in a new tab, but you can also open it in a popup window or in the current tab."
+	},
+	"clipperOpenModePopup": {
+		"message": "Popup (default)"
+	},
+	"clipperOpenModeSidePanel": {
+		"message": "Side panel (Chromium only)"
+	},
 	"close": {
 		"message": "Close"
 	},
@@ -312,6 +324,9 @@
 	},
 	"failedToSaveProvider": {
 		"message": "Failed to save provider. Please try again."
+	},
+	"firefoxPermissionRequired": {
+		"message": "Additional permissions required. To open Web Clipper from the highlighter, go to about:config and set this to true:\\n\\nextensions.openPopupWithoutUserGesture.enabled"
 	},
 	"feedback": {
 		"message": "Feedback"

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -139,6 +139,14 @@ async function initializeVersionDisplay(): Promise<void> {
 
 export function initializeGeneralSettings(): void {
 	loadSettings().then(async () => {
+		// Initialize clipper open mode dropdown
+		const clipperOpenModeDropdown = document.getElementById('clipper-open-mode-dropdown') as HTMLSelectElement;
+		if (clipperOpenModeDropdown) {
+			clipperOpenModeDropdown.value = generalSettings.clipperOpenMode || 'popup';
+			clipperOpenModeDropdown.addEventListener('change', () => {
+				saveSettings({ ...generalSettings, clipperOpenMode: clipperOpenModeDropdown.value as 'popup' | 'sidepanel' });
+			});
+		}
 		await setupLanguageAndDirection();
 
 		// Add version check initialization
@@ -216,26 +224,28 @@ function initializeAutoSave(): void {
 }
 
 function saveSettingsFromForm(): void {
-	const showMoreActionsToggle = document.getElementById('show-more-actions-toggle') as HTMLInputElement;
-	const betaFeaturesToggle = document.getElementById('beta-features-toggle') as HTMLInputElement;
-	const legacyModeToggle = document.getElementById('legacy-mode-toggle') as HTMLInputElement;
-	const silentOpenToggle = document.getElementById('silent-open-toggle') as HTMLInputElement;
-	const highlighterToggle = document.getElementById('highlighter-toggle') as HTMLInputElement;
-	const alwaysShowHighlightsToggle = document.getElementById('highlighter-visibility') as HTMLInputElement;
-	const highlightBehaviorSelect = document.getElementById('highlighter-behavior') as HTMLSelectElement;
+const showMoreActionsToggle = document.getElementById('show-more-actions-toggle') as HTMLInputElement;
+const betaFeaturesToggle = document.getElementById('beta-features-toggle') as HTMLInputElement;
+const legacyModeToggle = document.getElementById('legacy-mode-toggle') as HTMLInputElement;
+const silentOpenToggle = document.getElementById('silent-open-toggle') as HTMLInputElement;
+const highlighterToggle = document.getElementById('highlighter-toggle') as HTMLInputElement;
+const alwaysShowHighlightsToggle = document.getElementById('highlighter-visibility') as HTMLInputElement;
+const highlightBehaviorSelect = document.getElementById('highlighter-behavior') as HTMLSelectElement;
+const clipperOpenModeDropdown = document.getElementById('clipper-open-mode-dropdown') as HTMLSelectElement;
 
-	const updatedSettings = {
-		...generalSettings, // Keep existing settings
-		showMoreActionsButton: showMoreActionsToggle?.checked ?? generalSettings.showMoreActionsButton,
-		betaFeatures: betaFeaturesToggle?.checked ?? generalSettings.betaFeatures,
-		legacyMode: legacyModeToggle?.checked ?? generalSettings.legacyMode,
-		silentOpen: silentOpenToggle?.checked ?? generalSettings.silentOpen,
-		highlighterEnabled: highlighterToggle?.checked ?? generalSettings.highlighterEnabled,
-		alwaysShowHighlights: alwaysShowHighlightsToggle?.checked ?? generalSettings.alwaysShowHighlights,
-		highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior
-	};
+const updatedSettings = {
+	...generalSettings, // Keep existing settings
+	showMoreActionsButton: showMoreActionsToggle?.checked ?? generalSettings.showMoreActionsButton,
+	betaFeatures: betaFeaturesToggle?.checked ?? generalSettings.betaFeatures,
+	legacyMode: legacyModeToggle?.checked ?? generalSettings.legacyMode,
+	silentOpen: silentOpenToggle?.checked ?? generalSettings.silentOpen,
+	highlighterEnabled: highlighterToggle?.checked ?? generalSettings.highlighterEnabled,
+	alwaysShowHighlights: alwaysShowHighlightsToggle?.checked ?? generalSettings.alwaysShowHighlights,
+	highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior,
+	clipperOpenMode: clipperOpenModeDropdown?.value as 'popup' | 'sidepanel' ?? generalSettings.clipperOpenMode,
+};
 
-	saveSettings(updatedSettings);
+saveSettings(updatedSettings);
 }
 
 function initializeShowMoreActionsToggle(): void {
@@ -318,14 +328,14 @@ function initializeResetDefaultTemplateButton(): void {
 }
 
 function initializeSaveBehaviorDropdown(): void {
-    const dropdown = document.getElementById('save-behavior-dropdown') as HTMLSelectElement;
-    if (!dropdown) return;
+	const dropdown = document.getElementById('save-behavior-dropdown') as HTMLSelectElement;
+	if (!dropdown) return;
 
-    dropdown.value = generalSettings.saveBehavior;
-    dropdown.addEventListener('change', () => {
-        const newValue = dropdown.value as 'addToObsidian' | 'copyToClipboard' | 'saveFile';
-        saveSettings({ saveBehavior: newValue });
-    });
+	dropdown.value = generalSettings.saveBehavior;
+	dropdown.addEventListener('change', () => {
+		const newValue = dropdown.value as 'addToObsidian' | 'copyToClipboard' | 'saveFile';
+		saveSettings({ saveBehavior: newValue });
+	});
 }
 
 export function resetDefaultTemplate(): void {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -16,9 +16,17 @@
 		"<all_urls>",
 		"http://*/*",
 		"https://*/*"
-	],
-	"action": {
+	],	"action": {
 		"default_popup": "popup.html",
+		"default_icon": {
+			"16": "icons/icon16.png",
+			"48": "icons/icon48.png",
+			"128": "icons/icon128.png"
+		}
+	},
+	"sidebar_action": {
+		"default_panel": "side-panel.html",
+		"default_title": "Obsidian Web Clipper",
 		"default_icon": {
 			"16": "icons/icon16.png",
 			"48": "icons/icon48.png",

--- a/src/settings.html
+++ b/src/settings.html
@@ -148,8 +148,7 @@
 											<input type="checkbox" id="beta-features-toggle" />
 										</div>
 									</div>
-								</div>
-								<div class="setting-item mod-horizontal">
+								</div>								<div class="setting-item">
 								<div class="setting-item-info">
 									<label for="clipper-open-mode-dropdown" data-i18n="clipperOpenMode">Clipper UI open mode</label>
 									<div class="setting-item-description" data-i18n="clipperOpenModeDescription">

--- a/src/settings.html
+++ b/src/settings.html
@@ -60,6 +60,20 @@
 							<div id="usage-chart" class="usage-chart"></div>
 						</div>
 						<form id="general-settings-form">
+							<div class="setting-item mod-horizontal">
+								<div class="setting-item-info">
+									<label for="clipper-open-mode-dropdown" data-i18n="clipperOpenMode">Clipper UI open mode</label>
+									<div class="setting-item-description" data-i18n="clipperOpenModeDescription">
+										Choose how the Clipper UI opens when you use the highlighter: as a popup window (default) or in the Chrome side panel (Chrome only).
+									</div>
+								</div>
+								<div class="setting-item-control">
+									<select id="clipper-open-mode-dropdown">
+										<option value="popup" data-i18n="clipperOpenModePopup">Popup (default)</option>
+										<option value="sidepanel" data-i18n="clipperOpenModeSidepanel">Chrome side panel</option>
+									</select>
+								</div>
+							</div>
 							<div>
 								<div class="setting-item mod-horizontal is-hidden" id="rate-extension">
 									<div class="setting-item-info">

--- a/src/settings.html
+++ b/src/settings.html
@@ -60,20 +60,7 @@
 							<div id="usage-chart" class="usage-chart"></div>
 						</div>
 						<form id="general-settings-form">
-							<div class="setting-item mod-horizontal">
-								<div class="setting-item-info">
-									<label for="clipper-open-mode-dropdown" data-i18n="clipperOpenMode">Clipper UI open mode</label>
-									<div class="setting-item-description" data-i18n="clipperOpenModeDescription">
-										Choose how the Clipper UI opens when you use the highlighter: as a popup window (default) or in the Chrome side panel (Chrome only).
-									</div>
-								</div>
-								<div class="setting-item-control">
-									<select id="clipper-open-mode-dropdown">
-										<option value="popup" data-i18n="clipperOpenModePopup">Popup (default)</option>
-										<option value="sidepanel" data-i18n="clipperOpenModeSidepanel">Chrome side panel</option>
-									</select>
-								</div>
-							</div>
+
 							<div>
 								<div class="setting-item mod-horizontal is-hidden" id="rate-extension">
 									<div class="setting-item-info">
@@ -161,6 +148,20 @@
 											<input type="checkbox" id="beta-features-toggle" />
 										</div>
 									</div>
+								</div>
+								<div class="setting-item mod-horizontal">
+								<div class="setting-item-info">
+									<label for="clipper-open-mode-dropdown" data-i18n="clipperOpenMode">Clipper UI open mode</label>
+									<div class="setting-item-description" data-i18n="clipperOpenModeDescription">
+										Choose how the Clipper UI opens when you use the highlighter: as a popup window (default) or in the side panel (Chromeium only).
+									</div>
+								</div>
+								<div class="setting-item-control">
+									<select id="clipper-open-mode-dropdown">
+										<option value="popup" data-i18n="clipperOpenModePopup">Popup (default)</option>
+										<option value="sidepanel" data-i18n="clipperOpenModeSidepanel">Side panel (Chromium only)</option>
+									</select>
+								</div>
 								</div>
 								<div class="setting-item">
 									<div class="setting-item-info">

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -86,6 +86,11 @@ export interface Settings {
 	history: HistoryEntry[];
 	ratings: Rating[];
 	saveBehavior: 'addToObsidian' | 'saveFile' | 'copyToClipboard';
+
+	/**
+	 * Determines how the clipper UI is opened: 'popup' (default) or 'sidepanel'.
+	 */
+	clipperOpenMode?: 'popup' | 'sidepanel';
 }
 
 export interface ModelConfig {

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -179,8 +179,7 @@ async function handleClipButtonClick(e: Event) {
 				} else {
 					throw new Error('Invalid response from background script');
 				}
-			}
-			// Firefox sidebarAction support
+			}			// Firefox sidebarAction support
 			else if (
 				browserType === 'firefox' &&
 				browser.sidebarAction &&

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -36,6 +36,7 @@ export let generalSettings: Settings = {
 	},
 	history: [],
 	ratings: [],
+	clipperOpenMode: 'popup',
 	saveBehavior: 'addToObsidian'
 };
 
@@ -48,13 +49,14 @@ export function getLocalStorage(key: string): Promise<any> {
 }
 
 interface StorageData {
-	general_settings?: {
-		showMoreActionsButton?: boolean;
-		betaFeatures?: boolean;
-		legacyMode?: boolean;
-		silentOpen?: boolean;
-		saveBehavior?: 'addToObsidian' | 'copyToClipboard' | 'saveFile';
-	};
+   general_settings?: {
+	   showMoreActionsButton?: boolean;
+	   betaFeatures?: boolean;
+	   legacyMode?: boolean;
+	   silentOpen?: boolean;
+	   saveBehavior?: 'addToObsidian' | 'copyToClipboard' | 'saveFile';
+	   clipperOpenMode?: 'popup' | 'sidepanel';
+   };
 	vaults?: string[];
 	highlighter_settings?: {
 		highlighterEnabled?: boolean;
@@ -125,7 +127,8 @@ export async function loadSettings(): Promise<Settings> {
 			share: 0
 		},
 		history: [],
-		ratings: [],
+	   ratings: [],
+	   clipperOpenMode: 'popup',
 	};
 
 	// Update migration version if needed
@@ -161,7 +164,8 @@ export async function loadSettings(): Promise<Settings> {
 		stats: data.stats || defaultSettings.stats,
 		history: data.history || defaultSettings.history,
 		ratings: data.ratings || defaultSettings.ratings,
-		saveBehavior: data.general_settings?.saveBehavior ?? defaultSettings.saveBehavior
+	   saveBehavior: data.general_settings?.saveBehavior ?? defaultSettings.saveBehavior,
+	   clipperOpenMode: data.general_settings?.clipperOpenMode ?? defaultSettings.clipperOpenMode
 	};
 
 	generalSettings = loadedSettings;
@@ -174,15 +178,16 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 		generalSettings = { ...generalSettings, ...settings };
 	}
 
-	await browser.storage.sync.set({
-		vaults: generalSettings.vaults,
-		general_settings: {
-			showMoreActionsButton: generalSettings.showMoreActionsButton,
-			betaFeatures: generalSettings.betaFeatures,
-			legacyMode: generalSettings.legacyMode,
-			silentOpen: generalSettings.silentOpen,
-			saveBehavior: generalSettings.saveBehavior,
-		},
+   await browser.storage.sync.set({
+	   vaults: generalSettings.vaults,
+	   general_settings: {
+		   showMoreActionsButton: generalSettings.showMoreActionsButton,
+		   betaFeatures: generalSettings.betaFeatures,
+		   legacyMode: generalSettings.legacyMode,
+		   silentOpen: generalSettings.silentOpen,
+		   saveBehavior: generalSettings.saveBehavior,
+		   clipperOpenMode: generalSettings.clipperOpenMode,
+	   },
 		highlighter_settings: {
 			highlighterEnabled: generalSettings.highlighterEnabled,
 			alwaysShowHighlights: generalSettings.alwaysShowHighlights,


### PR DESCRIPTION
This pull request introduces a new feature to configure how the Clipper UI opens, adds support for side panel functionality in Chromium-based browsers and Firefox, and updates the settings and context menu accordingly. The most important changes are grouped below by theme.

### New Feature: Clipper UI Open Mode
* Added a new `clipperOpenMode` setting to allow users to choose how the Clipper UI opens: as a popup (default) or in a side panel (Chromium-only). This includes updates to the settings interface, dropdown initialization, and saving/loading logic. (`src/types/types.ts` [[1]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6R89-R93) `src/utils/storage-utils.ts` [[2]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbR39) [[3]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbR58) [[4]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbR131) [[5]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbL164-R168) [[6]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbR189) `src/managers/general-settings.ts` [[7]](diffhunk://#diff-e2a6f1491b6fed56017948f619e32f4d543463ffe214bf3bf421b38d35f6f945R142-R149) [[8]](diffhunk://#diff-e2a6f1491b6fed56017948f619e32f4d543463ffe214bf3bf421b38d35f6f945R234) [[9]](diffhunk://#diff-e2a6f1491b6fed56017948f619e32f4d543463ffe214bf3bf421b38d35f6f945L235-R245) `src/settings.html` [[10]](diffhunk://#diff-12230a30964d8e269766887dc72c950838ff40c03a31d1959002adda1e973c4eR151-R163)

### Side Panel and Sidebar Support
* Added support for opening the Clipper UI in the side panel for Chromium-based browsers using the Chrome API. (`src/background.ts` [[1]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR142-R181) [[2]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL227-R279) [[3]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL262-R318)

### Context Menu Updates
* Updated context menus to include options for opening the side panel in Chromium-based browsers and the sidebar in Firefox. (`src/background.ts` [[1]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL227-R279) [[2]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL262-R318)

### Localization Updates
* Added new localization strings for the `clipperOpenMode` setting and a Firefox-specific permissions message. (`src/_locales/en/messages.json` [[1]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412R109-R120) [[2]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412R328-R330)

### Highlighter Integration
* Updated the highlighter's clip button behavior to respect the `clipperOpenMode` setting and handle errors based on the browser type. (`src/utils/highlighter.ts` [[1]](diffhunk://#diff-95077ffb436237758645c1d32cbd6a0f6864df04750c07d6efb8eed0b1a4c783R163-R201) [[2]](diffhunk://#diff-95077ffb436237758645c1d32cbd6a0f6864df04750c07d6efb8eed0b1a4c783R210-R216)