### PR TITLE
Force open behaviour to be popup in mobile safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ If you want to run the extension permanently you can do so with the Nightly or D
 3. Double-click the preference, or right-click and select "Toggle", to set it to `false`.
 4. Go to `about:addons` > gear icon > **Install Add-on From File…**
 
+For iOS Simulator testing on macOS:
+
+1. Run `npm run build` to build the extension
+2. Open `xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj` in Xcode
+3. Select the **Obsidian Web Clipper (iOS)** scheme from the scheme selector
+4. Choose an iOS Simulator device and click **Run** to build and launch the app
+5. Once the app is running on the simulator, open **Safari**
+6. Navigate to a webpage and tap the **Extensions** button in Safari to access the Web Clipper extension
+
 ## Third-party libraries
 
 - [webextension-polyfill](https://github.com/mozilla/webextension-polyfill) for browser compatibility

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -299,9 +299,13 @@ document.addEventListener('DOMContentLoaded', async function() {
 		
 		currentTabId = response.tabId;
 		const tab = await getTabInfo(currentTabId);
+		const currentBrowser = await detectBrowser();
+		const isMobile = currentBrowser === 'mobile-safari';
+
+		const openBehavior: Settings['openBehavior'] = isMobile ? 'popup' : settings.openBehavior;
 
 		// Check if we should open in an iframe, but only if the URL is valid
-		if (isValidUrl(tab.url) && !isBlankPage(tab.url) && settings.openBehavior === 'embedded' && !isIframe && !isSidePanel) {
+		if (isValidUrl(tab.url) && !isBlankPage(tab.url) && openBehavior === 'embedded' && !isIframe && !isSidePanel) {
 			try {
 				const response = await browser.runtime.sendMessage({ action: "getActiveTabAndToggleIframe" }) as { success?: boolean; error?: string };
 				if (response && response.success) {

--- a/xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj/project.pbxproj
+++ b/xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 		7A15D46F2CB5D97B00BC4F99 /* highlighter.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = highlighter.css; path = ../../../dist_safari/highlighter.css; sourceTree = "<group>"; };
 		7A6480582D820A9800A5924D /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = reader.css; path = ../../../dist_safari/reader.css; sourceTree = "<group>"; };
 		7A6535C82D8B530300DDF54C /* reader-script.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "reader-script.js"; path = "../../../dist_safari/reader-script.js"; sourceTree = "<group>"; };
-		7AC138862E4B9C8E00B6F4CF /* side-panel.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "side-panel.html"; path = "/Users/kepano/Documents/Git/obsidian-clipper/dist_safari/side-panel.html"; sourceTree = "<absolute>"; };
+		7AC138862E4B9C8E00B6F4CF /* side-panel.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "side-panel.html"; path = "../../../dist_safari/side-panel.html"; sourceTree = "<group>"; };
 		7AEF056F2CA0F50D005FFBC2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = ../Base.lproj/Main.html; sourceTree = "<group>"; };
 		7AEF05702CA0F50D005FFBC2 /* Icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon.png; sourceTree = "<group>"; };
 		7AEF05712CA0F50D005FFBC2 /* Style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = Style.css; sourceTree = "<group>"; };


### PR DESCRIPTION
Hello!

I had an issue after importing my settings file from my desktop browser:
- I had the open behaviour set to embedded
- I imported the settings in the extension on mobile safari
- The extension would then try to display both the embedded and the popup

In this PR, I avoid this issue by forcing the open bahviour to be popup on mobile safari. 

I also fixed an import preventing building the iOS app and added instructions for testing in the readme.

In addition, I should mention that some of the changes in this PR were made with AI (only the Readme changes were left as the AI wrote them, I tweaked the code generated for the behaviour). 