### PR TITLE
Bug fix for YouTube markdown #603

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -679,6 +679,12 @@ export function createMarkdownContent(content: string, url: string) {
 		// Remove any consecutive newlines more than two
 		markdown = markdown.replace(/\n{3,}/g, '\n\n');
 
+		// Remove trailing backslashes due to youtube nested span tags
+		if (baseUrl.hostname.startsWith("www.youtube.com")) {
+			markdown = markdown.replace(/^\\(?=[#>*+\-\[])/gm, '');
+			console.log(markdown)
+		}
+
 		// Append footnotes at the end of the document
 		if (Object.keys(footnotes).length > 0) {
 			markdown += '\n\n---\n\n';


### PR DESCRIPTION
Hi,

I'm new to contributing to open-source projects, sorry if I made any mistakes regarding the rules of contributing here.

About the title-mentioned issue, I have found a possible fix for this.

From my understanding, the issue lies on the kind of formatting some videos have in the YouTube description, as it appears that a markdown description is generated by YouTube own rules and styling.

Thanks in advance, really like Obsidian as my main note-taking software.