### PR TITLE
Fix Turndown markdown escape bug #603 #365

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -38,6 +38,9 @@ export function createMarkdownContent(content: string, url: string) {
 		preformattedCode: true,
 	});
 
+	// disable markdown escaping by overriding the escape function
+	turndownService.escape = (str: string) => str;
+
 	turndownService.addRule('table', {
 		filter: 'table',
 		replacement: function(content, node) {


### PR DESCRIPTION
**Fixes**: #603 #365 

**Description**: this PR fixes the Turndown library processing of markdown, which introduces escape characters that affect the content of the clips. It does so by overriding the `turndownService.escape` function to just return the strings being processed. 

**Note**: this is also addressed by pull request #606, however that solution functions more as a band-aid for the incorrect escaping (specifically on youtube.com) rather than resolving the issue itself.