### PR TITLE
support importing multiple templates at once

### DIFF
--- a/src/utils/import-modal.ts
+++ b/src/utils/import-modal.ts
@@ -69,7 +69,9 @@ export async function showImportModal(
 		e.stopPropagation();
 		const files = e.dataTransfer?.files;
 		if (files && files.length > 0) {
-			handleFile(files[0]);
+			Array.prototype.forEach.call(files, (file) => {
+				handleFile(file)
+			})
 		}
 	}
 
@@ -78,15 +80,18 @@ export async function showImportModal(
 		e.stopPropagation();
 		fileInput = document.createElement('input');
 		fileInput.type = 'file';
+		fileInput.multiple = true
 		fileInput.accept = fileExtension;
 		fileInput.onchange = handleFileInputChange;
 		fileInput.click();
 	}
 
 	function handleFileInputChange(event: Event): void {
-		const file = (event.target as HTMLInputElement).files?.[0];
-		if (file) {
-			handleFile(file);
+		const files = (event.target as HTMLInputElement).files
+		if (files && files.length > 0) {
+			Array.prototype.forEach.call(files, (file) => {
+				handleFile(file)
+			})
 		}
 		// Clean up the file input
 		if (fileInput) {


### PR DESCRIPTION
So my use case is that I have a folder of templates that I want to use across potentially several computers. I'd like to be able to drag and drop the whole folder into the extension rather than importing them one by one.

Long term I believe the plan is to let the user put their templates in a folder - but I think this PR still has short term value.