### PR TITLE
feat: Add conditional logic and variable assignment to template engine

### DIFF
--- a/src/utils/tags/if.ts
+++ b/src/utils/tags/if.ts
@@ -1,0 +1,172 @@
+import { processSchema } from '../variables/schema';
+import { processVariables } from '../template-compiler';
+
+export async function processIfCondition(
+	match: RegExpExecArray,
+	variables: { [key: string]: any },
+	currentUrl: string,
+	processLogic: (text: string, variables: { [key: string]: any }, currentUrl: string) => Promise<string>
+): Promise<string> {
+	console.log('Processing if condition:', match[0]);
+
+	const [fullMatch, condition, ifContent, elseContent] = match;
+
+	let conditionValue: any;
+
+	try {
+		// Evaluate the condition
+		conditionValue = await evaluateCondition(condition.trim(), variables, currentUrl);
+		console.log(`Condition "${condition}" evaluates to:`, conditionValue);
+	} catch (error) {
+		console.error(`Error evaluating condition "${condition}":`, error);
+		return ''; // Remove the if block if condition evaluation fails
+	}
+
+	let contentToProcess: string;
+	if (conditionValue) {
+		contentToProcess = ifContent;
+	} else if (elseContent !== undefined) {
+		contentToProcess = elseContent;
+	} else {
+		return ''; // No content to process if condition is false and no else block
+	}
+
+	// Process nested logic structures and variables recursively
+	let processedContent = await processLogic(contentToProcess, variables, currentUrl);
+	processedContent = await processVariables(0, processedContent, variables, currentUrl);
+
+	return processedContent.trim();
+}
+
+async function evaluateCondition(
+	condition: string,
+	variables: { [key: string]: any },
+	currentUrl: string
+): Promise<boolean> {
+	// Trim whitespace
+	condition = condition.trim();
+
+	// Handle comparison operators: ==, !=, >, <, >=, <=
+	const comparisonRegex = /^(.+?)\s*(==|!=|>|<|>=|<=)\s*(.+)$/;
+	const comparisonMatch = condition.match(comparisonRegex);
+
+	if (comparisonMatch) {
+		const leftOperand = comparisonMatch[1].trim();
+		const operator = comparisonMatch[2];
+		const rightOperand = comparisonMatch[3].trim();
+
+		const leftValue = await evaluateOperand(leftOperand, variables, currentUrl);
+		const rightValue = await evaluateOperand(rightOperand, variables, currentUrl);
+
+		switch (operator) {
+			case '==':
+				return leftValue == rightValue; // Loose equality
+			case '!=':
+				return leftValue != rightValue;
+			case '>':
+				return Number(leftValue) > Number(rightValue);
+			case '<':
+				return Number(leftValue) < Number(rightValue);
+			case '>=':
+				return Number(leftValue) >= Number(rightValue);
+			case '<=':
+				return Number(leftValue) <= Number(rightValue);
+		}
+	}
+
+	// Handle schema conditions
+	if (condition.startsWith('schema:')) {
+		const schemaValue = await processSchema(`{{${condition}}}`, variables, currentUrl);
+		try {
+			const parsed = JSON.parse(schemaValue);
+			return isTruthy(parsed);
+		} catch (error) {
+			console.error(`Error parsing schema result for ${condition}:`, error);
+			return false;
+		}
+	}
+
+	// Handle variable conditions
+	if (condition.includes('.')) {
+		// Handle nested properties like "variable.property"
+		const value = condition.split('.').reduce((obj: any, key: string) => {
+			if (obj && typeof obj === 'object' && key in obj) {
+				return obj[key];
+			}
+			console.error(`Cannot access property ${key} of`, obj);
+			return undefined;
+		}, variables);
+		return isTruthy(value);
+	}
+
+	// Handle simple variable conditions
+	const value = variables[condition];
+	return isTruthy(value);
+}
+
+async function evaluateOperand(
+	operand: string,
+	variables: { [key: string]: any },
+	currentUrl: string
+): Promise<any> {
+	operand = operand.trim();
+
+	// Handle quoted strings
+	if ((operand.startsWith('"') && operand.endsWith('"')) ||
+		(operand.startsWith("'") && operand.endsWith("'"))) {
+		return operand.slice(1, -1);
+	}
+
+	// Handle numbers
+	if (!isNaN(Number(operand))) {
+		return Number(operand);
+	}
+
+	// Handle schema variables
+	if (operand.startsWith('schema:')) {
+		const schemaValue = await processSchema(`{{${operand}}}`, variables, currentUrl);
+		try {
+			return JSON.parse(schemaValue);
+		} catch (error) {
+			console.error(`Error parsing schema result for ${operand}:`, error);
+			return null;
+		}
+	}
+
+	// Handle nested properties like "variable.property"
+	if (operand.includes('.')) {
+		return operand.split('.').reduce((obj: any, key: string) => {
+			if (obj && typeof obj === 'object' && key in obj) {
+				return obj[key];
+			}
+			console.error(`Cannot access property ${key} of`, obj);
+			return undefined;
+		}, variables);
+	}
+
+	// Handle simple variables
+	return variables[operand];
+}
+
+function isTruthy(value: any): boolean {
+	// JavaScript truthy/falsy rules
+	if (value === null || value === undefined) {
+		return false;
+	}
+	if (typeof value === 'boolean') {
+		return value;
+	}
+	if (typeof value === 'number') {
+		return value !== 0;
+	}
+	if (typeof value === 'string') {
+		return value.trim().length > 0;
+	}
+	if (Array.isArray(value)) {
+		return value.length > 0;
+	}
+	if (typeof value === 'object') {
+		return Object.keys(value).length > 0;
+	}
+	return Boolean(value);
+}

--- a/src/utils/tags/set.ts
+++ b/src/utils/tags/set.ts
@@ -1,0 +1,89 @@
+import { processSchema } from '../variables/schema';
+import { processVariables } from '../template-compiler';
+
+export async function processVariableAssignment(
+	match: RegExpExecArray,
+	variables: { [key: string]: any },
+	currentUrl: string
+): Promise<void> {
+	const [fullMatch, variableName, valueExpression] = match;
+
+	console.log(`Setting variable: ${variableName} = ${valueExpression}`);
+
+	try {
+		// Evaluate the value expression
+		const value = await evaluateAssignmentValue(valueExpression.trim(), variables, currentUrl);
+
+		// Set the variable in the variables object
+		variables[variableName] = value;
+
+		console.log(`Variable ${variableName} set to:`, value);
+	} catch (error) {
+		console.error(`Error setting variable ${variableName}:`, error);
+		// Set to undefined if evaluation fails
+		variables[variableName] = undefined;
+	}
+}
+
+async function evaluateAssignmentValue(
+	expression: string,
+	variables: { [key: string]: any },
+	currentUrl: string
+): Promise<any> {
+	expression = expression.trim();
+
+	// Handle quoted strings
+	if ((expression.startsWith('"') && expression.endsWith('"')) ||
+		(expression.startsWith("'") && expression.endsWith("'"))) {
+		return expression.slice(1, -1);
+	}
+
+	// Handle numbers
+	if (!isNaN(Number(expression))) {
+		return Number(expression);
+	}
+
+	// Handle boolean literals
+	if (expression === 'true') return true;
+	if (expression === 'false') return false;
+
+	// Handle schema variables
+	if (expression.startsWith('schema:')) {
+		const schemaValue = await processSchema(`{{${expression}}}`, variables, currentUrl);
+		try {
+			return JSON.parse(schemaValue);
+		} catch (error) {
+			console.error(`Error parsing schema result for ${expression}:`, error);
+			return null;
+		}
+	}
+
+	// Handle expressions with filters (e.g., content|length, title|upper)
+	if (expression.includes('|')) {
+		// Create a temporary template to process the expression with filters
+		const tempTemplate = `{{${expression}}}`;
+		const processed = await processVariables(0, tempTemplate, variables, currentUrl);
+		return processed;
+	}
+
+	// Handle nested properties like "variable.property"
+	if (expression.includes('.')) {
+		const value = expression.split('.').reduce((obj: any, key: string) => {
+			if (obj && typeof obj === 'object' && key in obj) {
+				return obj[key];
+			}
+			console.error(`Cannot access property ${key} of`, obj);
+			return undefined;
+		}, variables);
+		return value;
+	}
+
+	// Handle simple variable references
+	if (variables.hasOwnProperty(expression)) {
+		return variables[expression];
+	}
+
+	// If nothing matches, return the expression as a string literal
+	console.warn(`Treating "${expression}" as string literal in assignment`);
+	return expression;
+}

--- a/src/utils/template-compiler.ts
+++ b/src/utils/template-compiler.ts
@@ -4,6 +4,8 @@ import { processSchema } from './variables/schema';
 import { processPrompt } from './variables/prompt';
 
 import { processForLoop } from './tags/for';
+import { processIfCondition } from './tags/if';
+import { processVariableAssignment } from './tags/set';
 
 // Define a type for logic handlers
 type LogicHandler = {
@@ -12,13 +14,38 @@ type LogicHandler = {
 	process: (match: RegExpExecArray, variables: { [key: string]: any }, currentUrl: string, processLogic: (text: string, variables: { [key: string]: any }, currentUrl: string) => Promise<string>) => Promise<string>;
 };
 
-// Define logic handlers
+// Define a type for assignment handlers that can modify variables
+type AssignmentHandler = {
+	type: string;
+	regex: RegExp;
+	process: (match: RegExpExecArray, variables: { [key: string]: any }, currentUrl: string) => Promise<void>;
+};
+
+// Define assignment handlers (processed first)
+const assignmentHandlers: AssignmentHandler[] = [
+	{
+		type: 'set',
+		regex: /{%\s*set\s+(\w+)\s*=\s*([\s\S]*?)\s*%}/g,
+		process: async (match, variables, currentUrl) => {
+			return processVariableAssignment(match, variables, currentUrl);
+		}
+	}
+];
+
+// Define logic handlers (processed after assignments)
 const logicHandlers: LogicHandler[] = [
 	{
 		type: 'for',
 		regex: /{%\s*for\s+(\w+)\s+in\s+([\w:@]+)\s*%}([\s\S]*?){%\s*endfor\s*%}/g,
 		process: async (match, variables, currentUrl, processLogic) => {
 			return processForLoop(match, variables, currentUrl, processLogic);
+		}
+	},
+	{
+		type: 'if',
+		regex: /{%\s*if\s+([\s\S]*?)\s*%}([\s\S]*?)(?:{%\s*else\s*%}([\s\S]*?))?{%\s*endif\s*%}/g,
+		process: async (match, variables, currentUrl, processLogic) => {
+			return processIfCondition(match, variables, currentUrl, processLogic);
 		}
 	},
 	// Add more logic handlers
@@ -34,10 +61,29 @@ export async function compileTemplate(tabId: number, text: string, variables: { 
 	return await processVariables(tabId, processedText, variables, currentUrl);
 }
 
+// Process assignments first (they define variables for later use)
+export async function processAssignments(text: string, variables: { [key: string]: any }, currentUrl: string): Promise<string> {
+	let processedText = text;
+
+	for (const handler of assignmentHandlers) {
+		let match;
+		while ((match = handler.regex.exec(processedText)) !== null) {
+			await handler.process(match, variables, currentUrl);
+			// Remove the assignment statement from the output
+			processedText = processedText.substring(0, match.index) + processedText.substring(match.index + match[0].length);
+			handler.regex.lastIndex = match.index;
+		}
+	}
+
+	return processedText;
+}
+
 // Process logic structures
 export async function processLogic(text: string, variables: { [key: string]: any }, currentUrl: string): Promise<string> {
-	let processedText = text;
-	
+	// First process assignments to define custom variables
+	let processedText = await processAssignments(text, variables, currentUrl);
+
+	// Then process other logic structures
 	for (const handler of logicHandlers) {
 		let match;
 		while ((match = handler.regex.exec(processedText)) !== null) {
@@ -59,7 +105,7 @@ export async function processVariables(tabId: number, text: string, variables: {
 	while ((match = regex.exec(result)) !== null) {
 		const fullMatch = match[0];
 		const trimmedMatch = match[1].trim();
-		
+
 		let replacement: string;
 
 		if (trimmedMatch.startsWith('selector:') || trimmedMatch.startsWith('selectorHtml:')) {
@@ -68,8 +114,29 @@ export async function processVariables(tabId: number, text: string, variables: {
 			replacement = await processSchema(fullMatch, variables, currentUrl);
 		} else if (trimmedMatch.startsWith('"') || trimmedMatch.startsWith('prompt:')) {
 			replacement = await processPrompt(fullMatch, variables, currentUrl);
+		} else if (trimmedMatch.startsWith('literal:')) {
+			// Handle string literals with literal: prefix
+			const literalContent = trimmedMatch.substring(8); // Remove 'literal:' prefix
+			if ((literalContent.startsWith('"') && literalContent.endsWith('"')) ||
+				(literalContent.startsWith("'") && literalContent.endsWith("'"))) {
+				replacement = literalContent.slice(1, -1);
+			} else {
+				replacement = literalContent;
+			}
 		} else {
-			replacement = await processSimpleVariable(trimmedMatch, variables, currentUrl);
+			// Check if it's a custom variable first, then fall back to simple variable processing
+			if (variables.hasOwnProperty(trimmedMatch)) {
+				// Handle custom variables set with {% set %}
+				const customValue = variables[trimmedMatch];
+				if (trimmedMatch.includes('|')) {
+					// Apply filters to custom variables
+					replacement = await processSimpleVariable(trimmedMatch, variables, currentUrl);
+				} else {
+					replacement = String(customValue ?? '');
+				}
+			} else {
+				replacement = await processSimpleVariable(trimmedMatch, variables, currentUrl);
+			}
 		}
 
 		result = result.substring(0, match.index) + replacement + result.substring(match.index + fullMatch.length);


### PR DESCRIPTION
- Add {% if %}...{% else %}...{% endif %} conditional logic support
- Add {% set variable = expression %} variable assignment functionality
- Support comparison operators (==, !=, >, <, >=, <=) in conditions
- Enable schema variables and nested property access in templates
- Add {{literal:text}} prefix support for string/number/boolean literals
- Maintain backward compatibility with existing template syntax
- Extend template compiler to process assignments before logic structures

This enhancement allows users to create more dynamic and flexible templates with conditional content, custom variable definitions, and precise literal control while maintaining full backward compatibility (purely additive changes).