### PR TITLE
Fix WeChat formula extraction via data-formula to data-latex promotion

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -26,6 +26,14 @@ declare global {
 	const iframeId = 'obsidian-clipper-iframe';
 	const containerId = 'obsidian-clipper-container';
 
+	function promoteFormulaAttributes() {
+		document.querySelectorAll('[data-formula]').forEach(el => {
+			if (!el.hasAttribute('data-latex')) {
+				el.setAttribute('data-latex', el.getAttribute('data-formula') || '');
+			}
+		});
+	}
+
 	function removeContainer(container: HTMLElement) {
 		container.classList.add('is-closing');
 		container.addEventListener('animationend', () => {
@@ -210,6 +218,9 @@ declare global {
 
 		if (request.action === "copyMarkdownToClipboard") {
 			try {
+				// Promote data-formula to data-latex before Defuddle strips it
+				promoteFormulaAttributes();
+
 				// Extract page content using Defuddle
 				const defuddled = new Defuddle(document, { url: document.URL }).parse();
 
@@ -245,6 +256,9 @@ declare global {
 			}
 
 			const extractedContent: { [key: string]: string } = {};
+
+			// Promote data-formula to data-latex before Defuddle strips it
+			promoteFormulaAttributes();
 
 			// Process with Defuddle first while we have access to the document
 			const defuddled = new Defuddle(document, { url: document.URL }).parse();

--- a/src/utils/markdown-converter.test.ts
+++ b/src/utils/markdown-converter.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from 'vitest';
+import { createMarkdownContent } from './markdown-converter';
+
+describe('math formula conversion', () => {
+	test('converts inline math with data-latex to $...$', () => {
+		const html = '<p>Let <math display="inline" data-latex="\\small X_1 + Y_2">X₁ + Y₂</math> be a sample</p>';
+		const md = createMarkdownContent(html, 'https://mp.weixin.qq.com/s/test');
+		expect(md).toContain('$X_1 + Y_2$');
+		expect(md).not.toContain('\\small');
+	});
+
+	test('converts block math with data-latex to $$...$$', () => {
+		const html = '<math display="block" data-latex="\\small \\beta(a) = \\sup_t X_t">β(a)</math>';
+		const md = createMarkdownContent(html, 'https://example.com/');
+		expect(md).toContain('$$');
+		expect(md).toContain('\\beta(a) = \\sup_t X_t');
+		expect(md).not.toContain('\\small');
+	});
+
+	test('decodes URI-encoded data-latex values', () => {
+		const html = '<p><math display="inline" data-latex="%5Csmall%20X%5E2">X²</math></p>';
+		const md = createMarkdownContent(html, 'https://example.com/');
+		expect(md).toContain('$X^2$');
+	});
+
+	test('passes through normal data-latex without cleaning prefix', () => {
+		const html = '<p><math display="inline" data-latex="E = mc^2">E=mc²</math></p>';
+		const md = createMarkdownContent(html, 'https://example.com/');
+		expect(md).toContain('$E = mc^2$');
+	});
+});

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -642,13 +642,26 @@ export function createMarkdownContent(content: string, url: string) {
 		return tableClone.outerHTML;
 	}
 
+	function cleanLatex(raw: string): string {
+		let result = raw.trim();
+		if (!result) return '';
+		try {
+			if (/%[0-9A-Fa-f]{2}/.test(result)) {
+				result = decodeURIComponent(result);
+			}
+		} catch { /* not URI-encoded */ }
+		result = result.replace(/^\\(?:small|displaystyle|textstyle|normalsize)\s+/, '');
+		result = result.replace(/\u00A0/g, ' ').trim();
+		return result;
+	}
+
 	function extractLatex(element: Element): string {
 		// Check if the element is a <math> element and has an alttext attribute
 		if (element.nodeName.toLowerCase() === 'math') {
 			let latex = element.getAttribute('data-latex');
 			let alttext = element.getAttribute('alttext');
 			if (latex) {
-				return latex.trim();
+				return cleanLatex(latex);
 			} else if (alttext) {
 				return alttext.trim();
 			}

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -137,7 +137,22 @@ export function makeUrlAbsolute(element: Element, attributeName: string, baseUrl
 export function processUrls(htmlContent: string, baseUrl: URL): string {
 	const parser = new DOMParser();
 	const doc = parser.parseFromString(htmlContent, 'text/html');
-	
+
+	// Promote lazy-loaded src before absolutizing URLs
+	doc.querySelectorAll('img').forEach(img => {
+		const dataSrc = img.getAttribute('data-src')
+			|| img.getAttribute('data-original')
+			|| img.getAttribute('data-actualsrc');
+		const src = img.getAttribute('src');
+		if (dataSrc && (!src || !src.trim() || src.startsWith('data:image/') || src === 'about:blank')) {
+			img.setAttribute('src', dataSrc);
+		}
+		const dataSrcset = img.getAttribute('data-srcset');
+		if (dataSrcset && !img.getAttribute('srcset')) {
+			img.setAttribute('srcset', dataSrcset);
+		}
+	});
+
 	// Handle relative URLs for images, links, videos, and audio embeds.
 	doc.querySelectorAll('img').forEach(img => makeUrlAbsolute(img, 'srcset', baseUrl));
 	doc.querySelectorAll('img').forEach(img => makeUrlAbsolute(img, 'src', baseUrl));


### PR DESCRIPTION
## Summary

- Promote `data-formula` → `data-latex` attributes before Defuddle runs, so Defuddle's built-in math pipeline converts them to `<math>` elements that the existing Turndown `math` rule handles
- Clean LaTeX values in `extractLatex()`: URI-decode, strip `\small`/`\displaystyle`/`\textstyle`/`\normalsize` prefixes, normalize non-breaking spaces
- Promote lazy-loaded image `data-src`/`data-original`/`data-actualsrc` → `src` in `processUrls()` so images from sites using lazy loading (including WeChat) are preserved

## Context

WeChat (mp.weixin.qq.com) articles store math formulas in `data-formula` HTML attributes. Defuddle strips `data-formula` because it's not in its attribute whitelist, but it does whitelist `data-latex` and has built-in handling that converts `[data-latex]` elements into `<math display="inline|block" data-latex="...">` elements. By copying `data-formula` to `data-latex` before Defuddle runs, the entire existing pipeline handles the rest — no new Turndown rules or WeChat-specific bypasses needed.

## Test plan

- [x] `npm run test` — all 494 tests pass (including 4 new math conversion tests)
- [x] Build extension, test on a WeChat article with math formulas:
  - Inline formulas → `$...$`
  - Block formulas → `$$\n...\n$$`
  - `\small` prefixes stripped
  - Images load correctly (lazy-load promotion)
- [ ] Test on non-WeChat pages (ArXiv, Wikipedia) to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)