### PR TITLE
Make `src` URLs on video & audio elements absolute

### DIFF
--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -138,10 +138,13 @@ export function processUrls(htmlContent: string, baseUrl: URL): string {
 	const parser = new DOMParser();
 	const doc = parser.parseFromString(htmlContent, 'text/html');
 	
-	// Handle relative URLs for both images and links
+	// Handle relative URLs for images, links, videos, and audio embeds.
 	doc.querySelectorAll('img').forEach(img => makeUrlAbsolute(img, 'srcset', baseUrl));
 	doc.querySelectorAll('img').forEach(img => makeUrlAbsolute(img, 'src', baseUrl));
 	doc.querySelectorAll('a').forEach(link => makeUrlAbsolute(link, 'href', baseUrl));
+	doc.querySelectorAll('video').forEach(video => makeUrlAbsolute(video, 'src', baseUrl));
+	doc.querySelectorAll('audio').forEach(audio => makeUrlAbsolute(audio, 'src', baseUrl));
+	doc.querySelectorAll(':is(video, audio) :is(source, track)').forEach(sourceOrTrack => makeUrlAbsolute(sourceOrTrack, 'src', baseUrl));
 	
 	// Serialize back to HTML
 	const serializer = new XMLSerializer();


### PR DESCRIPTION
To see the issue, clip https://tonsky.me/blog/crdt-filesync/ and note that the `<video>` at the end points to `demo.mp4`, and therefore won't load once added to Obsidian.

This simply reuses the logic already used for `img`s and `a`s.

Note: this is slightly related to kepano/defuddle#111, which makes `track` elements more useful by preserving their `kind`, `srclang`, and `label` attributes.