### PR TITLE
Add side panel open behavior option

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -518,7 +518,7 @@
 		"message": "Open"
 	},
 	"openBehaviorDescription": {
-		"message": "Choose how Web Clipper opens by default."
+		"message": "Choose how Web Clipper opens by default: Popup, embedded in-page, or the browser side panel."
 	},
 	"openBehaviorTitle": {
 		"message": "Open behavior"

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -319,18 +319,6 @@ document.addEventListener('DOMContentLoaded', async function() {
 				console.error('Error toggling iframe:', error);
 				// If there's an error, we'll fall through and open the normal popup.
 			}
-		} else if (openBehavior === 'sidepanel' && !isIframe && !isSidePanel) {
-			try {
-				const response = await browser.runtime.sendMessage({ action: "openSidePanel", tabId: currentTabId }) as { success?: boolean; error?: string };
-				if (response && response.success) {
-					window.close();
-					return;
-				} else if (response && response.error) {
-					console.error('Error opening side panel:', response.error);
-				}
-			} catch (error) {
-				console.error('Error opening side panel:', error);
-			}
 		}
 
 		// Connect to the background script for communication

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -304,7 +304,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 
 		const openBehavior: Settings['openBehavior'] = isMobile ? 'popup' : settings.openBehavior;
 
-		// Check if we should open in an iframe, but only if the URL is valid
+		// Check if we should open in an iframe or side panel, but only if the URL is valid
 		if (isValidUrl(tab.url) && !isBlankPage(tab.url) && openBehavior === 'embedded' && !isIframe && !isSidePanel) {
 			try {
 				const response = await browser.runtime.sendMessage({ action: "getActiveTabAndToggleIframe" }) as { success?: boolean; error?: string };
@@ -318,6 +318,18 @@ document.addEventListener('DOMContentLoaded', async function() {
 			} catch (error) {
 				console.error('Error toggling iframe:', error);
 				// If there's an error, we'll fall through and open the normal popup.
+			}
+		} else if (openBehavior === 'sidepanel' && !isIframe && !isSidePanel) {
+			try {
+				const response = await browser.runtime.sendMessage({ action: "openSidePanel", tabId: currentTabId }) as { success?: boolean; error?: string };
+				if (response && response.success) {
+					window.close();
+					return;
+				} else if (response && response.error) {
+					console.error('Error opening side panel:', response.error);
+				}
+			} catch (error) {
+				console.error('Error opening side panel:', error);
 			}
 		}
 

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -259,7 +259,7 @@ function saveSettingsFromForm(): void {
 
 	const updatedSettings = {
 		...generalSettings, // Keep existing settings
-		openBehavior: (openBehaviorDropdown?.value as 'popup' | 'embedded') ?? generalSettings.openBehavior,
+		openBehavior: (openBehaviorDropdown?.value as 'popup' | 'embedded' | 'sidepanel') ?? generalSettings.openBehavior,
 		showMoreActionsButton: showMoreActionsToggle?.checked ?? generalSettings.showMoreActionsButton,
 		betaFeatures: betaFeaturesToggle?.checked ?? generalSettings.betaFeatures,
 		legacyMode: legacyModeToggle?.checked ?? generalSettings.legacyMode,
@@ -349,7 +349,7 @@ function initializeOpenBehaviorDropdown(): void {
 		'open-behavior-dropdown',
 		generalSettings.openBehavior,
 		(value) => {
-			saveSettings({ ...generalSettings, openBehavior: value as 'popup' | 'embedded' });
+			saveSettings({ ...generalSettings, openBehavior: value as 'popup' | 'embedded' | 'sidepanel' });
 		}
 	);
 }

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -25,6 +25,15 @@
 			"128": "icons/icon128.png"
 		}
 	},
+	"sidebar_action": {
+		"default_panel": "side-panel.html",
+		"default_title": "Obsidian Web Clipper",
+		"default_icon": {
+			"16": "icons/icon16.png",
+			"48": "icons/icon48.png",
+			"128": "icons/icon128.png"
+		}
+	},
 	"options_ui": {
 		"page": "settings.html",
 		"open_in_tab": true

--- a/src/settings.html
+++ b/src/settings.html
@@ -159,6 +159,7 @@
 										<select id="open-behavior-dropdown">
 											<option value="popup" selected data-i18n="popup">Popup</option>
 											<option value="embedded" data-i18n="embedded">Embedded</option>
+											<option value="sidepanel" data-i18n="openSidePanel">Open side panel</option>
 										</select>
 									</div>
 								</div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -66,7 +66,7 @@ export interface Settings {
 	betaFeatures: boolean;
 	legacyMode: boolean;
 	silentOpen: boolean;
-	openBehavior: 'popup' | 'embedded';
+	openBehavior: 'popup' | 'embedded' | 'sidepanel';
 	highlighterEnabled: boolean;
 	alwaysShowHighlights: boolean;
 	highlightBehavior: string;

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -209,36 +209,15 @@ function updateUndoRedoButtons() {
 
 async function handleClipButtonClick(e: Event) {
 	e.preventDefault();
-	const browserType = await detectBrowser();
+	const openRequest = browser.runtime.sendMessage({ action: "openClipperUI" }) as Promise<{ success?: boolean; error?: string }>;
 
 	try {
-		await loadSettings();
-
-		const openBehavior = generalSettings.openBehavior ?? 'popup';
-
-		if (openBehavior === 'embedded') {
-			const embeddedResponse = await browser.runtime.sendMessage({ action: "getActiveTabAndToggleIframe" }) as { success?: boolean; error?: string };
-			if (embeddedResponse && embeddedResponse.success) {
-				return;
-			}
-			if (embeddedResponse && embeddedResponse.error) {
-				console.warn('Embedded mode not available:', embeddedResponse.error);
-			}
-		} else if (openBehavior === 'sidepanel') {
-			const sidePanelResponse = await browser.runtime.sendMessage({ action: "openSidePanel" }) as { success?: boolean; error?: string };
-			if (sidePanelResponse && sidePanelResponse.success) {
-				return;
-			}
-			if (sidePanelResponse && sidePanelResponse.error) {
-				console.warn('Side panel not available:', sidePanelResponse.error);
-			}
-		}
-
-		const popupResponse = await browser.runtime.sendMessage({ action: "openPopup" }) as { success?: boolean; error?: string };
-		if (popupResponse && 'success' in popupResponse && popupResponse.success === false) {
-			throw new Error(popupResponse.error || 'Unknown error');
+		const response = await openRequest;
+		if (response && 'success' in response && response.success === false) {
+			throw new Error(response.error || 'Unknown error');
 		}
 	} catch (error) {
+		const browserType = await detectBrowser();
 		console.error('Error opening clipper UI:', error);
 		if (browserType === 'firefox') {
 			alert("Additional permissions required. To open Web Clipper from the highlighter, go to about:config and set this to true:\n\nextensions.openPopupWithoutUserGesture.enabled");

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -54,7 +54,7 @@ interface StorageData {
 		betaFeatures?: boolean;
 		legacyMode?: boolean;
 		silentOpen?: boolean;
-		openBehavior?: boolean | 'popup' | 'embedded';
+		openBehavior?: boolean | 'popup' | 'embedded' | 'sidepanel';
 		saveBehavior?: 'addToObsidian' | 'copyToClipboard' | 'saveFile';
 	};
 	vaults?: string[];
@@ -153,9 +153,16 @@ export async function loadSettings(): Promise<Settings> {
 		betaFeatures: data.general_settings?.betaFeatures ?? defaultSettings.betaFeatures,
 		legacyMode: data.general_settings?.legacyMode ?? defaultSettings.legacyMode,
 		silentOpen: data.general_settings?.silentOpen ?? defaultSettings.silentOpen,
-		openBehavior: typeof data.general_settings?.openBehavior === 'boolean' 
-			? (data.general_settings.openBehavior ? 'embedded' : 'popup') 
-			: (data.general_settings?.openBehavior ?? defaultSettings.openBehavior),
+		openBehavior: (() => {
+			const storedValue = data.general_settings?.openBehavior;
+			if (typeof storedValue === 'boolean') {
+				return storedValue ? 'embedded' : 'popup';
+			}
+			if (storedValue === 'popup' || storedValue === 'embedded' || storedValue === 'sidepanel') {
+				return storedValue;
+			}
+			return defaultSettings.openBehavior;
+		})(),
 		highlighterEnabled: data.highlighter_settings?.highlighterEnabled ?? defaultSettings.highlighterEnabled,
 		alwaysShowHighlights: data.highlighter_settings?.alwaysShowHighlights ?? defaultSettings.alwaysShowHighlights,
 		highlightBehavior: data.highlighter_settings?.highlightBehavior ?? defaultSettings.highlightBehavior,


### PR DESCRIPTION
I added the side-panel as an additional option for the opening behaviour. As part of that i reworked the background controller and funneled every entry point (toolbar, context menu, highlighter) through a single helper function, this ensures that the side panel is opened only in direct response with user gestures.

I successfully tested the functionality on Chrome, Edge, Vivaldi, Firefox.

**Open behavior enhancements:**

* Added "sidepanel" as a new value for the `openBehavior` setting throughout the codebase, including types, settings management, and storage utilities. [[1]](diffhunk://#diff-11e9171ff36dfa6e6b396909ac6b924cf79337d5f05a7eaa15f78a9b2e2eded6L69-R69) [[2]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbL57-R57) [[3]](diffhunk://#diff-2d62c6e9c11969b57354456cb49e71e16a911ae78d2187a87e6cd280821a69cbL156-R165) [[4]](diffhunk://#diff-e2a6f1491b6fed56017948f619e32f4d543463ffe214bf3bf421b38d35f6f945L262-R262) [[5]](diffhunk://#diff-e2a6f1491b6fed56017948f619e32f4d543463ffe214bf3bf421b38d35f6f945L352-R352)
* Updated the settings UI (`settings.html`) and localization to allow users to select "side panel" as the default open behavior. [[1]](diffhunk://#diff-12230a30964d8e269766887dc72c950838ff40c03a31d1959002adda1e973c4eR162) [[2]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412L521-R521)

**Background script and browser integration:**

* Implemented robust logic in `background.ts` to handle opening the Clipper UI in the side panel using the appropriate browser APIs for Chrome, Firefox, and other browsers, including error handling and fallback behaviors. [[1]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR12-R17) [[2]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR66-R76) [[3]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR120-R156) [[4]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR270-R294) [[5]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL455-R538) [[6]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL476-R566) [[7]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fL489-R590) [[8]](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR747-R894)
* Updated context menu and message handling to support side panel and embedded modes, including new actions and improved tab resolution.

**Manifest and browser-specific configuration:**

* Added `sidebar_action` to the Firefox manifest to enable the side panel feature in Firefox.

**Popup and UI logic:**

* Updated popup logic to respect the new open behavior, opening in a side panel when selected and the environment supports it.
* Improved error handling and messaging for opening the Clipper UI from various entry points, including the highlighter button.