### PR TITLE
Convert heading urls into heading links within Obsidian

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -676,6 +676,14 @@ export function createMarkdownContent(content: string, url: string) {
 		// But don't affect image links like ![](image.jpg)
 		markdown = markdown.replace(/\n*(?<!!)\[]\([^)]+\)\n*/g, '');
 
+		// convert any heading links pointing to the current page e.g [Example](example.com#heading) into Obsidian relative links
+		// e.g. [[Example|#heading]]
+		const headingLinkPattern = new RegExp(
+			String.raw`\[([^\]]+)\]\(` + url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + String.raw`(#[-\w]+)\)`, // make sure to escape the url characters
+			"g"
+		);
+		markdown = markdown.replace(headingLinkPattern, (_, title, hash) => `[[${title}|${hash}]]`);
+
 		// Remove any consecutive newlines more than two
 		markdown = markdown.replace(/\n{3,}/g, '\n\n');
 

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -2,7 +2,6 @@ import TurndownService from 'turndown';
 import { MathMLToLaTeX } from 'mathml-to-latex';
 import { processUrls } from './string-utils';
 import { debugLog } from './debug';
-import { clipboard } from 'webextension-polyfill';
 
 const footnotes: { [key: string]: string } = {};
 

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -10,6 +10,8 @@ export function createMarkdownContent(content: string, url: string) {
 	debugLog('Markdown', 'Content length:', content.length);
 
 	const baseUrl = new URL(url);
+	// normalise even after header links have been clicked
+	baseUrl.hash = '';
 	// Process all URLs at the beginning
 	const processedContent = processUrls(content, baseUrl);
 
@@ -682,7 +684,7 @@ export function createMarkdownContent(content: string, url: string) {
 			String.raw`\[([^\]]+)\]\(` + url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + String.raw`(#[-\w]+)\)`, // make sure to escape the url characters
 			"g"
 		);
-		markdown = markdown.replace(headingLinkPattern, (_, title, hash) => `[[${title}|${hash}]]`);
+		markdown = markdown.replace(headingLinkPattern, (_, title, hash) => `[[${hash}|${title}]]`);
 
 		// Remove any consecutive newlines more than two
 		markdown = markdown.replace(/\n{3,}/g, '\n\n');

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -101,6 +101,8 @@ export function makeUrlAbsolute(element: Element, attributeName: string, baseUrl
 		try {
 			// Create a new URL object from the base URL
 			const resolvedBaseUrl = new URL(baseUrl.href);
+			// ensure that the clipper clips the same even if the user has clicked on a heading link
+			resolvedBaseUrl.hash = '';
 
 			const url = new URL(attributeValue, resolvedBaseUrl);
 			

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,5 +1,3 @@
-import { debugLog } from "./debug";
-
 export function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -101,7 +99,7 @@ export function makeUrlAbsolute(element: Element, attributeName: string, baseUrl
 		try {
 			// Create a new URL object from the base URL
 			const resolvedBaseUrl = new URL(baseUrl.href);
-
+			
 			const url = new URL(attributeValue, resolvedBaseUrl);
 			
 			if (!['http:', 'https:'].includes(url.protocol)) {

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -101,8 +101,6 @@ export function makeUrlAbsolute(element: Element, attributeName: string, baseUrl
 		try {
 			// Create a new URL object from the base URL
 			const resolvedBaseUrl = new URL(baseUrl.href);
-			// ensure that the clipper clips the same even if the user has clicked on a heading link
-			resolvedBaseUrl.hash = '';
 
 			const url = new URL(attributeValue, resolvedBaseUrl);
 			

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,3 +1,5 @@
+import { debugLog } from "./debug";
+
 export function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -99,12 +101,7 @@ export function makeUrlAbsolute(element: Element, attributeName: string, baseUrl
 		try {
 			// Create a new URL object from the base URL
 			const resolvedBaseUrl = new URL(baseUrl.href);
-			
-			// If the base URL points to a file, remove the filename to get the directory
-			if (!resolvedBaseUrl.pathname.endsWith('/')) {
-				resolvedBaseUrl.pathname = resolvedBaseUrl.pathname.substring(0, resolvedBaseUrl.pathname.lastIndexOf('/') + 1);
-			}
-			
+
 			const url = new URL(attributeValue, resolvedBaseUrl);
 			
 			if (!['http:', 'https:'].includes(url.protocol)) {


### PR DESCRIPTION
Fixes https://github.com/obsidianmd/obsidian-clipper/issues/593.

I have removed the file pathname check from `string-utils.ts` as it was mangling links with heading fragment like `https://borretti.me/article/two-years-of-rust#perf` into the invalid form `https://borretti.me/article/#perf`. Many links do not end with a `/` and yet are not files, so this seemed like misguided truncation.

I've also added a replacement that automatically converts urls containing heading links to the current (being clipped) page into proper Obsidian `[[#heading|title]]` links. Unfortunately, this isn't quite perfect (see comments) but it will function perfectly on almost every website.