### PR TITLE
Fix `Cannot read properties of null (reading 'childNodes')`

### DIFF
--- a/src/utils/filters/remove_html.ts
+++ b/src/utils/filters/remove_html.ts
@@ -44,7 +44,7 @@ export const remove_html = (html: string, params: string = ''): string => {
 	// Serialize back to HTML
 	const serializer = new XMLSerializer();
 	let result = '';
-	Array.from(doc.body.childNodes).forEach(node => {
+	Array.from(doc.body?.childNodes ?? []).forEach(node => {
 		if (node.nodeType === Node.ELEMENT_NODE) {
 			result += serializer.serializeToString(node);
 		} else if (node.nodeType === Node.TEXT_NODE) {


### PR DESCRIPTION
Not sure when https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString doesn't include a body node, but this is observable on the sites listed in the issue.

Fixes #618 