### PR TITLE
Fix misleading error message on browser extension store pages

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -538,6 +538,9 @@
 	"pageCannotBeClipped": {
 		"message": "This page cannot be clipped."
 	},
+	"restrictedPage": {
+		"message": "This page cannot be clipped. Browser extension pages are protected."
+	},
 	"pageVariables": {
 		"message": "Page variables"
 	},

--- a/src/utils/active-tab-manager.test.ts
+++ b/src/utils/active-tab-manager.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'vitest';
+import { isValidUrl, isBlankPage, isRestrictedUrl } from './active-tab-manager';
+
+describe('isValidUrl', () => {
+	test('returns true for http URLs', () => {
+		expect(isValidUrl('http://example.com')).toBe(true);
+	});
+
+	test('returns true for https URLs', () => {
+		expect(isValidUrl('https://example.com')).toBe(true);
+	});
+
+	test('returns true for file URLs', () => {
+		expect(isValidUrl('file:///path/to/file.html')).toBe(true);
+	});
+
+	test('returns false for about: URLs', () => {
+		expect(isValidUrl('about:blank')).toBe(false);
+	});
+
+	test('returns false for chrome: URLs', () => {
+		expect(isValidUrl('chrome://extensions')).toBe(false);
+	});
+});
+
+describe('isBlankPage', () => {
+	test('returns true for about:blank', () => {
+		expect(isBlankPage('about:blank')).toBe(true);
+	});
+
+	test('returns true for chrome://newtab/', () => {
+		expect(isBlankPage('chrome://newtab/')).toBe(true);
+	});
+
+	test('returns true for edge://newtab/', () => {
+		expect(isBlankPage('edge://newtab/')).toBe(true);
+	});
+
+	test('returns false for regular URLs', () => {
+		expect(isBlankPage('https://example.com')).toBe(false);
+	});
+});
+
+describe('isRestrictedUrl', () => {
+	// Firefox addon store
+	test('returns true for addons.mozilla.org', () => {
+		expect(isRestrictedUrl('https://addons.mozilla.org')).toBe(true);
+		expect(isRestrictedUrl('https://addons.mozilla.org/en-US/firefox/addon/some-addon/')).toBe(true);
+	});
+
+	// Chrome Web Store
+	test('returns true for Chrome Web Store URLs', () => {
+		expect(isRestrictedUrl('https://chrome.google.com/webstore')).toBe(true);
+		expect(isRestrictedUrl('https://chrome.google.com/webstore/detail/some-extension/abc123')).toBe(true);
+		expect(isRestrictedUrl('https://chromewebstore.google.com')).toBe(true);
+		expect(isRestrictedUrl('https://chromewebstore.google.com/detail/some-extension/abc123')).toBe(true);
+	});
+
+	// Edge Add-ons
+	test('returns true for Edge Add-ons URLs', () => {
+		expect(isRestrictedUrl('https://microsoftedge.microsoft.com/addons')).toBe(true);
+		expect(isRestrictedUrl('https://microsoftedge.microsoft.com/addons/detail/some-extension/abc123')).toBe(true);
+	});
+
+	// Non-restricted URLs
+	test('returns false for regular URLs', () => {
+		expect(isRestrictedUrl('https://example.com')).toBe(false);
+		expect(isRestrictedUrl('https://google.com')).toBe(false);
+		expect(isRestrictedUrl('https://mozilla.org')).toBe(false);
+	});
+
+	// Edge cases
+	test('returns false for similar but non-restricted URLs', () => {
+		// chrome.google.com but not /webstore
+		expect(isRestrictedUrl('https://chrome.google.com/intl/en/chrome/')).toBe(false);
+		// microsoftedge.microsoft.com but not /addons
+		expect(isRestrictedUrl('https://microsoftedge.microsoft.com/')).toBe(false);
+	});
+
+	test('handles invalid URLs gracefully', () => {
+		expect(isRestrictedUrl('')).toBe(false);
+		expect(isRestrictedUrl('not-a-url')).toBe(false);
+	});
+});

--- a/src/utils/active-tab-manager.ts
+++ b/src/utils/active-tab-manager.ts
@@ -13,7 +13,8 @@ export async function updateCurrentActiveTab(windowId: number) {
 			tabId: currentActiveTabId,
 			url: tabs[0].url,
 			isValidUrl: isValidUrl(tabs[0].url),
-			isBlankPage: isBlankPage(tabs[0].url)
+			isBlankPage: isBlankPage(tabs[0].url),
+			isRestrictedUrl: isRestrictedUrl(tabs[0].url)
 		});
 	}
 }
@@ -26,4 +27,26 @@ export function isValidUrl(url: string): boolean {
 
 export function isBlankPage(url: string): boolean {
 	return url === 'about:blank' || url === 'chrome://newtab/' || url === 'edge://newtab/';
+}
+
+// Check if the URL is a browser-protected page that extensions cannot access
+export function isRestrictedUrl(url: string): boolean {
+	try {
+		const urlObj = new URL(url);
+		const hostname = urlObj.hostname;
+		
+		// Firefox addon store
+		if (hostname === 'addons.mozilla.org') return true;
+		
+		// Chrome Web Store
+		if (hostname === 'chrome.google.com' && urlObj.pathname.startsWith('/webstore')) return true;
+		if (hostname === 'chromewebstore.google.com') return true;
+		
+		// Edge Add-ons
+		if (hostname === 'microsoftedge.microsoft.com' && urlObj.pathname.startsWith('/addons')) return true;
+		
+		return false;
+	} catch {
+		return false;
+	}
 }


### PR DESCRIPTION
Fixes #662

When trying to clip pages from browser extension stores (like addons.mozilla.org, chrome.google.com/webstore, microsoftedge.microsoft.com/addons), the extension showed a misleading error message asking users to restart their browser, when in fact these pages are protected by the browser and cannot be accessed by extensions.

Changes:
- Add isRestrictedUrl() function to detect browser-protected extension store pages
- Show appropriate 'This page cannot be clipped. Browser extension pages are protected.' message
- Add tests for the new isRestrictedUrl function
- Check for restricted URLs in popup initialization, refreshFields, and tab change handlers

Afterwards on addons.mozilla.org
<img width="1729" height="731" alt="image" src="https://github.com/user-attachments/assets/2e0bc177-b33e-4c8b-a1c1-b3588cb11b0e" />

On chromewebstore.google.com
<img width="1650" height="733" alt="image" src="https://github.com/user-attachments/assets/45a35e31-0388-4ea1-aa50-e171c4ae4f33" />
