### PR TITLE
Fix: wrap property names with special characters in quotes for Obsidian frontmatter

### DIFF
--- a/src/utils/obsidian-note-creator.ts
+++ b/src/utils/obsidian-note-creator.ts
@@ -6,7 +6,10 @@ import { generalSettings, incrementStat } from './storage-utils';
 export async function generateFrontmatter(properties: Property[]): Promise<string> {
 	let frontmatter = '---\n';
 	for (const property of properties) {
-		frontmatter += `${property.name}:`;
+		// Wrap property name in quotes if it contains special characters (colon, space, etc.)
+		const needsQuotes = /[:\s]/.test(property.name);
+		const propertyKey = needsQuotes ? `"${property.name}"` : property.name;
+		frontmatter += `${propertyKey}:`;
 
 		const propertyType = generalSettings.propertyTypes.find(p => p.name === property.name)?.type || 'text';
 


### PR DESCRIPTION
This PR fixes #540. It ensures that property names containing special characters (such as colons or spaces) are automatically wrapped in double quotes when generating YAML frontmatter. This prevents errors in Obsidian when saving properties like 'Status: Rate:'." --base main --head fix-property-quotes