### PR TITLE
Update Japanese translation for highlightInline

### DIFF
--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -344,7 +344,7 @@
 		"message": "Web Clipperの使い方とトラブルシューティングのヘルプを参照してください。"
 	},
 	"highlightInline": {
-		"message": "ページ内容を高亮表示"
+		"message": "ページ内容をハイライトする"
 	},
 	"highlightPage": {
 		"message": "ページをハイライト"


### PR DESCRIPTION
Replaces the term '高亮表示' with 'ハイライトする' in the 'highlightInline' message for improved clarity and consistency in the Japanese locale.