### PR TITLE
Fix CLI: empty output due to missing browser globals and wrong Defuddle input

### DIFF
--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -27,6 +27,15 @@ const polyfillBanner = `
   if (typeof globalThis.document === "undefined") {
     globalThis.document = _parseHTML("<!DOCTYPE html><html><head></head><body></body></html>").document;
   }
+  if (typeof globalThis.navigator === "undefined") {
+    var _platform = process.platform === "win32" ? "Win32" : process.platform === "darwin" ? "MacIntel" : "Linux x86_64";
+    globalThis.navigator = { userAgent: "Node.js/" + process.version, platform: _platform, userAgentData: null };
+  }
+  if (typeof globalThis.getComputedStyle === "undefined") {
+    globalThis.getComputedStyle = function() {
+      return { display: "block", visibility: "visible", getPropertyValue: function() { return ""; } };
+    };
+  }
 })();
 `.trim();
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -178,11 +178,10 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 
 	// Use pre-parsed document if provided, otherwise parse
 	const doc = parsedDocument ?? documentParser.parseFromString(html, 'text/html');
-	const documentElement = doc.documentElement || doc;
 
 	// Extract content with defuddle
 	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
-	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
+	const defuddle = new DefuddleClass(doc as unknown as Document, { url });
 	const defuddleResult = defuddle.parse();
 
 	// Convert to markdown

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -207,7 +207,7 @@ async function main(): Promise<void> {
 			if (hasSchemaTrigs) {
 				const DefuddleClass = (await import('defuddle')).default;
 				parsedDocument = linkedomParser.parseFromString(html, 'text/html');
-				const defuddle = new DefuddleClass((parsedDocument.documentElement || parsedDocument) as unknown as Document, { url: args.url });
+				const defuddle = new DefuddleClass(parsedDocument as unknown as Document, { url: args.url });
 				const defuddleResult = defuddle.parse();
 				matched = matchTemplate(templates, args.url, defuddleResult.schemaOrgData);
 			}


### PR DESCRIPTION
Fixes #745

Three bugs in the initial CLI implementation that caused empty output:

**1. `navigator` not defined**
`sanitizeFileName()` reads `navigator.platform`, but the polyfill banner only provided `window`, `document`, and `DOMParser`. Added `navigator` and `getComputedStyle` stubs.

**2. Defuddle receives `doc.documentElement` instead of `doc`**
`api.ts` and `cli.ts` were unwrapping the linkedom document to its `<html>` element before passing it to Defuddle. Defuddle expects a Document object — passing the element causes it to return empty strings for title, description, and content.

**3. `getComputedStyle` missing**
Defuddle uses it to detect hidden elements. Without it, extraction falls back to raw HTML which converts to empty markdown.

Fixed with the help of Claude Code.