### PR TITLE
Adapt extension for LogSeq via HTTP API (Phase 1-3)

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -330,50 +330,11 @@ browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime
 			}
 		}
 
-		if (typedRequest.action === "openObsidianUrl") {
-			const url = (typedRequest as any).url;
-			if (url) {
-				browser.tabs.query({active: true, currentWindow: true}).then((tabs) => {
-					const currentTab = tabs[0];
-					if (currentTab && currentTab.id) {
-						browser.tabs.update(currentTab.id, { url: url }).then(() => {
-							sendResponse({ success: true });
-						}).catch((error) => {
-							console.error('Error opening Obsidian URL:', error);
-							sendResponse({
-								success: false,
-								error: error instanceof Error ? error.message : String(error)
-							});
-						});
-					} else {
-						sendResponse({
-							success: false,
-							error: 'No active tab found'
-						});
-					}
-				}).catch((error) => {
-					console.error('Error querying tabs:', error);
-					sendResponse({
-						success: false,
-						error: error instanceof Error ? error.message : String(error)
-					});
-				});
-				return true;
-			} else {
-				sendResponse({
-					success: false,
-					error: 'Missing URL'
-				});
-				return true;
-			}
-		}
-
 		// For other actions that use sendResponse
-		if (typedRequest.action === "extractContent" || 
+		if (typedRequest.action === "extractContent" ||
 			typedRequest.action === "ensureContentScriptLoaded" ||
 			typedRequest.action === "getHighlighterMode" ||
-			typedRequest.action === "toggleHighlighterMode" ||
-			typedRequest.action === "openObsidianUrl") {
+			typedRequest.action === "toggleHighlighterMode") {
 			return true;
 		}
 	}
@@ -431,7 +392,7 @@ const debouncedUpdateContextMenu = debounce(async (tabId: number) => {
 			contexts: browser.Menus.ContextType[];
 		}[] = [
 				{
-					id: "open-obsidian-clipper",
+					id: "open-logseq-clipper",
 					title: "Save this page",
 					contexts: ["page", "selection", "image", "video", "audio"]
 				},
@@ -487,7 +448,7 @@ const debouncedUpdateContextMenu = debounce(async (tabId: number) => {
 }, 100); // 100ms debounce time
 
 browser.contextMenus.onClicked.addListener(async (info, tab) => {
-	if (info.menuItemId === "open-obsidian-clipper") {
+	if (info.menuItemId === "open-logseq-clipper") {
 		browser.action.openPopup();
 	} else if (info.menuItemId === "enter-highlighter" && tab && tab.id) {
 		await setHighlighterMode(tab.id, true);

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { Template, Property, PromptVariable } from '../types/types';
 import { incrementStat, addHistoryEntry, getClipHistory } from '../utils/storage-utils';
-import { generateFrontmatter, saveToObsidian } from '../utils/obsidian-note-creator';
+import { generateLogseqProperties, saveToLogseq } from '../utils/logseq-note-creator';
 import { extractPageContent, initializePageContent } from '../utils/content-extractor';
 import { compileTemplate } from '../utils/template-compiler';
 import { initializeIcons, getPropertyTypeIcon } from '../icons/icons';
@@ -33,7 +33,7 @@ let currentTemplate: Template | null = null;
 let templates: Template[] = [];
 let currentVariables: { [key: string]: string } = {};
 let currentTabId: number | undefined;
-let lastSelectedVault: string | null = null;
+let lastSelectedGraph: string | null = null;
 
 const isSidePanel = window.location.pathname.includes('side-panel.html');
 const urlParams = new URLSearchParams(window.location.search);
@@ -51,10 +51,10 @@ const memoizedCompileTemplate = memoizeWithExpiration(
 	}
 );
 
-// Memoize generateFrontmatter with a longer expiration
-const memoizedGenerateFrontmatter = memoizeWithExpiration(
+// Memoize generateLogseqProperties with a longer expiration
+const memoizedGenerateLogseqProperties = memoizeWithExpiration(
 	async (properties: Property[]) => {
-		return generateFrontmatter(properties);
+		return generateLogseqProperties(properties);
 	},
 	{ expirationMs: 5000 }
 );
@@ -170,14 +170,14 @@ async function initializeExtension(tabId: number) {
 		currentTemplate = templates[0];
 		debugLog('Templates', 'Current template set to:', currentTemplate);
 
-		// Load last selected vault
-		lastSelectedVault = await getLocalStorage('lastSelectedVault');
-		if (!lastSelectedVault && loadedSettings.vaults.length > 0) {
-			lastSelectedVault = loadedSettings.vaults[0];
+		// Load last selected graph
+		lastSelectedGraph = await getLocalStorage('lastSelectedGraph');
+		if (!lastSelectedGraph && loadedSettings.graphs.length > 0) {
+			lastSelectedGraph = loadedSettings.graphs[0];
 		}
-		debugLog('Vaults', 'Last selected vault:', lastSelectedVault);
+		debugLog('Graphs', 'Last selected graph:', lastSelectedGraph);
 
-		updateVaultDropdown(loadedSettings.vaults);
+		updateGraphDropdown(loadedSettings.graphs);
 
 		const tab = await getTabInfo(tabId);
 		if (!tab.url || isBlankPage(tab.url)) {
@@ -321,7 +321,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 
 			try {
 				// DOM-dependent initializations
-				updateVaultDropdown(loadedSettings.vaults);
+				updateGraphDropdown(loadedSettings.graphs);
 				populateTemplateDropdown();
 				setupEventListeners(currentTabId);
 				await initializeUI();
@@ -417,9 +417,9 @@ function setupEventListeners(tabId: number) {
 			}) as Property[];
 
 			const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
-			const frontmatter = await generateFrontmatter(properties);
-			const fileContent = frontmatter + noteContentField.value;
-			
+			const logseqProperties = generateLogseqProperties(properties);
+			const fileContent = logseqProperties + noteContentField.value;
+
 			await copyToClipboard(fileContent);
 		});
 	}
@@ -446,11 +446,11 @@ function setupEventListeners(tabId: number) {
 				
 				// Use Promise.all to prepare the data
 				Promise.all([
-					generateFrontmatter(properties),
+					Promise.resolve(generateLogseqProperties(properties)),
 					Promise.resolve(noteContentField.value)
-				]).then(([frontmatter, noteContent]) => {
-					const fileContent = frontmatter + noteContent;
-					
+				]).then(([logseqProperties, noteContent]) => {
+					const fileContent = logseqProperties + noteContent;
+
 					// Call share directly from the click handler
 					const noteNameField = document.getElementById('note-name-field') as HTMLInputElement;
 					let fileName = noteNameField?.value || 'untitled';
@@ -462,22 +462,22 @@ function setupEventListeners(tabId: number) {
 					if (navigator.share && navigator.canShare) {
 						const blob = new Blob([fileContent], { type: 'text/markdown;charset=utf-8' });
 						const file = new File([blob], fileName, { type: 'text/markdown;charset=utf-8' });
-						
+
 						const shareData = {
 							files: [file],
-							text: 'Shared from Obsidian Web Clipper'
+							text: 'Shared from LogSeq Cupertino Clipper'
 						};
 
 						if (navigator.canShare(shareData)) {
 							const pathField = document.getElementById('path-name-field') as HTMLInputElement;
-							const vaultDropdown = document.getElementById('vault-select') as HTMLSelectElement;
+							const graphDropdown = document.getElementById('graph-select') as HTMLSelectElement;
 							const path = pathField?.value || '';
-							const vault = vaultDropdown?.value || '';
+							const graph = graphDropdown?.value || '';
 
 							navigator.share(shareData)
 								.then(async () => {
 									const tabInfo = await getCurrentTabInfo();
-									await incrementStat('share', vault, path, tabInfo.url, tabInfo.title);
+									await incrementStat('share', graph, path, tabInfo.url, tabInfo.title);
 									const moreDropdown = document.getElementById('more-dropdown');
 									if (moreDropdown) {
 											moreDropdown.classList.remove('show');
@@ -717,13 +717,13 @@ async function initializeTemplateFields(currentTabId: number, template: Template
 	// Cache the current URL once at the start to avoid repeated getTabInfo calls
 	const currentUrl = currentTabId ? (await getTabInfo(currentTabId)).url || '' : '';
 
-	// Handle vault selection
-	const vaultDropdown = document.getElementById('vault-select') as HTMLSelectElement;
-	if (vaultDropdown) {
-		if (template.vault) {
-			vaultDropdown.value = template.vault;
-		} else if (lastSelectedVault) {
-			vaultDropdown.value = lastSelectedVault;
+	// Handle graph selection
+	const graphDropdown = document.getElementById('graph-select') as HTMLSelectElement;
+	if (graphDropdown) {
+		if (template.graph) {
+			graphDropdown.value = template.graph;
+		} else if (lastSelectedGraph) {
+			graphDropdown.value = lastSelectedGraph;
 		}
 	}
 
@@ -995,38 +995,38 @@ async function getReplacedTemplate(template: Template, variables: { [key: string
 	return replacedTemplate;
 }
 
-function updateVaultDropdown(vaults: string[]) {
-	const vaultDropdown = document.getElementById('vault-select') as HTMLSelectElement | null;
-	const vaultContainer = document.getElementById('vault-container');
+function updateGraphDropdown(graphs: string[]) {
+	const graphDropdown = document.getElementById('graph-select') as HTMLSelectElement | null;
+	const graphContainer = document.getElementById('graph-container');
 
-	if (!vaultDropdown || !vaultContainer) return;
+	if (!graphDropdown || !graphContainer) return;
 
 	// Clear existing options
-	vaultDropdown.textContent = '';
-	
-	vaults.forEach(vault => {
+	graphDropdown.textContent = '';
+
+	graphs.forEach(graph => {
 		const option = document.createElement('option');
-		option.value = vault;
-		option.textContent = vault;
-		vaultDropdown.appendChild(option);
+		option.value = graph;
+		option.textContent = graph;
+		graphDropdown.appendChild(option);
 	});
 
-	// Only show vault selector if vaults are defined
-	if (vaults.length > 0) {
-		vaultContainer.style.display = 'block';
-		if (lastSelectedVault && vaults.includes(lastSelectedVault)) {
-			vaultDropdown.value = lastSelectedVault;
+	// Only show graph selector if graphs are defined
+	if (graphs.length > 0) {
+		graphContainer.style.display = 'block';
+		if (lastSelectedGraph && graphs.includes(lastSelectedGraph)) {
+			graphDropdown.value = lastSelectedGraph;
 		} else {
-			vaultDropdown.value = vaults[0];
+			graphDropdown.value = graphs[0];
 		}
 	} else {
-		vaultContainer.style.display = 'none';
+		graphContainer.style.display = 'none';
 	}
 
-	// Add event listener to update lastSelectedVault when changed
-	vaultDropdown.addEventListener('change', () => {
-		lastSelectedVault = vaultDropdown.value;
-		setLocalStorage('lastSelectedVault', lastSelectedVault);
+	// Add event listener to update lastSelectedGraph when changed
+	graphDropdown.addEventListener('change', () => {
+		lastSelectedGraph = graphDropdown.value;
+		setLocalStorage('lastSelectedGraph', lastSelectedGraph);
 	});
 }
 
@@ -1131,17 +1131,17 @@ export async function copyToClipboard(content: string) {
 		});
 		
 		const pathField = document.getElementById('path-name-field') as HTMLInputElement;
-		const vaultDropdown = document.getElementById('vault-select') as HTMLSelectElement;
+		const graphDropdown = document.getElementById('graph-select') as HTMLSelectElement;
 		const path = pathField?.value || '';
-		const vault = vaultDropdown?.value || '';
-		
+		const graph = graphDropdown?.value || '';
+
 		const tabInfo = await getCurrentTabInfo();
-		await incrementStat('copyToClipboard', vault, path, tabInfo.url, tabInfo.title);
+		await incrementStat('copyToClipboard', graph, path, tabInfo.url, tabInfo.title);
 
 		// Change the main button text temporarily
 		const clipButton = document.getElementById('clip-btn');
 		if (clipButton) {
-			const originalText = clipButton.textContent || getMessage('addToObsidian');
+			const originalText = clipButton.textContent || getMessage('addToLogseq');
 			clipButton.textContent = getMessage('copied');
 			
 			// Reset the text after 1.5 seconds
@@ -1159,12 +1159,12 @@ async function handleSaveToDownloads() {
 	try {
 		const noteNameField = document.getElementById('note-name-field') as HTMLInputElement;
 		const pathField = document.getElementById('path-name-field') as HTMLInputElement;
-		const vaultDropdown = document.getElementById('vault-select') as HTMLSelectElement;
-		
+
 		let fileName = noteNameField?.value || 'untitled';
 		const path = pathField?.value || '';
-		const vault = vaultDropdown?.value || '';
-		
+		const graphDropdown2 = document.getElementById('graph-select') as HTMLSelectElement;
+		const graph = graphDropdown2?.value || '';
+
 		const properties = Array.from(document.querySelectorAll('.metadata-property input')).map(input => {
 			const inputElement = input as HTMLInputElement;
 			return {
@@ -1175,8 +1175,8 @@ async function handleSaveToDownloads() {
 		}) as Property[];
 
 		const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
-		const frontmatter = await generateFrontmatter(properties);
-		const fileContent = frontmatter + noteContentField.value;
+		const logseqProperties = generateLogseqProperties(properties);
+		const fileContent = logseqProperties + noteContentField.value;
 
 		await saveFile({
 			content: fileContent,
@@ -1187,7 +1187,7 @@ async function handleSaveToDownloads() {
 		});
 
 		const tabInfo = await getCurrentTabInfo();
-		await incrementStat('saveFile', vault, path, tabInfo.url, tabInfo.title);
+		await incrementStat('saveFile', graph, path, tabInfo.url, tabInfo.title);
 
 		const moreDropdown = document.getElementById('more-dropdown');
 		if (moreDropdown) {
@@ -1214,35 +1214,35 @@ function determineMainAction() {
 			mainButton.textContent = getMessage('copyToClipboard');
 			mainButton.onclick = () => copyContent();
 			// Add direct actions to secondary
-			addSecondaryAction(secondaryActions, 'addToObsidian', () => handleClipObsidian());
+			addSecondaryAction(secondaryActions, 'addToLogseq', () => handleClipLogseq());
 			addSecondaryAction(secondaryActions, 'saveFile', handleSaveToDownloads);
 			break;
 		case 'saveFile':
 			mainButton.textContent = getMessage('saveFile');
 			mainButton.onclick = () => handleSaveToDownloads();
 			// Add direct actions to secondary
-			addSecondaryAction(secondaryActions, 'addToObsidian', () => handleClipObsidian());
+			addSecondaryAction(secondaryActions, 'addToLogseq', () => handleClipLogseq());
 			addSecondaryAction(secondaryActions, 'copyToClipboard', copyContent);
 			break;
-		default: // 'addToObsidian'
-			mainButton.textContent = getMessage('addToObsidian');
-			mainButton.onclick = () => handleClipObsidian();
+		default: // 'addToLogseq'
+			mainButton.textContent = getMessage('addToLogseq');
+			mainButton.onclick = () => handleClipLogseq();
 			// Add direct actions to secondary
 			addSecondaryAction(secondaryActions, 'copyToClipboard', copyContent);
 			addSecondaryAction(secondaryActions, 'saveFile', handleSaveToDownloads);
 	}
 }
 
-async function handleClipObsidian(): Promise<void> {
+async function handleClipLogseq(): Promise<void> {
 	if (!currentTemplate) return;
 
-	const vaultDropdown = document.getElementById('vault-select') as HTMLSelectElement;
+	const graphDropdown = document.getElementById('graph-select') as HTMLSelectElement;
 	const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
 	const noteNameField = document.getElementById('note-name-field') as HTMLInputElement;
 	const pathField = document.getElementById('path-name-field') as HTMLInputElement;
 	const interpretBtn = document.getElementById('interpret-btn') as HTMLButtonElement;
 
-	if (!vaultDropdown || !noteContentField) {
+	if (!noteContentField) {
 		showError('Some required fields are missing. Please try reloading the extension.');
 		return;
 	}
@@ -1268,29 +1268,29 @@ async function handleClipObsidian(): Promise<void> {
 			};
 		}) as Property[];
 
-		const frontmatter = await generateFrontmatter(properties);
-		const fileContent = frontmatter + noteContentField.value;
+		const logseqProperties = generateLogseqProperties(properties);
+		const noteContent = noteContentField.value;
 
-		// Save to Obsidian
-		const selectedVault = currentTemplate.vault || vaultDropdown.value;
+		// Save to LogSeq
+		const selectedGraph = currentTemplate.graph || graphDropdown?.value || '';
 		const isDailyNote = currentTemplate.behavior === 'append-daily' || currentTemplate.behavior === 'prepend-daily';
 		const noteName = isDailyNote ? '' : noteNameField?.value || '';
 		const path = isDailyNote ? '' : pathField?.value || '';
 
-		await saveToObsidian(fileContent, noteName, path, selectedVault, currentTemplate.behavior);
+		await saveToLogseq(logseqProperties, noteContent, noteName, path, selectedGraph, currentTemplate.behavior);
 		const tabInfo = await getCurrentTabInfo();
-		await incrementStat('addToObsidian', selectedVault, path, tabInfo.url, tabInfo.title);
+		await incrementStat('addToLogseq', selectedGraph, path, tabInfo.url, tabInfo.title);
 
-		if (!currentTemplate.vault) {
-			lastSelectedVault = selectedVault;
-			await setLocalStorage('lastSelectedVault', lastSelectedVault);
+		if (!currentTemplate.graph) {
+			lastSelectedGraph = selectedGraph;
+			await setLocalStorage('lastSelectedGraph', lastSelectedGraph);
 		}
 
 		if (!isSidePanel) {
 			setTimeout(() => window.close(), 500);
 		}
 	} catch (error) {
-		console.error('Error in handleClipObsidian:', error);
+		console.error('Error in handleClipLogseq:', error);
 		showError('failedToSaveFile');
 		throw error;
 	}
@@ -1327,7 +1327,7 @@ function getActionIcon(actionType: string): string {
 	switch (actionType) {
 		case 'copyToClipboard': return 'copy';
 		case 'saveFile': return 'file-down';
-		case 'addToObsidian': return 'pen-line';
+		case 'addToLogseq': return 'pen-line';
 		default: return 'plus';
 	}
 }
@@ -1343,8 +1343,8 @@ async function copyContent() {
 	}) as Property[];
 
 	const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
-	const frontmatter = await generateFrontmatter(properties);
-	const fileContent = frontmatter + noteContentField.value;
+	const logseqProperties = generateLogseqProperties(properties);
+	const fileContent = logseqProperties + noteContentField.value;
 	await copyToClipboard(fileContent);
 }
 

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -18,23 +18,24 @@ import { getClipHistory } from '../utils/storage-utils';
 import dayjs from 'dayjs';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
 import { showModal, hideModal } from '../utils/modal-utils';
+import { logseqClient } from '../utils/logseq-api-client';
 
 dayjs.extend(weekOfYear);
 
 const STORE_URLS = {
-	chrome: 'https://chromewebstore.google.com/detail/obsidian-web-clipper/cnjifjpddelmedmihgijeibhnjfabmlf',
-	firefox: 'https://addons.mozilla.org/en-US/firefox/addon/web-clipper-obsidian/',
-	safari: 'https://apps.apple.com/us/app/obsidian-web-clipper/id6720708363',
-	edge: 'https://microsoftedge.microsoft.com/addons/detail/obsidian-web-clipper/eigdjhmgnaaeaonimdklocfekkaanfme'
+	chrome: 'https://chromewebstore.google.com/detail/logseq-cupertino-clipper',
+	firefox: 'https://addons.mozilla.org/en-US/firefox/addon/logseq-cupertino-clipper/',
+	safari: '#',
+	edge: '#'
 };
 
-export function updateVaultList(): void {
-	const vaultList = document.getElementById('vault-list') as HTMLUListElement;
-	if (!vaultList) return;
+export function updateGraphList(): void {
+	const graphList = document.getElementById('graph-list') as HTMLUListElement;
+	if (!graphList) return;
 
-	// Clear existing vaults
-	vaultList.textContent = '';
-	generalSettings.vaults.forEach((vault, index) => {
+	// Clear existing graphs
+	graphList.textContent = '';
+	generalSettings.graphs.forEach((graph, index) => {
 		const li = document.createElement('li');
 		li.dataset.index = index.toString();
 		li.draggable = true;
@@ -44,12 +45,12 @@ export function updateVaultList(): void {
 		li.appendChild(dragHandle);
 
 		const span = document.createElement('span');
-		span.textContent = vault;
+		span.textContent = graph;
 		li.appendChild(span);
 
 		const removeBtn = createElementWithClass('button', 'remove-vault-btn clickable-icon');
 		removeBtn.setAttribute('type', 'button');
-		removeBtn.setAttribute('aria-label', getMessage('removeVault'));
+		removeBtn.setAttribute('aria-label', getMessage('removeGraph'));
 		removeBtn.appendChild(createElementWithHTML('i', '', { 'data-lucide': 'trash-2' }));
 		li.appendChild(removeBtn);
 
@@ -59,24 +60,24 @@ export function updateVaultList(): void {
 		li.addEventListener('dragend', handleDragEnd);
 		removeBtn.addEventListener('click', (e) => {
 			e.stopPropagation();
-			removeVault(index);
+			removeGraph(index);
 		});
-		vaultList.appendChild(li);
+		graphList.appendChild(li);
 	});
 
-	initializeIcons(vaultList);
+	initializeIcons(graphList);
 }
 
-export function addVault(vault: string): void {
-	generalSettings.vaults.push(vault);
+export function addGraph(graph: string): void {
+	generalSettings.graphs.push(graph);
 	saveSettings();
-	updateVaultList();
+	updateGraphList();
 }
 
-export function removeVault(index: number): void {
-	generalSettings.vaults.splice(index, 1);
+export function removeGraph(index: number): void {
+	generalSettings.graphs.splice(index, 1);
 	saveSettings();
-	updateVaultList();
+	updateGraphList();
 }
 
 export async function setShortcutInstructions() {
@@ -86,11 +87,11 @@ export async function setShortcutInstructions() {
 		// Clear content
 		shortcutInstructionsElement.textContent = '';
 		shortcutInstructionsElement.appendChild(document.createTextNode(getMessage('shortcutInstructionsIntro') + ' '));
-		
+
 		// Browser-specific instructions
 		let instructionsText = '';
 		let url = '';
-		
+
 		switch (browser) {
 			case 'chrome':
 				instructionsText = getMessage('shortcutInstructionsChrome', ['$URL']);
@@ -115,24 +116,21 @@ export async function setShortcutInstructions() {
 			default:
 				instructionsText = getMessage('shortcutInstructionsDefault');
 		}
-		
+
 		if (url) {
-			// Split text around the URL placeholder and add strong element
 			const parts = instructionsText.split('$URL');
 			if (parts.length === 2) {
 				shortcutInstructionsElement.appendChild(document.createTextNode(parts[0]));
-				
+
 				const strongElement = document.createElement('strong');
 				strongElement.textContent = url;
 				shortcutInstructionsElement.appendChild(strongElement);
-				
+
 				shortcutInstructionsElement.appendChild(document.createTextNode(parts[1]));
 			} else {
-				// Fallback if no placeholder found
 				shortcutInstructionsElement.appendChild(document.createTextNode(instructionsText));
 			}
 		} else {
-			// Safari and default cases (no URL needed)
 			shortcutInstructionsElement.appendChild(document.createTextNode(instructionsText));
 		}
 	}
@@ -148,7 +146,6 @@ async function initializeVersionDisplay(): Promise<void> {
 		versionNumber.textContent = manifest.version;
 	}
 
-	// Only add update listener for browsers that support it
 	const currentBrowser = await detectBrowser();
 	if (currentBrowser !== 'safari' && currentBrowser !== 'mobile-safari' && browser.runtime.onUpdateAvailable) {
 		browser.runtime.onUpdateAvailable.addListener((details) => {
@@ -158,7 +155,6 @@ async function initializeVersionDisplay(): Promise<void> {
 			}
 		});
 	} else {
-		// For Safari, just hide the update status elements
 		if (updateAvailable) {
 			updateAvailable.style.display = 'none';
 		}
@@ -172,15 +168,12 @@ export function initializeGeneralSettings(): void {
 	loadSettings().then(async () => {
 		await setupLanguageAndDirection();
 
-		// Add version check initialization
 		await initializeVersionDisplay();
 
-		// Get clip history and ratings
 		const history = await getClipHistory();
 		const totalClips = history.length;
 		const existingRatings = await getLocalStorage('ratings') || [];
 
-		// Show rating section only total clips >= 20 and no previous ratings
 		const rateExtensionSection = document.getElementById('rate-extension');
 		if (rateExtensionSection && totalClips >= 20 && existingRatings.length === 0) {
 			rateExtensionSection.classList.remove('is-hidden');
@@ -201,8 +194,7 @@ export function initializeGeneralSettings(): void {
 							}
 						});
 						await handleRating(rating);
-						
-						// Hide the rating section after rating
+
 						if (rateExtensionSection) {
 							rateExtensionSection.style.display = 'none';
 						}
@@ -211,12 +203,10 @@ export function initializeGeneralSettings(): void {
 			}
 		}
 
-		updateVaultList();
+		updateGraphList();
 		initializeShowMoreActionsToggle();
 		initializeBetaFeaturesToggle();
-		initializeLegacyModeToggle();
-		initializeSilentOpenToggle();
-		initializeVaultInput();
+		initializeGraphInput();
 		initializeOpenBehaviorDropdown();
 		initializeKeyboardShortcuts();
 		initializeToggles();
@@ -227,9 +217,9 @@ export function initializeGeneralSettings(): void {
 		initializeHighlighterSettings();
 		initializeExportHighlightsButton();
 		initializeSaveBehaviorDropdown();
+		initializeLogseqApiSettings();
 		await initializeUsageChart();
 
-		// Initialize feedback modal close button
 		const feedbackModal = document.getElementById('feedback-modal');
 		const feedbackCloseBtn = feedbackModal?.querySelector('.feedback-close-btn');
 		if (feedbackCloseBtn) {
@@ -241,7 +231,6 @@ export function initializeGeneralSettings(): void {
 function initializeAutoSave(): void {
 	const generalSettingsForm = document.getElementById('general-settings-form');
 	if (generalSettingsForm) {
-		// Listen for both input and change events
 		generalSettingsForm.addEventListener('input', debounce(saveSettingsFromForm, 500));
 		generalSettingsForm.addEventListener('change', debounce(saveSettingsFromForm, 500));
 	}
@@ -251,19 +240,15 @@ function saveSettingsFromForm(): void {
 	const openBehaviorDropdown = document.getElementById('open-behavior-dropdown') as HTMLSelectElement;
 	const showMoreActionsToggle = document.getElementById('show-more-actions-toggle') as HTMLInputElement;
 	const betaFeaturesToggle = document.getElementById('beta-features-toggle') as HTMLInputElement;
-	const legacyModeToggle = document.getElementById('legacy-mode-toggle') as HTMLInputElement;
-	const silentOpenToggle = document.getElementById('silent-open-toggle') as HTMLInputElement;
 	const highlighterToggle = document.getElementById('highlighter-toggle') as HTMLInputElement;
 	const alwaysShowHighlightsToggle = document.getElementById('highlighter-visibility') as HTMLInputElement;
 	const highlightBehaviorSelect = document.getElementById('highlighter-behavior') as HTMLSelectElement;
 
 	const updatedSettings = {
-		...generalSettings, // Keep existing settings
+		...generalSettings,
 		openBehavior: (openBehaviorDropdown?.value as 'popup' | 'embedded') ?? generalSettings.openBehavior,
 		showMoreActionsButton: showMoreActionsToggle?.checked ?? generalSettings.showMoreActionsButton,
 		betaFeatures: betaFeaturesToggle?.checked ?? generalSettings.betaFeatures,
-		legacyMode: legacyModeToggle?.checked ?? generalSettings.legacyMode,
-		silentOpen: silentOpenToggle?.checked ?? generalSettings.silentOpen,
 		highlighterEnabled: highlighterToggle?.checked ?? generalSettings.highlighterEnabled,
 		alwaysShowHighlights: alwaysShowHighlightsToggle?.checked ?? generalSettings.alwaysShowHighlights,
 		highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior
@@ -278,16 +263,16 @@ function initializeShowMoreActionsToggle(): void {
 	});
 }
 
-function initializeVaultInput(): void {
-	const vaultInput = document.getElementById('vault-input') as HTMLInputElement;
-	if (vaultInput) {
-		vaultInput.addEventListener('keypress', (e) => {
+function initializeGraphInput(): void {
+	const graphInput = document.getElementById('graph-input') as HTMLInputElement;
+	if (graphInput) {
+		graphInput.addEventListener('keypress', (e) => {
 			if (e.key === 'Enter') {
 				e.preventDefault();
-				const newVault = vaultInput.value.trim();
-				if (newVault) {
-					addVault(newVault);
-					vaultInput.value = '';
+				const newGraph = graphInput.value.trim();
+				if (newGraph) {
+					addGraph(newGraph);
+					graphInput.value = '';
 				}
 			}
 		});
@@ -301,17 +286,15 @@ async function initializeKeyboardShortcuts(): Promise<void> {
 	const browser = await detectBrowser();
 
 	if (browser === 'mobile-safari') {
-		// For Safari, display a message about keyboard shortcuts not being available
 		const messageItem = document.createElement('div');
 		messageItem.className = 'shortcut-item';
 		messageItem.textContent = getMessage('shortcutInstructionsSafari');
 		shortcutsList.appendChild(messageItem);
 	} else {
-		// For other browsers, proceed with displaying the shortcuts
 		getCommands().then(commands => {
 			commands.forEach(command => {
 				const shortcutItem = createElementWithClass('div', 'shortcut-item');
-				
+
 				const descriptionSpan = document.createElement('span');
 				descriptionSpan.textContent = command.description;
 				shortcutItem.appendChild(descriptionSpan);
@@ -329,18 +312,6 @@ async function initializeKeyboardShortcuts(): Promise<void> {
 function initializeBetaFeaturesToggle(): void {
 	initializeSettingToggle('beta-features-toggle', generalSettings.betaFeatures, (checked) => {
 		saveSettings({ ...generalSettings, betaFeatures: checked });
-	});
-}
-
-function initializeLegacyModeToggle(): void {
-	initializeSettingToggle('legacy-mode-toggle', generalSettings.legacyMode, (checked) => {
-		saveSettings({ ...generalSettings, legacyMode: checked });
-	});
-}
-
-function initializeSilentOpenToggle(): void {
-	initializeSettingToggle('silent-open-toggle', generalSettings.silentOpen, (checked) => {
-		saveSettings({ ...generalSettings, silentOpen: checked });
 	});
 }
 
@@ -362,21 +333,69 @@ function initializeResetDefaultTemplateButton(): void {
 }
 
 function initializeSaveBehaviorDropdown(): void {
-    const dropdown = document.getElementById('save-behavior-dropdown') as HTMLSelectElement;
-    if (!dropdown) return;
+	const dropdown = document.getElementById('save-behavior-dropdown') as HTMLSelectElement;
+	if (!dropdown) return;
 
-    dropdown.value = generalSettings.saveBehavior;
-    dropdown.addEventListener('change', () => {
-        const newValue = dropdown.value as 'addToObsidian' | 'copyToClipboard' | 'saveFile';
-        saveSettings({ saveBehavior: newValue });
-    });
+	dropdown.value = generalSettings.saveBehavior;
+	dropdown.addEventListener('change', () => {
+		const newValue = dropdown.value as 'addToLogseq' | 'copyToClipboard' | 'saveFile';
+		saveSettings({ saveBehavior: newValue });
+	});
+}
+
+function initializeLogseqApiSettings(): void {
+	const tokenInput = document.getElementById('logseq-api-token') as HTMLInputElement;
+	const portInput = document.getElementById('logseq-api-port') as HTMLInputElement;
+	const testBtn = document.getElementById('test-logseq-connection-btn') as HTMLButtonElement;
+	const statusEl = document.getElementById('logseq-connection-status');
+
+	if (tokenInput) {
+		tokenInput.value = generalSettings.logseqApiToken || '';
+		tokenInput.addEventListener('change', () => {
+			saveSettings({ ...generalSettings, logseqApiToken: tokenInput.value });
+		});
+	}
+
+	if (portInput) {
+		portInput.value = String(generalSettings.logseqApiPort || 12315);
+		portInput.addEventListener('change', () => {
+			const port = parseInt(portInput.value, 10);
+			if (port > 0 && port < 65536) {
+				saveSettings({ ...generalSettings, logseqApiPort: port });
+			}
+		});
+	}
+
+	if (testBtn && statusEl) {
+		testBtn.addEventListener('click', async () => {
+			// Save current values before testing
+			if (tokenInput) saveSettings({ ...generalSettings, logseqApiToken: tokenInput.value });
+			if (portInput) {
+				const port = parseInt(portInput.value, 10);
+				if (port > 0 && port < 65536) saveSettings({ ...generalSettings, logseqApiPort: port });
+			}
+
+			statusEl.textContent = getMessage('testConnection') + '...';
+			statusEl.className = 'setting-item-description';
+
+			const available = await logseqClient.isAvailable();
+			if (available) {
+				const graphName = await logseqClient.getCurrentGraph();
+				statusEl.textContent = getMessage('connectionSuccess') || `Connected${graphName ? ' to graph: ' + graphName : ''}`;
+				statusEl.style.color = 'var(--color-green)';
+			} else {
+				statusEl.textContent = getMessage('connectionFailed') || 'Could not connect to LogSeq. Make sure the desktop app is running and HTTP API is enabled.';
+				statusEl.style.color = 'var(--color-red)';
+			}
+		});
+	}
 }
 
 export function resetDefaultTemplate(): void {
 	const defaultTemplate = createDefaultTemplate();
 	const currentTemplates = getTemplates();
 	const defaultIndex = currentTemplates.findIndex((t: Template) => t.name === getMessage('defaultTemplateName'));
-	
+
 	if (defaultIndex !== -1) {
 		currentTemplates[defaultIndex] = defaultTemplate;
 	} else {
@@ -442,41 +461,34 @@ async function initializeUsageChart(): Promise<void> {
 			timeRange: periodSelect.value as '30d' | 'all',
 			aggregation: aggregationSelect.value as 'day' | 'week' | 'month'
 		};
-		
+
 		const chartData = aggregateUsageData(history, options);
 		await createUsageChart(chartContainer, chartData);
 	};
 
-	// Initialize with default selections
 	await updateChart();
 
-	// Update when any selector changes
 	periodSelect.addEventListener('change', updateChart);
 	aggregationSelect.addEventListener('change', updateChart);
 }
 
 async function handleRating(rating: number) {
-	// Get existing ratings from storage
 	const existingRatings = await getLocalStorage('ratings') || [];
-	
-	// Add new rating
+
 	const newRating = {
 		rating,
 		date: new Date().toISOString()
 	};
-	
-	// Update both storage and generalSettings
+
 	const updatedRatings = [...existingRatings, newRating];
 	generalSettings.ratings = updatedRatings;
-	
-	// Save to storage
+
 	await setLocalStorage('ratings', updatedRatings);
 	await saveSettings();
 
 	if (rating >= 4) {
-		// Redirect to appropriate store
 		const browser = await detectBrowser();
-		let storeUrl = STORE_URLS.chrome; // Default to Chrome store
+		let storeUrl = STORE_URLS.chrome;
 
 		switch (browser) {
 			case 'firefox':
@@ -495,7 +507,6 @@ async function handleRating(rating: number) {
 
 		window.open(storeUrl, '_blank');
 	} else {
-		// Show feedback modal for ratings < 4
 		const modal = document.getElementById('feedback-modal');
 		showModal(modal);
 	}

--- a/src/popup.html
+++ b/src/popup.html
@@ -49,10 +49,10 @@
 			</div>
 			<div class="clipper-footer">
 				<div class="vault-path-container">
-					<div id="vault-container" style="display: none;">
-						<select id="vault-select"></select>
+					<div id="graph-container" style="display: none;">
+						<select id="graph-select"></select>
 					</div>
-					<input id="path-name-field" type="text" data-i18n="folder"/>
+					<input id="path-name-field" type="text" data-i18n="namespace"/>
 				</div>
 				<div id="interpreter" style="display: none;">
 					<textarea id="prompt-context" rows="3"></textarea>

--- a/src/settings.html
+++ b/src/settings.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-	<title>Obsidian Web Clipper</title>
+	<title>LogSeq Cupertino Clipper</title>
 	<link rel="stylesheet" href="style.css">
 </head>
 <body style="height: 100%; overflow: hidden;">
@@ -30,7 +30,7 @@
 						<div id="navbar-title">
 							<svg xmlns="http://www.w3.org/2000/svg" class="logo" fill="none" viewBox="0 0 256 256">
 								<path class="purple" d="M94.82 149.44c6.53-1.94 17.13-4.9 29.26-5.71a102.97 102.97 0 0 1-7.64-48.84c1.63-16.51 7.54-30.38 13.25-42.1l3.47-7.14 4.48-9.18c2.35-5 4.08-9.38 4.9-13.56.81-4.07.81-7.64-.2-11.11-1.03-3.47-3.07-7.14-7.15-11.21a17.02 17.02 0 0 0-15.8 3.77l-52.81 47.5a17.12 17.12 0 0 0-5.5 10.2l-4.5 30.18a149.26 149.26 0 0 1 38.24 57.2ZM54.45 106l-1.02 3.06-27.94 62.2a17.33 17.33 0 0 0 3.27 18.96l43.94 45.16a88.7 88.7 0 0 0 8.97-88.5A139.47 139.47 0 0 0 54.45 106Z"/><path class="purple" d="m82.9 240.79 2.34.2c8.26.2 22.33 1.02 33.64 3.06 9.28 1.73 27.73 6.83 42.82 11.21 11.52 3.47 23.45-5.8 25.08-17.73 1.23-8.67 3.57-18.46 7.75-27.53a94.81 94.81 0 0 0-25.9-40.99 56.48 56.48 0 0 0-29.56-13.35 96.55 96.55 0 0 0-40.99 4.79 98.89 98.89 0 0 1-15.29 80.34h.1Z"/><path class="purple" d="M201.87 197.76a574.87 574.87 0 0 0 19.78-31.6 8.67 8.67 0 0 0-.61-9.48 185.58 185.58 0 0 1-21.82-35.9c-5.91-14.16-6.73-36.08-6.83-46.69 0-4.07-1.22-8.05-3.77-11.21l-34.16-43.33c0 1.94-.4 3.87-.81 5.81a76.42 76.42 0 0 1-5.71 15.9l-4.7 9.8-3.36 6.72a111.95 111.95 0 0 0-12.03 38.23 93.9 93.9 0 0 0 8.67 47.92 67.9 67.9 0 0 1 39.56 16.52 99.4 99.4 0 0 1 25.8 37.31Z"/></svg>
-							<span>Obsidian Web Clipper</span>
+							<span>LogSeq Cupertino Clipper</span>
 						</div>
 						<button id="hamburger-menu" class="hamburger-menu">
 							<span class="hamburger-icon"></span>
@@ -107,7 +107,7 @@
 										</div>
 									</div>
 									<div class="setting-item-control">
-										<a href="https://github.com/obsidianmd/obsidian-clipper/releases" id="changelog-link" data-i18n="changelog" class="btn" target="_blank">Changelog</a>
+										<a href="https://github.com/andrefigueredo/logseq-cupertino-clipper/releases" id="changelog-link" data-i18n="changelog" class="btn" target="_blank">Changelog</a>
 									</div>
 								</div>
 								
@@ -117,15 +117,44 @@
 										<div class="setting-item-description" data-i18n="helpDescription">Learn how to use Web Clipper and get help troubleshooting.</div>
 									</div>
 									<div class="setting-item-control">
-										<a href="https://help.obsidian.md/web-clipper" id="help-open-btn" class="btn" target="_blank" data-i18n="open">Open</a>
+										<a href="#" id="help-open-btn" class="btn" target="_blank" data-i18n="open">Open</a>
 									</div>
 								</div>
 							</div>
 							<div>
-								<h3 data-i18n="vaults">Vaults</h3>
+								<h3 data-i18n="graphs">Graphs</h3>
 								<div class="setting-item-description" data-i18n="vaultsDescription">By default, clipped notes are saved to the currently open vault. You can add vaults here if you want the option to save to different vaults. Vault names must exactly match the name of the Obsidian vault. Press <strong>enter</strong> to add a&nbsp;vault.</div>
-								<input type="text" id="vault-input" data-i18n="addVaultPlaceholder" placeholder="Press enter to add a vault" autocomplete="off" spellcheck="false" />
-								<ul id="vault-list"></ul>
+								<input type="text" id="graph-input" data-i18n="addGraphPlaceholder" placeholder="Press enter to add a graph" autocomplete="off" spellcheck="false" />
+								<ul id="graph-list"></ul>
+							<div>
+								<h3>LogSeq API</h3>
+								<div class="setting-item-description" data-i18n="logseqApiDescription">Configure the LogSeq HTTP API connection. Enable the API server in LogSeq Settings &gt; Features &gt; HTTP APIs server.</div>
+								<div class="setting-item mod-horizontal">
+									<div class="setting-item-info">
+										<label for="logseq-api-token" data-i18n="apiToken">API Token</label>
+									</div>
+									<div class="setting-item-control">
+										<input type="password" id="logseq-api-token" autocomplete="off" spellcheck="false" />
+									</div>
+								</div>
+								<div class="setting-item mod-horizontal">
+									<div class="setting-item-info">
+										<label for="logseq-api-port" data-i18n="apiPort">API Port</label>
+									</div>
+									<div class="setting-item-control">
+										<input type="number" id="logseq-api-port" value="12315" min="1" max="65535" style="width: 80px;" />
+									</div>
+								</div>
+								<div class="setting-item mod-horizontal">
+									<div class="setting-item-info">
+										<label data-i18n="testConnection">Test Connection</label>
+										<div id="logseq-connection-status" class="setting-item-description"></div>
+									</div>
+									<div class="setting-item-control">
+										<button type="button" id="test-logseq-connection-btn" data-i18n="testConnection">Test</button>
+									</div>
+								</div>
+							</div>
 							</div>
 							<div id="hotkeys-subsection">
 								<h3 data-i18n="hotkeys">Hotkeys</h3>
@@ -171,36 +200,10 @@
 									</div>
 									<div class="setting-item-control">
 										<select id="save-behavior-dropdown">
-											<option value="addToObsidian" selected data-i18n="addToObsidian">Add to Obsidian</option>
+											<option value="addToLogseq" selected data-i18n="addToLogseq">Add to Obsidian</option>
 											<option value="copyToClipboard" data-i18n="copyToClipboard">Copy to clipboard</option>
 											<option value="saveFile" data-i18n="saveFile">Save file</option>
 										</select>
-									</div>
-								</div>
-								<div class="setting-item mod-horizontal">
-									<div class="setting-item-info">
-										<label for="silent-open-toggle" data-i18n="silentOpen">Save clipped note without opening&nbsp;it</label>
-										<div class="setting-item-description" data-i18n="silentOpenDescription">
-											Clipped notes will be saved but will not open as a new tab. Obsidian will still be brought to the foreground.
-										</div>
-									</div>
-									<div class="setting-item-control">
-										<div class="checkbox-container">
-											<input type="checkbox" id="silent-open-toggle" />
-										</div>
-									</div>
-								</div>
-								<div class="setting-item mod-horizontal">
-									<div class="setting-item-info">
-										<label for="legacy-mode-toggle" data-i18n="legacyMode">Legacy&nbsp;mode</label>
-										<div class="setting-item-description" data-i18n="legacyModeDescription">
-											Uses the URI clipping method compatible with Obsidian 1.6.7 or earlier. Note that the length of the content you can clip is limited by your browser and OS. Some pages may fail without any errors.
-										</div>
-									</div>
-									<div class="setting-item-control">
-										<div class="checkbox-container">
-											<input type="checkbox" id="legacy-mode-toggle" />
-										</div>
 									</div>
 								</div>
 								<div class="setting-item mod-horizontal">
@@ -313,7 +316,7 @@
 									<div class="setting-item-info">
 										<label for="interpreter-toggle" data-i18n="enableInterpreter">Enable interpreter</label>
 										<div class="setting-item-description" data-i18n="enableInterpreterDescription">
-											Use natural language to extract data from pages. For example, you can use the template syntax <strong>{{"a summary of the page"}}</strong>. Requires an API key or custom model configured below. <a href="https://help.obsidian.md/web-clipper/interpreter" target="_blank">Learn more</a>.
+											Use natural language to extract data from pages. For example, you can use the template syntax <strong>{{"a summary of the page"}}</strong>. Requires an API key or custom model configured below. <a href="#/interpreter" target="_blank">Learn more</a>.
 										</div>
 									</div>
 									<div class="setting-item-control">
@@ -507,9 +510,9 @@
 									<input type="text" id="template-path-name" placeholder="Clippings" />
 								</div>
 								<div class="setting-item">
-									<label for="template-vault" data-i18n="vault">Vault</label>
-									<div class="setting-item-description" data-i18n="vaultDescription">Select the default vault for this template. Go to general settings to add or remove vaults.</div>
-									<select id="template-vault">
+									<label for="template-graph" data-i18n="graph">Vault</label>
+									<div class="setting-item-description" data-i18n="graphDescription">Select the default graph for this template. Go to general settings to add or remove graphs.</div>
+									<select id="template-graph">
 										<option value="" data-i18n="lastUsed">Last used</option>
 									</select>
 								</div>
@@ -691,7 +694,7 @@
 					<p data-i18n="feedbackDescription">How can we improve Web Clipper? Please visit our help page, where you can report bugs, suggest features, and get help with common issues.</p>
 				</div>
 				<div class="modal-button-container">
-					<a class="btn mod-cta" href="https://help.obsidian.md/web-clipper/troubleshoot" target="_blank" data-i18n="help">Help</a>
+					<a class="btn mod-cta" href="#/troubleshoot" target="_blank" data-i18n="help">Help</a>
 					<button class="feedback-close-btn" data-i18n="close">Close</button>
 				</div>
 			</div>

--- a/src/side-panel.html
+++ b/src/side-panel.html
@@ -53,10 +53,10 @@
 			</div>
 			<div class="clipper-footer">
 				<div class="vault-path-container">
-					<div id="vault-container" style="display: none;">
-						<select id="vault-select"></select>
+					<div id="graph-container" style="display: none;">
+						<select id="graph-select"></select>
 					</div>
-					<input id="path-name-field" type="text" data-i18n="folder"/>
+					<input id="path-name-field" type="text" data-i18n="namespace"/>
 				</div>
 				<div id="interpreter" style="display: none;">
 					<textarea id="prompt-context" rows="3"></textarea>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,7 +7,7 @@ export interface Template {
 	noteContentFormat: string;
 	properties: Property[];
 	triggers?: string[];
-	vault?: string;
+	graph?: string;
 	context?: string;
 }
 
@@ -50,7 +50,7 @@ export interface Rating {
 	date: string;
 }
 
-export type SaveBehavior = 'addToObsidian' | 'saveFile' | 'copyToClipboard';
+export type SaveBehavior = 'addToLogseq' | 'saveFile' | 'copyToClipboard';
 
 export interface ReaderSettings {
 	fontSize: number;
@@ -61,11 +61,9 @@ export interface ReaderSettings {
 }
 
 export interface Settings {
-	vaults: string[];
+	graphs: string[];
 	showMoreActionsButton: boolean;
 	betaFeatures: boolean;
-	legacyMode: boolean;
-	silentOpen: boolean;
 	openBehavior: 'popup' | 'embedded';
 	highlighterEnabled: boolean;
 	alwaysShowHighlights: boolean;
@@ -78,15 +76,18 @@ export interface Settings {
 	defaultPromptContext: string;
 	propertyTypes: PropertyType[];
 	readerSettings: ReaderSettings;
+	logseqApiToken: string;
+	logseqApiPort: number;
+	logseqJournalFormat: string;
 	stats: {
-		addToObsidian: number;
+		addToLogseq: number;
 		saveFile: number;
 		copyToClipboard: number;
 		share: number;
 	};
 	history: HistoryEntry[];
 	ratings: Rating[];
-	saveBehavior: 'addToObsidian' | 'saveFile' | 'copyToClipboard';
+	saveBehavior: 'addToLogseq' | 'saveFile' | 'copyToClipboard';
 }
 
 export interface ModelConfig {
@@ -100,9 +101,9 @@ export interface ModelConfig {
 export interface HistoryEntry {
 	datetime: string;
 	url: string;
-	action: 'addToObsidian' | 'saveFile' | 'copyToClipboard' | 'share';
+	action: 'addToLogseq' | 'saveFile' | 'copyToClipboard' | 'share';
 	title?: string;
-	vault?: string;
+	graph?: string;
 	path?: string;
 }
 

--- a/src/utils/logseq-api-client.ts
+++ b/src/utils/logseq-api-client.ts
@@ -1,0 +1,90 @@
+import { generalSettings } from './storage-utils';
+
+export interface BatchBlock {
+	content: string;
+	children?: BatchBlock[];
+}
+
+export class LogseqAPIClient {
+	private get baseUrl(): string {
+		return `http://127.0.0.1:${generalSettings.logseqApiPort || 12315}`;
+	}
+
+	private get token(): string {
+		return generalSettings.logseqApiToken || '';
+	}
+
+	async call(method: string, args: any[]): Promise<any> {
+		const response = await fetch(`${this.baseUrl}/api`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.token}`
+			},
+			body: JSON.stringify({ method, args })
+		});
+
+		if (!response.ok) {
+			const text = await response.text().catch(() => response.statusText);
+			throw new Error(`LogSeq API error ${response.status}: ${text}`);
+		}
+
+		return response.json();
+	}
+
+	async isAvailable(): Promise<boolean> {
+		try {
+			await fetch(`${this.baseUrl}/api`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': `Bearer ${this.token}`
+				},
+				body: JSON.stringify({ method: 'logseq.App.getCurrentGraph', args: [] }),
+				signal: AbortSignal.timeout(3000)
+			});
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async getCurrentGraph(): Promise<string | null> {
+		try {
+			const result = await this.call('logseq.App.getCurrentGraph', []);
+			return result?.name || null;
+		} catch {
+			return null;
+		}
+	}
+
+	async getPage(name: string): Promise<any> {
+		return this.call('logseq.Editor.getPage', [name]);
+	}
+
+	async createPage(name: string, properties?: Record<string, string>, options?: { redirect?: boolean }): Promise<any> {
+		return this.call('logseq.Editor.createPage', [name, properties || {}, { redirect: false, ...options }]);
+	}
+
+	async appendBlockInPage(page: string, content: string): Promise<any> {
+		return this.call('logseq.Editor.appendBlockInPage', [page, content]);
+	}
+
+	async prependBlockInPage(page: string, content: string): Promise<any> {
+		return this.call('logseq.Editor.prependBlockInPage', [page, content]);
+	}
+
+	async insertBatchBlock(srcBlock: string, blocks: BatchBlock[], opts?: { sibling?: boolean }): Promise<any> {
+		return this.call('logseq.Editor.insertBatchBlock', [srcBlock, blocks, { sibling: false, ...opts }]);
+	}
+
+	async getPageBlocksTree(page: string): Promise<any[]> {
+		return this.call('logseq.Editor.getPageBlocksTree', [page]);
+	}
+
+	async removeBlock(blockUuid: string): Promise<any> {
+		return this.call('logseq.Editor.removeBlock', [blockUuid]);
+	}
+}
+
+export const logseqClient = new LogseqAPIClient();

--- a/src/utils/logseq-note-creator.ts
+++ b/src/utils/logseq-note-creator.ts
@@ -1,0 +1,198 @@
+import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import { sanitizeFileName } from './string-utils';
+import { Template, Property } from '../types/types';
+import { generalSettings, incrementStat } from './storage-utils';
+import { copyToClipboard } from './clipboard-utils';
+import { logseqClient, BatchBlock } from './logseq-api-client';
+import { getMessage } from './i18n';
+
+dayjs.extend(advancedFormat);
+
+/**
+ * Generates LogSeq properties block in `property:: value` format.
+ * These go at the top of the page (page-level properties).
+ */
+export function generateLogseqProperties(properties: Property[]): string {
+	let propsBlock = '';
+
+	for (const property of properties) {
+		if (!property.name || property.value === undefined) continue;
+
+		const propertyType = generalSettings.propertyTypes.find(p => p.name === property.name)?.type || 'text';
+		const name = property.name;
+		let value = property.value;
+
+		if (value === undefined || value === null) {
+			propsBlock += `${name}:: \n`;
+			continue;
+		}
+
+		switch (propertyType) {
+			case 'multitext': {
+				let items: string[];
+				if (value.trim().startsWith('["') && value.trim().endsWith('"]')) {
+					try {
+						items = JSON.parse(value);
+					} catch {
+						items = value.split(',').map(item => item.trim());
+					}
+				} else {
+					// Split by comma but keep wikilinks intact
+					items = value.split(/,(?![^\[]*\]\])/).map(item => item.trim());
+				}
+				items = items.filter(item => item !== '');
+				propsBlock += `${name}:: ${items.join(', ')}\n`;
+				break;
+			}
+			case 'number': {
+				const numericValue = value.replace(/[^\d.-]/g, '');
+				propsBlock += numericValue ? `${name}:: ${parseFloat(numericValue)}\n` : `${name}:: \n`;
+				break;
+			}
+			case 'checkbox': {
+				const isChecked = typeof value === 'boolean' ? value : value === 'true';
+				propsBlock += `${name}:: ${isChecked}\n`;
+				break;
+			}
+			case 'date':
+			case 'datetime':
+				propsBlock += value.trim() !== '' ? `${name}:: ${value}\n` : `${name}:: \n`;
+				break;
+			default: // text
+				propsBlock += value.trim() !== '' ? `${name}:: ${value}\n` : `${name}:: \n`;
+		}
+	}
+
+	return propsBlock;
+}
+
+/**
+ * Splits markdown content into logical blocks for LogSeq's outliner.
+ * Returns an array of strings, each representing a top-level block.
+ */
+export function convertToBlocks(markdownContent: string): string[] {
+	if (!markdownContent.trim()) return [];
+
+	// Preserve fenced code blocks as single units
+	const codeBlockRegex = /```[\s\S]*?```/g;
+	const codeBlocks: string[] = [];
+	const withPlaceholders = markdownContent.replace(codeBlockRegex, (match) => {
+		codeBlocks.push(match);
+		return `%%CODEBLOCK_${codeBlocks.length - 1}%%`;
+	});
+
+	// Preserve tables as single units
+	const tableRegex = /(\|.+\|\n)+/g;
+	const tables: string[] = [];
+	const withTablePlaceholders = withPlaceholders.replace(tableRegex, (match) => {
+		tables.push(match.trimEnd());
+		return `%%TABLE_${tables.length - 1}%%\n`;
+	});
+
+	// Split by double newlines (paragraph boundaries)
+	const rawBlocks = withTablePlaceholders
+		.split(/\n{2,}/)
+		.map(block => block.trim())
+		.filter(block => block.length > 0);
+
+	// Restore placeholders
+	const restoredBlocks = rawBlocks.map(block => {
+		let restored = block;
+		restored = restored.replace(/%%CODEBLOCK_(\d+)%%/g, (_, idx) => codeBlocks[parseInt(idx)]);
+		restored = restored.replace(/%%TABLE_(\d+)%%/g, (_, idx) => tables[parseInt(idx)]);
+		return restored;
+	});
+
+	return restoredBlocks;
+}
+
+/**
+ * Gets today's journal page name in the configured LogSeq format.
+ */
+function getTodayJournalPageName(): string {
+	const format = generalSettings.logseqJournalFormat || 'MMM Do, YYYY';
+	return dayjs().format(format);
+}
+
+/**
+ * Saves content to LogSeq via the HTTP API.
+ */
+export async function saveToLogseq(
+	propertiesContent: string,
+	noteContent: string,
+	noteName: string,
+	namespace: string,
+	graph: string | undefined,
+	behavior: Template['behavior'],
+): Promise<void> {
+	const isDailyNote = behavior === 'append-daily' || behavior === 'prepend-daily';
+
+	// Determine the full page name
+	let fullPageName: string;
+	if (isDailyNote) {
+		fullPageName = getTodayJournalPageName();
+	} else {
+		const sanitized = sanitizeFileName(noteName);
+		fullPageName = namespace ? `${namespace}/${sanitized}` : sanitized;
+	}
+
+	// Check if API is available
+	const available = await logseqClient.isAvailable();
+	if (!available) {
+		throw new Error(getMessage('logseqApiUnavailable') || 'Cannot connect to LogSeq. Make sure the desktop app is running and the HTTP API is enabled in Settings > Features.');
+	}
+
+	// Convert content to blocks
+	const contentBlocks = convertToBlocks(noteContent);
+
+	switch (behavior) {
+		case 'create':
+		case 'overwrite': {
+			if (behavior === 'overwrite') {
+				// Delete all existing blocks before writing
+				try {
+					const existingBlocks = await logseqClient.getPageBlocksTree(fullPageName);
+					for (const block of existingBlocks || []) {
+						await logseqClient.removeBlock(block.uuid);
+					}
+				} catch {
+					// Page may not exist yet, continue
+				}
+			}
+
+			// Create or ensure page exists
+			await logseqClient.createPage(fullPageName, {});
+
+			// Add properties block first (as first block of the page)
+			if (propertiesContent.trim()) {
+				await logseqClient.appendBlockInPage(fullPageName, propertiesContent.trimEnd());
+			}
+
+			// Add content blocks
+			for (const block of contentBlocks) {
+				await logseqClient.appendBlockInPage(fullPageName, block);
+			}
+			break;
+		}
+
+		case 'append-specific':
+		case 'append-daily': {
+			// Append properties + content
+			const appendText = [propertiesContent.trimEnd(), ...contentBlocks].filter(Boolean).join('\n\n');
+			if (appendText.trim()) {
+				await logseqClient.appendBlockInPage(fullPageName, appendText);
+			}
+			break;
+		}
+
+		case 'prepend-specific':
+		case 'prepend-daily': {
+			const prependText = [propertiesContent.trimEnd(), ...contentBlocks].filter(Boolean).join('\n\n');
+			if (prependText.trim()) {
+				await logseqClient.prependBlockInPage(fullPageName, prependText);
+			}
+			break;
+		}
+	}
+}

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -6,10 +6,8 @@ import { copyToClipboard } from 'core/popup';
 export type { Settings, ModelConfig, PropertyType, HistoryEntry, Provider, Rating };
 
 export let generalSettings: Settings = {
-	vaults: [],
+	graphs: [],
 	betaFeatures: false,
-	legacyMode: false,
-	silentOpen: false,
 	openBehavior: 'popup',
 	highlighterEnabled: true,
 	alwaysShowHighlights: false,
@@ -22,6 +20,9 @@ export let generalSettings: Settings = {
 	interpreterAutoRun: false,
 	defaultPromptContext: '',
 	propertyTypes: [],
+	logseqApiToken: '',
+	logseqApiPort: 12315,
+	logseqJournalFormat: 'MMM Do, YYYY',
 	readerSettings: {
 		fontSize: 1.5,
 		lineHeight: 1.6,
@@ -30,14 +31,14 @@ export let generalSettings: Settings = {
 		themeMode: 'auto'
 	},
 	stats: {
-		addToObsidian: 0,
+		addToLogseq: 0,
 		saveFile: 0,
 		copyToClipboard: 0,
 		share: 0
 	},
 	history: [],
 	ratings: [],
-	saveBehavior: 'addToObsidian'
+	saveBehavior: 'addToLogseq'
 };
 
 export function setLocalStorage(key: string, value: any): Promise<void> {
@@ -52,12 +53,10 @@ interface StorageData {
 	general_settings?: {
 		showMoreActionsButton?: boolean;
 		betaFeatures?: boolean;
-		legacyMode?: boolean;
-		silentOpen?: boolean;
 		openBehavior?: boolean | 'popup' | 'embedded';
-		saveBehavior?: 'addToObsidian' | 'copyToClipboard' | 'saveFile';
+		saveBehavior?: 'addToLogseq' | 'copyToClipboard' | 'saveFile';
 	};
-	vaults?: string[];
+	graphs?: string[];
 	highlighter_settings?: {
 		highlighterEnabled?: boolean;
 		alwaysShowHighlights?: boolean;
@@ -78,9 +77,14 @@ interface StorageData {
 		interpreterAutoRun?: boolean;
 		defaultPromptContext?: string;
 	};
+	logseq_api_settings?: {
+		logseqApiToken?: string;
+		logseqApiPort?: number;
+		logseqJournalFormat?: string;
+	};
 	property_types?: PropertyType[];
 	stats?: {
-		addToObsidian: number;
+		addToLogseq: number;
 		saveFile: number;
 		copyToClipboard: number;
 		share: number;
@@ -90,18 +94,16 @@ interface StorageData {
 	migrationVersion?: number;
 }
 
-const CURRENT_MIGRATION_VERSION = 1;
+const CURRENT_MIGRATION_VERSION = 2;
 
 export async function loadSettings(): Promise<Settings> {
 	const data = await browser.storage.sync.get(null) as StorageData;
-	
+
 	// Load default settings first
 	const defaultSettings: Settings = {
-		vaults: [],
+		graphs: [],
 		showMoreActionsButton: false,
 		betaFeatures: false,
-		legacyMode: false,
-		silentOpen: false,
 		openBehavior: 'popup',
 		highlighterEnabled: true,
 		alwaysShowHighlights: true,
@@ -113,7 +115,10 @@ export async function loadSettings(): Promise<Settings> {
 		interpreterAutoRun: false,
 		defaultPromptContext: '',
 		propertyTypes: [],
-		saveBehavior: 'addToObsidian',
+		logseqApiToken: '',
+		logseqApiPort: 12315,
+		logseqJournalFormat: 'MMM Do, YYYY',
+		saveBehavior: 'addToLogseq',
 		readerSettings: {
 			fontSize: 1.5,
 			lineHeight: 1.6,
@@ -122,7 +127,7 @@ export async function loadSettings(): Promise<Settings> {
 			themeMode: 'auto'
 		},
 		stats: {
-			addToObsidian: 0,
+			addToLogseq: 0,
 			saveFile: 0,
 			copyToClipboard: 0,
 			share: 0
@@ -138,23 +143,21 @@ export async function loadSettings(): Promise<Settings> {
 	}
 
 	// Validate and sanitize data to prevent corruption
-	const sanitizedVaults = Array.isArray(data.vaults) ? data.vaults.filter(v => typeof v === 'string') : [];
-	const sanitizedModels = Array.isArray(data.interpreter_settings?.models) 
-		? data.interpreter_settings.models.filter(m => m && typeof m === 'object' && typeof m.id === 'string') 
+	const sanitizedGraphs = Array.isArray(data.graphs) ? data.graphs.filter(v => typeof v === 'string') : [];
+	const sanitizedModels = Array.isArray(data.interpreter_settings?.models)
+		? data.interpreter_settings.models.filter(m => m && typeof m === 'object' && typeof m.id === 'string')
 		: [];
-	const sanitizedProviders = Array.isArray(data.interpreter_settings?.providers) 
-		? data.interpreter_settings.providers.filter(p => p && typeof p === 'object' && typeof p.id === 'string') 
+	const sanitizedProviders = Array.isArray(data.interpreter_settings?.providers)
+		? data.interpreter_settings.providers.filter(p => p && typeof p === 'object' && typeof p.id === 'string')
 		: [];
 
 	// Load user settings
 	const loadedSettings: Settings = {
-		vaults: sanitizedVaults.length > 0 ? sanitizedVaults : defaultSettings.vaults,
+		graphs: sanitizedGraphs.length > 0 ? sanitizedGraphs : defaultSettings.graphs,
 		showMoreActionsButton: data.general_settings?.showMoreActionsButton ?? defaultSettings.showMoreActionsButton,
 		betaFeatures: data.general_settings?.betaFeatures ?? defaultSettings.betaFeatures,
-		legacyMode: data.general_settings?.legacyMode ?? defaultSettings.legacyMode,
-		silentOpen: data.general_settings?.silentOpen ?? defaultSettings.silentOpen,
-		openBehavior: typeof data.general_settings?.openBehavior === 'boolean' 
-			? (data.general_settings.openBehavior ? 'embedded' : 'popup') 
+		openBehavior: typeof data.general_settings?.openBehavior === 'boolean'
+			? (data.general_settings.openBehavior ? 'embedded' : 'popup')
 			: (data.general_settings?.openBehavior ?? defaultSettings.openBehavior),
 		highlighterEnabled: data.highlighter_settings?.highlighterEnabled ?? defaultSettings.highlighterEnabled,
 		alwaysShowHighlights: data.highlighter_settings?.alwaysShowHighlights ?? defaultSettings.alwaysShowHighlights,
@@ -166,6 +169,9 @@ export async function loadSettings(): Promise<Settings> {
 		interpreterAutoRun: data.interpreter_settings?.interpreterAutoRun ?? defaultSettings.interpreterAutoRun,
 		defaultPromptContext: data.interpreter_settings?.defaultPromptContext || defaultSettings.defaultPromptContext,
 		propertyTypes: data.property_types || defaultSettings.propertyTypes,
+		logseqApiToken: data.logseq_api_settings?.logseqApiToken || defaultSettings.logseqApiToken,
+		logseqApiPort: data.logseq_api_settings?.logseqApiPort ?? defaultSettings.logseqApiPort,
+		logseqJournalFormat: data.logseq_api_settings?.logseqJournalFormat || defaultSettings.logseqJournalFormat,
 		readerSettings: {
 			fontSize: data.reader_settings?.fontSize ?? defaultSettings.readerSettings.fontSize,
 			lineHeight: data.reader_settings?.lineHeight ?? defaultSettings.readerSettings.lineHeight,
@@ -190,12 +196,10 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 	}
 
 	await browser.storage.sync.set({
-		vaults: generalSettings.vaults,
+		graphs: generalSettings.graphs,
 		general_settings: {
 			showMoreActionsButton: generalSettings.showMoreActionsButton,
 			betaFeatures: generalSettings.betaFeatures,
-			legacyMode: generalSettings.legacyMode,
-			silentOpen: generalSettings.silentOpen,
 			openBehavior: generalSettings.openBehavior,
 			saveBehavior: generalSettings.saveBehavior,
 		},
@@ -212,6 +216,11 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 			interpreterAutoRun: generalSettings.interpreterAutoRun,
 			defaultPromptContext: generalSettings.defaultPromptContext
 		},
+		logseq_api_settings: {
+			logseqApiToken: generalSettings.logseqApiToken,
+			logseqApiPort: generalSettings.logseqApiPort,
+			logseqJournalFormat: generalSettings.logseqJournalFormat,
+		},
 		property_types: generalSettings.propertyTypes,
 		reader_settings: {
 			fontSize: generalSettings.readerSettings.fontSize,
@@ -224,14 +233,9 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 	});
 }
 
-export async function setLegacyMode(enabled: boolean): Promise<void> {
-	await saveSettings({ legacyMode: enabled });
-	console.log(`Legacy mode ${enabled ? 'enabled' : 'disabled'}`);
-}
-
 export async function incrementStat(
 	action: keyof Settings['stats'],
-	vault?: string,
+	graph?: string,
 	path?: string,
 	url?: string,
 	title?: string
@@ -242,15 +246,15 @@ export async function incrementStat(
 
 	// Add history entry if URL is provided
 	if (url) {
-		await addHistoryEntry(action, url, title, vault, path);
+		await addHistoryEntry(action, url, title, graph, path);
 	}
 }
 
 export async function addHistoryEntry(
-	action: keyof Settings['stats'], 
-	url: string, 
+	action: keyof Settings['stats'],
+	url: string,
 	title?: string,
-	vault?: string,
+	graph?: string,
 	path?: string
 ): Promise<void> {
 	const entry: HistoryEntry = {
@@ -258,7 +262,7 @@ export async function addHistoryEntry(
 		url,
 		action,
 		title,
-		vault,
+		graph,
 		path
 	};
 


### PR DESCRIPTION
## Summary

- **New**: `logseq-api-client.ts` — HTTP client for LogSeq desktop API (`localhost:12315`)
- **New**: `logseq-note-creator.ts` — block-based note creation with `property:: value` format
- **Updated**: Replace all vault/Obsidian terminology with graph/LogSeq across types, storage, UI, and settings
- **Updated**: Settings page with LogSeq API token + port + connection test UI
- **Updated**: `popup.ts` uses `saveToLogseq()` and graph-based state management
- **Removed**: Obsidian URI scheme handler from `background.ts`, `legacyMode`, `silentOpen`

## What's still pending (future PRs)

- Phase 4: `template-manager.ts`, `markdown-converter.ts`, `callout.ts` format adaptations
- Phase 5: Branding — manifests, `package.json`, i18n strings, scattered references
- Phase 6: Remove `obsidian-note-creator.ts`, run build/tests

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] Load extension unpacked in Chrome
- [ ] Open LogSeq desktop, enable HTTP API (Settings > Features > HTTP APIs server)
- [ ] In extension settings: enter API token, test connection shows success
- [ ] Clip a web page → new page created in LogSeq with `property:: value` frontmatter
- [ ] Test append/prepend to daily journal page
- [ ] Verify graph selector reflects available graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)