### PR TITLE
fix: normalize timestamps to UTC in template fixture tests

### DIFF
--- a/src/utils/template-integration.test.ts
+++ b/src/utils/template-integration.test.ts
@@ -7,6 +7,9 @@ import { createMarkdownContent } from 'defuddle/full';
 import { buildVariables, generateFrontmatter, formatPropertyValue } from './shared';
 import { compileTemplate } from './template-compiler';
 import { createAsyncResolver, createSelectorProcessor } from '../api';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+dayjs.extend(utc);
 
 // ---------------------------------------------------------------------------
 // Freeze time so {{date}} is deterministic in expected output
@@ -16,6 +19,14 @@ const FROZEN_DATE = new Date('2025-01-15T12:00:00Z');
 
 beforeAll(() => { vi.useFakeTimers({ now: FROZEN_DATE }); });
 afterAll(() => { vi.useRealTimers(); });
+
+// Normalize timezone-aware timestamps to UTC for cross-timezone comparison
+function normalizeTimestamps(text: string): string {
+    return text.replace(
+        /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)/g,
+        (match) => dayjs(match).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
+    );
+}
 
 // ---------------------------------------------------------------------------
 // Fixture types
@@ -150,6 +161,6 @@ describe('Template fixtures', () => {
 			);
 		}
 
-		expect(result.trim()).toEqual(expected.trim());
+		expect(normalizeTimestamps(result.trim())).toEqual(normalizeTimestamps(expected.trim()));
 	});
 });


### PR DESCRIPTION
## Problem
The youtube template fixture test fails on machines outside the UTC-8 timezone 
because the expected output hardcodes a timezone-aware timestamp (-08:00).

When running on UTC+8 (e.g. China), the test produces:
  created: "2025-01-15T20:00:00+08:00"

But the expected fixture contains:
  created: "2025-01-15T04:00:00-08:00"

These represent the same moment in time, but string comparison fails.

## Fix
Added a `normalizeTimestamps()` helper in the test file that converts all 
ISO 8601 timestamps to UTC before comparison, using the `dayjs` library 
already present in the project.

This makes the test pass correctly on any timezone.

## Testing
Verified on UTC+8 (Asia/Shanghai): all 548 tests pass.
