### PR TITLE
Add decode_uri filter

### DIFF
--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -9,6 +9,7 @@ import { camel } from './filters/camel';
 import { capitalize } from './filters/capitalize';
 import { date } from './filters/date';
 import { date_modify, validateDateModifyParams } from './filters/date_modify';
+import { decode_uri } from './filters/decode_uri';
 import { first } from './filters/first';
 import { footnote } from './filters/footnote';
 import { fragment_link } from './filters/fragment_link';
@@ -84,6 +85,7 @@ export const filterMetadata: Record<string, FilterMetadata> = {
 	camel: {},
 	capitalize: {},
 	date: { example: 'date:"YYYY-MM-DD"' },
+	decode_uri: {},
 	duration: {},
 	first: {},
 	footnote: {},
@@ -136,6 +138,7 @@ export const filters: { [key: string]: FilterFunction } = {
 	capitalize,
 	date_modify,
 	date,
+	decode_uri,
 	duration,
 	first,
 	footnote,

--- a/src/utils/filters/decode_uri.test.ts
+++ b/src/utils/filters/decode_uri.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest';
+import { decode_uri } from './decode_uri';
+
+describe('decode_uri filter', () => {
+	test('decodes URL-encoded Chinese text', () => {
+		expect(decode_uri('%E8%BF%99%E6%9C%9F%E5%92%B1%E4%BB%AC')).toBe('这期咱们');
+	});
+
+	test('decodes URL-encoded special characters', () => {
+		expect(decode_uri('hello%20world')).toBe('hello world');
+		expect(decode_uri('%26%3D%3F')).toBe('&=?');
+	});
+
+	test('handles already decoded text', () => {
+		expect(decode_uri('hello world')).toBe('hello world');
+		expect(decode_uri('这期咱们')).toBe('这期咱们');
+	});
+
+	test('handles empty string', () => {
+		expect(decode_uri('')).toBe('');
+	});
+
+	test('handles mixed encoded and plain text', () => {
+		expect(decode_uri('Hello%20%E4%B8%96%E7%95%8C')).toBe('Hello 世界');
+	});
+
+	test('returns original string for malformed URI', () => {
+		expect(decode_uri('%E0%A4%A')).toBe('%E0%A4%A');
+		expect(decode_uri('%')).toBe('%');
+		expect(decode_uri('%ZZ')).toBe('%ZZ');
+	});
+});

--- a/src/utils/filters/decode_uri.ts
+++ b/src/utils/filters/decode_uri.ts
@@ -1,0 +1,8 @@
+export const decode_uri = (str: string): string => {
+	try {
+		return decodeURIComponent(str);
+	} catch {
+		// If decoding fails (e.g., malformed URI), return the original string
+		return str;
+	}
+};


### PR DESCRIPTION
Adds decode_uri filter to decode URL-encoded text in template variables                                              

Usage                                                                                                               
`{{schema:@VideoObject:description|decode_uri}}`
                         
                                                                                                                      
Fixes [#668](https://github.com/obsidianmd/obsidian-clipper/issues/668)

https://www.bilibili.com/video/BV1fCLBzhEQR/
Before
<img width="413" height="561" alt="image" src="https://github.com/user-attachments/assets/4da45fb1-a720-4b81-a71e-8152763cb435" />

After
<img width="430" height="572" alt="image" src="https://github.com/user-attachments/assets/d30d4537-f7f1-4aa2-b102-9c7668790efd" />
