### PR TITLE
npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1502,14 +1502,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {


### PR DESCRIPTION
This PR addresses _1 critical_ security vulnerability per `npm audit` by updating the `form-data` from `4.0.2` to `4.0.4`.