### PR TITLE
Add Ollama Turbo support and update request handling in interpreter

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -68,6 +68,18 @@
 			{ "id": "Llama-3.3-70B-Instruct", "name": "Llama 3.3 70B" }
 		]
 	},
+  "ollamaturbo": {
+		"id": "ollamaturbo",
+		"name": "Ollama Turbo",
+    "apiKeyUrl": "https://ollama.com/settings/keys",
+		"apiKeyRequired": true,
+		"modelsList": "https://ollama.com/models",
+		"baseUrl": "https://ollama.com/api/chat",
+		"popularModels": [
+			{ "id": "gpt-oss:20b", "name": "GPT OSS 20B" },
+			{ "id": "gpt-oss:120b", "name": "GPT OSS 120B" }
+		]
+	},
 	"ollama": {
 		"id": "ollama",
 		"name": "Ollama",

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -110,16 +110,36 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 					{ role: 'user', content: `
 						"${promptContext}"
 						"${JSON.stringify(promptContent)}"`
-					}
-				]
-			};
-			headers = {
-				...headers,
-				'HTTP-Referer': 'https://obsidian.md/',
-				'X-Title': 'Obsidian Web Clipper',
-				'Authorization': `Bearer ${provider.apiKey}`
-			};
-		} else if (provider.name.toLowerCase().includes('ollama')) {
+          }
+        ]
+      };
+      headers = {
+        ...headers,
+        'HTTP-Referer': 'https://obsidian.md/',
+        'X-Title': 'Obsidian Web Clipper',
+        'Authorization': `Bearer ${provider.apiKey}`
+      };
+    } else if (provider.name.toLowerCase().includes("turbo")) {
+      requestUrl = provider.baseUrl;
+      requestBody = {
+        model: model.providerModelId,
+        messages: [
+          { role: 'system', content: systemContent },
+          { role: 'user', content: `${promptContext}` },
+          { role: 'user', content: `${JSON.stringify(promptContent)}` }
+        ],
+        format: 'json',
+        num_ctx: 120000,
+        temperature: 0.5,
+        stream: false
+      };
+      headers = {
+        ...headers, 
+        'HTTP-Referer': 'https://obsidian.md/', 
+        'X-Title': 'Obsidian Web Clipper', 
+        'Authorization': `Bearer ${provider.apiKey}`
+      };
+		} else if (provider.name.toLowerCase().includes('ollama') && !provider.name.toLowerCase().includes("turbo")) {
 			requestUrl = provider.baseUrl;
 			requestBody = {
 				model: model.providerModelId,


### PR DESCRIPTION
I submitted an issue about Turbo being added as a hosted option for Ollama (#580). It turned out to be super easy to implement, just adding an option with a header. Works perfectly. 