### PR TITLE
Fixed clipper not correctly choosing src for images with srcset

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -143,7 +143,6 @@ export function createMarkdownContent(content: string, url: string) {
 		replacement: function(content, node) {
 			const figure = node as HTMLElement;
 			const img = figure.querySelector('img');
-			console.log(img)
 			const figcaption = figure.querySelector('figcaption');
 			
 			if (!img) return content;
@@ -159,7 +158,7 @@ export function createMarkdownContent(content: string, url: string) {
 				// deconstruct the srcset urls
 				const srcsetUrls = srcset.split(",%20");
 				for (let url of srcsetUrls) {
-					
+
 					const split = url.split("%20");
 					const srcUrl = split[0];
 					const width = parseInt(split[1]);
@@ -174,10 +173,7 @@ export function createMarkdownContent(content: string, url: string) {
 				src = images[0].src;
 			}
 
-			
-
-
-			console.log({alt, src, srcset})
+		
 			let caption = '';
 
 			if (figcaption) {
@@ -667,10 +663,8 @@ export function createMarkdownContent(content: string, url: string) {
 	}
 
 	try {
-		console.log(processedContent)
-		
+
 		let markdown = turndownService.turndown(processedContent);
-		console.log(markdown)
 		debugLog('Markdown', 'Markdown conversion successful');
 
 		// Remove the title from the beginning of the content if it exists
@@ -696,7 +690,6 @@ export function createMarkdownContent(content: string, url: string) {
 		
 		// Clear the footnotes object for the next conversion
 		Object.keys(footnotes).forEach(key => delete footnotes[key]);
-		console.log(markdown)
 
 		return markdown.trim();
 	} catch (error) {

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -143,12 +143,41 @@ export function createMarkdownContent(content: string, url: string) {
 		replacement: function(content, node) {
 			const figure = node as HTMLElement;
 			const img = figure.querySelector('img');
+			console.log(img)
 			const figcaption = figure.querySelector('figcaption');
 			
 			if (!img) return content;
 
 			const alt = img.getAttribute('alt') || '';
-			const src = img.getAttribute('src') || '';
+			let src = img.getAttribute('src') || '';
+			const srcset = img.getAttribute('srcset') || '';
+
+			if (srcset) {
+
+				let images: {src: string, width: number}[] = [];
+
+				// deconstruct the srcset urls
+				const srcsetUrls = srcset.split(",%20");
+				for (let url of srcsetUrls) {
+					
+					const split = url.split("%20");
+					const srcUrl = split[0];
+					const width = parseInt(split[1]);
+
+					images.push({src: srcUrl, width});
+				}
+
+				// we need to choose one of the images to use from the srcset
+				// for convenience, simply grab the first one
+				// this could be updated to take width into account
+
+				src = images[0].src;
+			}
+
+			
+
+
+			console.log({alt, src, srcset})
 			let caption = '';
 
 			if (figcaption) {
@@ -638,7 +667,10 @@ export function createMarkdownContent(content: string, url: string) {
 	}
 
 	try {
+		console.log(processedContent)
+		
 		let markdown = turndownService.turndown(processedContent);
+		console.log(markdown)
 		debugLog('Markdown', 'Markdown conversion successful');
 
 		// Remove the title from the beginning of the content if it exists
@@ -664,6 +696,7 @@ export function createMarkdownContent(content: string, url: string) {
 		
 		// Clear the footnotes object for the next conversion
 		Object.keys(footnotes).forEach(key => delete footnotes[key]);
+		console.log(markdown)
 
 		return markdown.trim();
 	} catch (error) {


### PR DESCRIPTION
This is a small fix for issue https://github.com/obsidianmd/obsidian-clipper/issues/450

Some images use the `srcset` attribute rather than the `src` attribute in the raw html. The web clipper currently grabs the (invalid) src url and fails to embed. This PR simply grabs the first image present in the `srcset` if present and replaces the default `src`.