### PR TITLE
feat: add support for <object> image elements in content extraction

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -233,9 +233,19 @@ declare global {
 		}
 
 		if (request.action === "getPageContent") {
+			// Convert <object> image elements to <img> for content extraction
+			document.querySelectorAll('object[type^="image/"]').forEach(obj => {
+				const data = obj.getAttribute('data');
+				if (!data) return;
+				const img = document.createElement('img');
+				img.src = data;
+				img.alt = obj.getAttribute('aria-label') || obj.getAttribute('name') || '';
+				obj.replaceWith(img);
+			});
+
 			let selectedHtml = '';
 			const selection = window.getSelection();
-			
+
 			if (selection && selection.rangeCount > 0) {
 				const range = selection.getRangeAt(0);
 				const clonedSelection = range.cloneContents();

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -229,6 +229,19 @@ export function createMarkdownContent(content: string, url: string) {
 		}
 	});
 
+	turndownService.addRule('objectImage', {
+		filter: function(node: Node): boolean {
+			return node.nodeName === 'OBJECT' &&
+				((node as Element).getAttribute('type') || '').startsWith('image/');
+		},
+		replacement: function(content, node) {
+			const el = node as Element;
+			const data = el.getAttribute('data') || '';
+			const alt = el.getAttribute('aria-label') || el.getAttribute('name') || '';
+			return data ? `![${alt}](${data})` : '';
+		}
+	});
+
 	// Use Obsidian format for YouTube embeds and tweets
 	turndownService.addRule('embedToMarkdown', {
 		filter: function (node: Node): boolean {

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -145,6 +145,7 @@ export function processUrls(htmlContent: string, baseUrl: URL): string {
 	doc.querySelectorAll('video').forEach(video => makeUrlAbsolute(video, 'src', baseUrl));
 	doc.querySelectorAll('audio').forEach(audio => makeUrlAbsolute(audio, 'src', baseUrl));
 	doc.querySelectorAll(':is(video, audio) :is(source, track)').forEach(sourceOrTrack => makeUrlAbsolute(sourceOrTrack, 'src', baseUrl));
+	doc.querySelectorAll('object[data]').forEach(obj => makeUrlAbsolute(obj, 'data', baseUrl));
 	
 	// Serialize back to HTML
 	const serializer = new XMLSerializer();


### PR DESCRIPTION
## Summary

Some websites embed images using `<object type="image/svg+xml">` instead of standard `<img>` tags (e.g. technical documentation sites with SVG diagrams). These elements were silently dropped during content extraction, causing diagrams and illustrations to be lost when clipping.

## Changes

- **`src/content.ts`**: Convert `<object type^="image/">` to `<img>` elements in the DOM before Defuddle extraction and selection capture, so they flow through the existing image processing pipeline
- **`src/utils/string-utils.ts`**: Add `object[data]` URL resolution in `processUrls` for any surviving `<object>` elements in HTML strings
- **`src/utils/markdown-converter.ts`**: Add Turndown rule as safety net to convert `<object>` image elements to markdown image syntax

## Test plan

- [x] All 493 existing tests pass
- [x] Load extension, clip a page with `<object type="image/svg+xml">` diagrams, verify images appear in markdown output
- [x] Verify image URLs are absolute and downloadable