### PR TITLE
fix: improve weibo metadata extraction

### DIFF
--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -20,6 +20,9 @@ The main content variable is `{{content}}`, which contains the article content, 
 | Variable            | Description                                                                            |
 | ------------------- | -------------------------------------------------------------------------------------- |
 | `{{author}}`        | Author of the page                                                                     |
+| `{{authorHandle}}`  | Author name formatted for the page, e.g. `@name` on Weibo                              |
+| `{{authorLink}}`    | Author as a Markdown link when the page exposes a profile URL                          |
+| `{{authorUrl}}`     | Author profile URL when it can be extracted                                            |
 | `{{content}}`       | Article content, [[Highlight web pages\|highlights]], or selection, in Markdown format |
 | `{{contentHtml}}`   | Article content, [[Highlight web pages\|highlights]], or selection, in HTML format     |
 | `{{date}}`          | Current date, can be formatted using the `date` filter                                 |
@@ -117,4 +120,3 @@ Nested properties and array access work as well, both with and without the schem
 - `{{schema:author.name}}` will find the first `author` property and then access its `name` sub-property.
 - `{{schema:author[0].name}}` will access the `name` of the first author in an array of authors.
 - `{{schema:author[*].name}}` will return an array of all author names.
-

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ import { compileTemplate, SelectorProcessor } from './utils/template-compiler';
 import { AsyncResolver, RenderContext } from './utils/renderer';
 import { applyFilters } from './utils/filters';
 import { buildVariables, generateFrontmatter, extractContentBySelector, selectorContentToString, formatPropertyValue } from './utils/shared';
+import { resolvePageMetadata } from './utils/page-metadata';
 import { sanitizeFileName } from './utils/string-utils';
 import { Template, Property } from './types/types';
 
@@ -184,14 +185,22 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
 	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
 	const defuddleResult = defuddle.parse();
+	const resolvedMetadata = resolvePageMetadata({
+		url,
+		document: doc as unknown as Document,
+		title: defuddleResult.title,
+		author: defuddleResult.author,
+		metaTags: defuddleResult.metaTags,
+	});
 
 	// Convert to markdown
 	const markdownContent = createMarkdownContent(defuddleResult.content, url);
 
 	// Build template variables
 	const variables = buildVariables({
-		title: defuddleResult.title,
-		author: defuddleResult.author,
+		title: resolvedMetadata.title,
+		author: resolvedMetadata.author,
+		authorUrl: resolvedMetadata.authorUrl,
 		content: markdownContent,
 		contentHtml: defuddleResult.content,
 		url,

--- a/src/api.ts
+++ b/src/api.ts
@@ -190,6 +190,7 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 		document: doc as unknown as Document,
 		title: defuddleResult.title,
 		author: defuddleResult.author,
+		contentHtml: defuddleResult.content,
 		metaTags: defuddleResult.metaTags,
 	});
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -190,6 +190,7 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 		document: doc as unknown as Document,
 		title: defuddleResult.title,
 		author: defuddleResult.author,
+		published: defuddleResult.published,
 		contentHtml: defuddleResult.content,
 		metaTags: defuddleResult.metaTags,
 	});
@@ -209,7 +210,7 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 		description: defuddleResult.description,
 		favicon: defuddleResult.favicon,
 		image: defuddleResult.image,
-		published: defuddleResult.published,
+		published: resolvedMetadata.published,
 		site: defuddleResult.site,
 		language: defuddleResult.language,
 		wordCount: defuddleResult.wordCount,

--- a/src/content.ts
+++ b/src/content.ts
@@ -295,6 +295,7 @@ declare global {
 					document,
 					title: defuddled.title,
 					author: defuddled.author,
+					contentHtml: defuddled.content,
 					metaTags: defuddled.metaTags,
 				});
 				const extractedContent: { [key: string]: string } = {

--- a/src/content.ts
+++ b/src/content.ts
@@ -7,6 +7,7 @@ import { extractContentBySelector as extractContentBySelectorShared } from './ut
 import { createMarkdownContent } from 'defuddle/full';
 import { flattenShadowDom } from './utils/flatten-shadow-dom';
 import { saveFile } from './utils/file-utils';
+import { resolvePageMetadata } from './utils/page-metadata';
 
 declare global {
 	interface Window {
@@ -170,6 +171,7 @@ declare global {
 		parseTime: number;
 		published: string;
 		author: string;
+		authorUrl: string;
 		site: string;
 		wordCount: number;
 		language: string;
@@ -288,6 +290,13 @@ declare global {
 				);
 				const defuddled = await Promise.race([defuddle.parseAsync(), parseTimeout])
 					.catch(() => defuddle.parse());
+				const resolvedMetadata = resolvePageMetadata({
+					url: document.URL,
+					document,
+					title: defuddled.title,
+					author: defuddled.author,
+					metaTags: defuddled.metaTags,
+				});
 				const extractedContent: { [key: string]: string } = {
 					...defuddled.variables,
 				};
@@ -335,7 +344,8 @@ declare global {
 				const cleanedHtml = doc.documentElement.outerHTML;
 
 				const response: ContentResponse = {
-					author: defuddled.author,
+					author: resolvedMetadata.author,
+					authorUrl: resolvedMetadata.authorUrl,
 					content: defuddled.content,
 					description: defuddled.description,
 					domain: getDomain(document.URL),
@@ -350,7 +360,7 @@ declare global {
 					schemaOrgData: defuddled.schemaOrgData,
 					selectedHtml: selectedHtml,
 					site: defuddled.site,
-					title: defuddled.title,
+					title: resolvedMetadata.title,
 					wordCount: defuddled.wordCount,
 					metaTags: defuddled.metaTags || []
 				};

--- a/src/content.ts
+++ b/src/content.ts
@@ -295,6 +295,7 @@ declare global {
 					document,
 					title: defuddled.title,
 					author: defuddled.author,
+					published: defuddled.published,
 					contentHtml: defuddled.content,
 					metaTags: defuddled.metaTags,
 				});
@@ -357,7 +358,7 @@ declare global {
 					image: defuddled.image,
 					language: defuddled.language || '',
 					parseTime: defuddled.parseTime,
-					published: defuddled.published,
+					published: resolvedMetadata.published,
 					schemaOrgData: defuddled.schemaOrgData,
 					selectedHtml: selectedHtml,
 					site: defuddled.site,

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -675,7 +675,8 @@ async function refreshFields(tabId: number, checkTemplateTriggers: boolean = tru
 				extractedData.site,
 				extractedData.wordCount,
 				extractedData.language || '',
-				extractedData.metaTags
+				extractedData.metaTags,
+				extractedData.authorUrl
 			);
 			if (initializedContent) {
 				currentVariables = initializedContent.currentVariables;

--- a/src/managers/template-manager.ts
+++ b/src/managers/template-manager.ts
@@ -111,6 +111,8 @@ async function prepareTemplateForSave(template: Template): Promise<[string[], st
 }
 
 export function createDefaultTemplate(): Template {
+	const authorDefaultValue = '{% if authorLink %}{{authorLink}}{% else %}{{author|split:", "|wikilink|join}}{% endif %}';
+
 	return {
 		id: Date.now().toString() + Math.random().toString(36).slice(2, 11),
 		name: getMessage('defaultTemplateName'),
@@ -122,7 +124,7 @@ export function createDefaultTemplate(): Template {
 		properties: [
 			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'title', value: '{{title}}' },
 			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'source', value: '{{url}}' },
-			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'author', value: '{{author|split:", "|wikilink|join}}' },
+			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'author', value: authorDefaultValue },
 			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'published', value: '{{published}}' },
 			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'created', value: '{{date}}' },
 			{ id: Date.now().toString() + Math.random().toString(36).slice(2, 11), name: 'description', value: '{{description}}' },
@@ -212,7 +214,7 @@ async function updateGlobalPropertyTypes(templates: Template[]): Promise<void> {
 	const defaultTypes: { [key: string]: { type: string, defaultValue: string } } = {
 		'title': { type: 'text', defaultValue: '{{title}}' },
 		'source': { type: 'text', defaultValue: '{{url}}' },
-		'author': { type: 'multitext', defaultValue: '{{author|split:", "|wikilink|join}}' },
+		'author': { type: 'multitext', defaultValue: '{% if authorLink %}{{authorLink}}{% else %}{{author|split:", "|wikilink|join}}{% endif %}' },
 		'published': { type: 'date', defaultValue: '{{published}}' },
 		'created': { type: 'date', defaultValue: '{{date}}' },
 		'description': { type: 'text', defaultValue: '{{description}}' },

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -48,6 +48,7 @@ interface ContentResponse {
 	highlights: AnyHighlightData[];
 	title: string;
 	author: string;
+	authorUrl: string;
 	description: string;
 	domain: string;
 	favicon: string;
@@ -137,7 +138,8 @@ export async function initializePageContent(
 	site: string,
 	wordCount: number,
 	language: string,
-	metaTags: { name?: string | null; property?: string | null; content: string | null }[]
+	metaTags: { name?: string | null; property?: string | null; content: string | null }[],
+	authorUrl: string
 ) {
 	try {
 		currentUrl = currentUrl.replace(/#:~:text=[^&]+(&|$)/, '');
@@ -178,6 +180,7 @@ export async function initializePageContent(
 		const currentVariables = buildVariables({
 			title,
 			author,
+			authorUrl,
 			content: markdownBody,
 			contentHtml: content,
 			url: currentUrl,

--- a/src/utils/page-metadata.test.ts
+++ b/src/utils/page-metadata.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from 'vitest';
+import { parseHTML } from 'linkedom';
+import { resolvePageMetadata } from './page-metadata';
+
+describe('resolvePageMetadata', () => {
+	test('keeps non-weibo metadata unchanged', () => {
+		const { document } = parseHTML('<html><head><title>Example</title></head><body></body></html>');
+		const metadata = resolvePageMetadata({
+			url: 'https://example.com/post',
+			document: document as unknown as Document,
+			title: 'Example title',
+			author: 'Example author',
+		});
+
+		expect(metadata).toEqual({
+			title: 'Example title',
+			author: 'Example author',
+			authorUrl: '',
+		});
+	});
+
+	test('extracts weibo title and author profile link from page anchors', () => {
+		const { document } = parseHTML(`
+			<html>
+				<head>
+					<title>微博</title>
+					<meta property="og:title" content="李老师发布了头条文章：《创业之前，你想过怎么给你的产品起名吗？》">
+				</head>
+				<body>
+					<article>
+						<header class="head-info">
+							<a class="author" href="/u/1234567890">@李老师好文</a>
+						</header>
+					</article>
+				</body>
+			</html>
+		`);
+
+		const metadata = resolvePageMetadata({
+			url: 'https://weibo.com/1234567890/AbCdEf',
+			document: document as unknown as Document,
+			title: '微博',
+			author: '',
+			metaTags: [
+				{ property: 'og:title', name: null, content: '李老师发布了头条文章：《创业之前，你想过怎么给你的产品起名吗？》' },
+			],
+		});
+
+		expect(metadata).toEqual({
+			title: '创业之前，你想过怎么给你的产品起名吗？',
+			author: '李老师好文',
+			authorUrl: 'https://weibo.com/u/1234567890',
+		});
+	});
+
+	test('falls back to script metadata for weibo author', () => {
+		const { document } = parseHTML(`
+			<html>
+				<head><title>微博</title></head>
+				<body>
+					<script>
+						window.__INITIAL_STATE__ = {"status":{"user":{"screen_name":"科技圈观察员","idstr":"99887766"}}};
+					</script>
+				</body>
+			</html>
+		`);
+
+		const metadata = resolvePageMetadata({
+			url: 'https://m.weibo.cn/status/AbCdEf',
+			document: document as unknown as Document,
+			title: '微博',
+			author: '',
+		});
+
+		expect(metadata).toEqual({
+			title: '微博',
+			author: '科技圈观察员',
+			authorUrl: 'https://weibo.com/u/99887766',
+		});
+	});
+});

--- a/src/utils/page-metadata.test.ts
+++ b/src/utils/page-metadata.test.ts
@@ -16,6 +16,7 @@ describe('resolvePageMetadata', () => {
 			title: 'Example title',
 			author: 'Example author',
 			authorUrl: '',
+			published: '',
 		});
 	});
 
@@ -50,6 +51,7 @@ describe('resolvePageMetadata', () => {
 			title: '创业之前，你想过怎么给你的产品起名吗？',
 			author: '李老师好文',
 			authorUrl: 'https://weibo.com/u/1234567890',
+			published: '',
 		});
 	});
 
@@ -76,6 +78,7 @@ describe('resolvePageMetadata', () => {
 			title: '微博',
 			author: '科技圈观察员',
 			authorUrl: 'https://weibo.com/u/99887766',
+			published: '',
 		});
 	});
 
@@ -85,6 +88,7 @@ describe('resolvePageMetadata', () => {
 				<head><title>微博</title></head>
 				<body>
 					<article>
+						<p>公开</p>
 						<p>这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截断规则。</p>
 						<p>这是第二行。</p>
 					</article>
@@ -98,15 +102,17 @@ describe('resolvePageMetadata', () => {
 			title: '微博',
 			author: '',
 			contentHtml: `
+				<p>公开</p>
 				<p>这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截断规则。</p>
 				<p>这是第二行。</p>
 			`,
 		});
 
 		expect(metadata).toEqual({
-			title: '这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截',
+			title: '这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截断规则。',
 			author: '',
 			authorUrl: '',
+			published: '',
 		});
 	});
 
@@ -130,5 +136,26 @@ describe('resolvePageMetadata', () => {
 		});
 
 		expect(metadata.title).toBe('余弦发了一个短视频，快来看呀。');
+	});
+
+	test('extracts published time from script created_at', () => {
+		const { document } = parseHTML(`
+			<html>
+				<head><title>微博正文 - 微博</title></head>
+				<body>
+					<script>
+						window.__INITIAL_STATE__ = {"status":{"created_at":"Fri Apr 04 09:15:00 +0800 2026"}};
+					</script>
+				</body>
+			</html>
+		`);
+
+		const metadata = resolvePageMetadata({
+			url: 'https://weibo.com/2194035935/QugQQpcVa',
+			document: document as unknown as Document,
+			title: '微博正文 - 微博',
+		});
+
+		expect(metadata.published).toBe('2026-04-04 09:15');
 	});
 });

--- a/src/utils/page-metadata.test.ts
+++ b/src/utils/page-metadata.test.ts
@@ -109,4 +109,26 @@ describe('resolvePageMetadata', () => {
 			authorUrl: '',
 		});
 	});
+
+	test('treats 微博正文 - 微博 as a generic title and falls back to content', () => {
+		const { document } = parseHTML(`
+			<html>
+				<head><title>微博正文 - 微博</title></head>
+				<body>
+					<article>
+						<p>余弦发了一个短视频，快来看呀。</p>
+					</article>
+				</body>
+			</html>
+		`);
+
+		const metadata = resolvePageMetadata({
+			url: 'https://weibo.com/2194035935/QugQQpcVa',
+			document: document as unknown as Document,
+			title: '微博正文 - 微博',
+			contentHtml: '<p>余弦发了一个短视频，快来看呀。</p>',
+		});
+
+		expect(metadata.title).toBe('余弦发了一个短视频，快来看呀。');
+	});
 });

--- a/src/utils/page-metadata.test.ts
+++ b/src/utils/page-metadata.test.ts
@@ -78,4 +78,35 @@ describe('resolvePageMetadata', () => {
 			authorUrl: 'https://weibo.com/u/99887766',
 		});
 	});
+
+	test('falls back to the first line of weibo content when no title is available', () => {
+		const { document } = parseHTML(`
+			<html>
+				<head><title>微博</title></head>
+				<body>
+					<article>
+						<p>这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截断规则。</p>
+						<p>这是第二行。</p>
+					</article>
+				</body>
+			</html>
+		`);
+
+		const metadata = resolvePageMetadata({
+			url: 'https://weibo.com/1234567890/AbCdEf',
+			document: document as unknown as Document,
+			title: '微博',
+			author: '',
+			contentHtml: `
+				<p>这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截断规则。</p>
+				<p>这是第二行。</p>
+			`,
+		});
+
+		expect(metadata).toEqual({
+			title: '这是微博正文的第一行，而且确实比三十个字符更长一些用来验证截',
+			author: '',
+			authorUrl: '',
+		});
+	});
 });

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -9,6 +9,7 @@ interface ResolvePageMetadataParams {
 	document?: Document;
 	title?: string;
 	author?: string;
+	contentHtml?: string;
 	metaTags?: MetaTag[];
 }
 
@@ -43,11 +44,12 @@ export function resolvePageMetadata(params: ResolvePageMetadataParams): Resolved
 	}
 
 	const weiboMetadata = extractWeiboMetadata(params.document, params.url, params.metaTags);
-	const resolvedTitle = shouldReplaceWeiboTitle(title) ? (weiboMetadata.title || title) : title;
+	const fallbackTitle = extractWeiboTitleFromContentHtml(params.contentHtml);
+	const resolvedTitle = shouldReplaceWeiboTitle(title) ? weiboMetadata.title : title;
 	const resolvedAuthor = author || weiboMetadata.author || '';
 
 	return {
-		title: resolvedTitle,
+		title: resolvedTitle || fallbackTitle || title,
 		author: resolvedAuthor,
 		authorUrl: weiboMetadata.authorUrl || '',
 	};
@@ -111,6 +113,28 @@ function extractWeiboTitleFromDocument(document: Document | undefined): string {
 	}
 
 	return '';
+}
+
+function extractWeiboTitleFromContentHtml(contentHtml: string | undefined): string {
+	if (!contentHtml) {
+		return '';
+	}
+
+	const firstLine = normalizeWhitespace(
+		contentHtml
+			.replace(/<(p|div|h1|h2|h3|li|blockquote|br)\b[^>]*>/gi, '\n')
+			.replace(/<\/(p|div|h1|h2|h3|li|blockquote)>/gi, '\n')
+			.replace(/<[^>]+>/g, ' ')
+			.split('\n')
+			.map(line => normalizeWhitespace(line))
+			.find(Boolean)
+	);
+
+	if (!firstLine) {
+		return '';
+	}
+
+	return firstLine.length > 30 ? firstLine.slice(0, 30) : firstLine;
 }
 
 function extractWeiboAuthor(document: Document | undefined, pageUrl: string, metaTags: MetaTag[] | undefined): { author: string; authorUrl: string } {

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -1,0 +1,365 @@
+interface MetaTag {
+	name?: string | null;
+	property?: string | null;
+	content: string | null;
+}
+
+interface ResolvePageMetadataParams {
+	url: string;
+	document?: Document;
+	title?: string;
+	author?: string;
+	metaTags?: MetaTag[];
+}
+
+interface WeiboMetadata {
+	title?: string;
+	author?: string;
+	authorUrl?: string;
+}
+
+export interface ResolvedPageMetadata {
+	title: string;
+	author: string;
+	authorUrl: string;
+}
+
+const GENERIC_WEIBO_TITLES = new Set([
+	'微博',
+	'微博正文',
+	'Sina Visitor System',
+]);
+
+export function resolvePageMetadata(params: ResolvePageMetadataParams): ResolvedPageMetadata {
+	const title = normalizeWhitespace(params.title);
+	const author = normalizeWhitespace(params.author);
+
+	if (!isWeiboUrl(params.url)) {
+		return {
+			title,
+			author,
+			authorUrl: '',
+		};
+	}
+
+	const weiboMetadata = extractWeiboMetadata(params.document, params.url, params.metaTags);
+	const resolvedTitle = shouldReplaceWeiboTitle(title) ? (weiboMetadata.title || title) : title;
+	const resolvedAuthor = author || weiboMetadata.author || '';
+
+	return {
+		title: resolvedTitle,
+		author: resolvedAuthor,
+		authorUrl: weiboMetadata.authorUrl || '',
+	};
+}
+
+function extractWeiboMetadata(document: Document | undefined, pageUrl: string, metaTags: MetaTag[] | undefined): WeiboMetadata {
+	const metaTitle = extractWeiboTitleFromMeta(metaTags);
+	const documentTitle = extractWeiboTitleFromDocument(document);
+	const { author, authorUrl } = extractWeiboAuthor(document, pageUrl, metaTags);
+
+	return {
+		title: metaTitle || documentTitle,
+		author,
+		authorUrl,
+	};
+}
+
+function extractWeiboTitleFromMeta(metaTags: MetaTag[] | undefined): string {
+	if (!metaTags?.length) {
+		return '';
+	}
+
+	const preferredKeys = new Set([
+		'og:title',
+		'twitter:title',
+		'title',
+	]);
+
+	for (const meta of metaTags) {
+		const key = (meta.property || meta.name || '').trim().toLowerCase();
+		const content = normalizeWhitespace(meta.content);
+		if (!content || !preferredKeys.has(key)) {
+			continue;
+		}
+
+		const title = normalizeWeiboTitle(content);
+		if (title) {
+			return title;
+		}
+	}
+
+	return '';
+}
+
+function extractWeiboTitleFromDocument(document: Document | undefined): string {
+	if (!document) {
+		return '';
+	}
+
+	const candidates = [
+		document.title,
+		document.querySelector('h1')?.textContent || '',
+		document.querySelector('article h2')?.textContent || '',
+	];
+
+	for (const candidate of candidates) {
+		const title = normalizeWeiboTitle(candidate);
+		if (title) {
+			return title;
+		}
+	}
+
+	return '';
+}
+
+function extractWeiboAuthor(document: Document | undefined, pageUrl: string, metaTags: MetaTag[] | undefined): { author: string; authorUrl: string } {
+	const fromMeta = extractWeiboAuthorFromMeta(metaTags, pageUrl);
+	if (fromMeta.author && fromMeta.authorUrl) {
+		return fromMeta;
+	}
+
+	const fromAnchor = extractWeiboAuthorFromAnchors(document, pageUrl);
+	if (fromAnchor.author && fromAnchor.authorUrl) {
+		return fromAnchor;
+	}
+
+	const fromScript = extractWeiboAuthorFromScripts(document, pageUrl);
+	if (fromScript.author) {
+		return fromScript;
+	}
+
+	return fromMeta.author ? fromMeta : { author: '', authorUrl: '' };
+}
+
+function extractWeiboAuthorFromMeta(metaTags: MetaTag[] | undefined, pageUrl: string): { author: string; authorUrl: string } {
+	if (!metaTags?.length) {
+		return { author: '', authorUrl: '' };
+	}
+
+	let author = '';
+	let authorUrl = '';
+
+	for (const meta of metaTags) {
+		const key = (meta.property || meta.name || '').trim().toLowerCase();
+		const content = normalizeWhitespace(meta.content);
+		if (!content) {
+			continue;
+		}
+
+		if ((key === 'author' || key === 'article:author') && !author && !looksLikeUrl(content)) {
+			author = stripLeadingAt(content);
+		}
+
+		if (!authorUrl && looksLikeUrl(content)) {
+			const normalizedUrl = normalizeWeiboProfileUrl(content, pageUrl);
+			if (normalizedUrl) {
+				authorUrl = normalizedUrl;
+			}
+		}
+	}
+
+	return { author, authorUrl };
+}
+
+function extractWeiboAuthorFromAnchors(document: Document | undefined, pageUrl: string): { author: string; authorUrl: string } {
+	if (!document) {
+		return { author: '', authorUrl: '' };
+	}
+
+	const anchors = Array.from(document.querySelectorAll('a[href]'))
+		.map(anchor => {
+			const href = normalizeWeiboProfileUrl(anchor.getAttribute('href') || '', pageUrl);
+			const text = normalizeWhitespace(
+				anchor.textContent
+				|| anchor.getAttribute('title')
+				|| anchor.getAttribute('aria-label')
+				|| ''
+			);
+			return {
+				href,
+				text: stripLeadingAt(text),
+				score: href ? scoreWeiboAuthorAnchor(anchor) : -1,
+			};
+		})
+		.filter(candidate => candidate.href && isLikelyWeiboAuthorName(candidate.text))
+		.sort((a, b) => b.score - a.score);
+
+	if (anchors.length === 0) {
+		return { author: '', authorUrl: '' };
+	}
+
+	return {
+		author: anchors[0].text,
+		authorUrl: anchors[0].href,
+	};
+}
+
+function extractWeiboAuthorFromScripts(document: Document | undefined, pageUrl: string): { author: string; authorUrl: string } {
+	if (!document) {
+		return { author: '', authorUrl: '' };
+	}
+
+	const scripts = Array.from(document.querySelectorAll('script'))
+		.map(script => script.textContent || '')
+		.filter(Boolean);
+
+	for (const scriptText of scripts) {
+		const screenNameMatch = scriptText.match(/"screen_name"\s*:\s*"([^"]+)"/);
+		if (!screenNameMatch) {
+			continue;
+		}
+
+		const author = stripLeadingAt(decodeEscapedString(screenNameMatch[1]));
+		if (!isLikelyWeiboAuthorName(author)) {
+			continue;
+		}
+
+		const profileUrlMatch = scriptText.match(/"profile_url"\s*:\s*"([^"]+)"/);
+		if (profileUrlMatch) {
+			const authorUrl = normalizeWeiboProfileUrl(decodeEscapedString(profileUrlMatch[1]), pageUrl);
+			if (authorUrl) {
+				return { author, authorUrl };
+			}
+		}
+
+		const idMatch = scriptText.match(/"idstr"\s*:\s*"(\d+)"/);
+		if (idMatch) {
+			return {
+				author,
+				authorUrl: `https://weibo.com/u/${idMatch[1]}`,
+			};
+		}
+
+		return { author, authorUrl: '' };
+	}
+
+	return { author: '', authorUrl: '' };
+}
+
+function normalizeWeiboTitle(value: string | null | undefined): string {
+	const normalized = normalizeWhitespace(value);
+	if (!normalized || GENERIC_WEIBO_TITLES.has(normalized)) {
+		return '';
+	}
+
+	const quotedMatch = normalized.match(/(?:《|“|")(.*?)(?:》|”|")/);
+	if (quotedMatch?.[1]) {
+		return normalizeWhitespace(quotedMatch[1]);
+	}
+
+	return normalized
+		.replace(/\s*[-|｜_]\s*微博.*$/i, '')
+		.replace(/\s*-\s*Sina Visitor System$/i, '')
+		.trim();
+}
+
+function normalizeWeiboProfileUrl(rawUrl: string, pageUrl: string): string {
+	if (!rawUrl || rawUrl.startsWith('javascript:') || rawUrl.startsWith('#')) {
+		return '';
+	}
+
+	try {
+		const url = new URL(rawUrl, pageUrl);
+		const hostname = url.hostname.toLowerCase();
+		const path = url.pathname.replace(/\/+$/, '');
+
+		if (!hostname.includes('weibo.com') && hostname !== 'm.weibo.cn' && hostname !== 'weibo.cn') {
+			return '';
+		}
+
+		if (/^\/(status|detail)\//.test(path) || /^\/ttarticle\//.test(path)) {
+			return '';
+		}
+
+		if (/^\/u\/\d+$/.test(path) || /^\/n\/[^/]+$/.test(path)) {
+			return `https://weibo.com${path}`;
+		}
+
+		if (/^\/profile\/\d+$/.test(path)) {
+			return `https://m.weibo.cn${path}`;
+		}
+
+		if (hostname.includes('weibo.com') && /^\/[^/]+$/.test(path)) {
+			return `https://weibo.com${path}`;
+		}
+
+		if (hostname === 'm.weibo.cn' && /^\/[^/]+$/.test(path)) {
+			return `https://m.weibo.cn${path}`;
+		}
+	} catch (error) {
+		return '';
+	}
+
+	return '';
+}
+
+function scoreWeiboAuthorAnchor(anchor: Element): number {
+	let score = 0;
+	const href = anchor.getAttribute('href') || '';
+	const className = (anchor.getAttribute('class') || '').toLowerCase();
+
+	if (/\/(u\/\d+|n\/[^/?#]+|profile\/\d+)$/.test(href)) {
+		score += 8;
+	}
+
+	if (anchor.closest('header, article, [class*="head"], [class*="user"], [class*="author"], [class*="profile"], [class*="info"]')) {
+		score += 4;
+	}
+
+	if (className.includes('author') || className.includes('user') || className.includes('profile')) {
+		score += 3;
+	}
+
+	if (href.includes('/status/') || href.includes('/detail/')) {
+		score -= 6;
+	}
+
+	return score;
+}
+
+function shouldReplaceWeiboTitle(title: string): boolean {
+	return !title || GENERIC_WEIBO_TITLES.has(title);
+}
+
+function isWeiboUrl(url: string): boolean {
+	try {
+		const hostname = new URL(url).hostname.toLowerCase();
+		return hostname === 'weibo.com'
+			|| hostname.endsWith('.weibo.com')
+			|| hostname === 'm.weibo.cn'
+			|| hostname === 'weibo.cn';
+	} catch (error) {
+		return false;
+	}
+}
+
+function normalizeWhitespace(value: string | null | undefined): string {
+	return (value || '')
+		.replace(/\u00a0/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function stripLeadingAt(value: string): string {
+	return value.replace(/^@+/, '').trim();
+}
+
+function isLikelyWeiboAuthorName(value: string): boolean {
+	if (!value || value.length > 40) {
+		return false;
+	}
+
+	return !/^(微博|全文|网页链接|赞|评论|转发|收藏|关注|超话|热搜)$/i.test(value);
+}
+
+function looksLikeUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value);
+}
+
+function decodeEscapedString(value: string): string {
+	return value
+		.replace(/\\"/g, '"')
+		.replace(/\\\//g, '/')
+		.replace(/\\u([\dA-Fa-f]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -263,7 +263,7 @@ function extractWeiboAuthorFromScripts(document: Document | undefined, pageUrl: 
 
 function normalizeWeiboTitle(value: string | null | undefined): string {
 	const normalized = normalizeWhitespace(value);
-	if (!normalized || GENERIC_WEIBO_TITLES.has(normalized)) {
+	if (!normalized || isGenericWeiboTitle(normalized)) {
 		return '';
 	}
 
@@ -272,10 +272,12 @@ function normalizeWeiboTitle(value: string | null | undefined): string {
 		return normalizeWhitespace(quotedMatch[1]);
 	}
 
-	return normalized
+	const cleaned = normalized
 		.replace(/\s*[-|｜_]\s*微博.*$/i, '')
 		.replace(/\s*-\s*Sina Visitor System$/i, '')
 		.trim();
+
+	return isGenericWeiboTitle(cleaned) ? '' : cleaned;
 }
 
 function normalizeWeiboProfileUrl(rawUrl: string, pageUrl: string): string {
@@ -343,7 +345,19 @@ function scoreWeiboAuthorAnchor(anchor: Element): number {
 }
 
 function shouldReplaceWeiboTitle(title: string): boolean {
-	return !title || GENERIC_WEIBO_TITLES.has(title);
+	return !title || isGenericWeiboTitle(title);
+}
+
+function isGenericWeiboTitle(title: string): boolean {
+	if (!title) {
+		return true;
+	}
+
+	if (GENERIC_WEIBO_TITLES.has(title)) {
+		return true;
+	}
+
+	return /^(微博正文)(\s*[-|｜_]\s*微博.*)?$/i.test(title);
 }
 
 function isWeiboUrl(url: string): boolean {

--- a/src/utils/page-metadata.ts
+++ b/src/utils/page-metadata.ts
@@ -9,6 +9,7 @@ interface ResolvePageMetadataParams {
 	document?: Document;
 	title?: string;
 	author?: string;
+	published?: string;
 	contentHtml?: string;
 	metaTags?: MetaTag[];
 }
@@ -17,12 +18,14 @@ interface WeiboMetadata {
 	title?: string;
 	author?: string;
 	authorUrl?: string;
+	published?: string;
 }
 
 export interface ResolvedPageMetadata {
 	title: string;
 	author: string;
 	authorUrl: string;
+	published: string;
 }
 
 const GENERIC_WEIBO_TITLES = new Set([
@@ -31,15 +34,27 @@ const GENERIC_WEIBO_TITLES = new Set([
 	'Sina Visitor System',
 ]);
 
+const GENERIC_WEIBO_CONTENT_LINES = new Set([
+	'公开',
+	'仅自己可见',
+	'好友圈',
+	'粉丝可见',
+	'置顶',
+	'置顶微博',
+	'已编辑',
+]);
+
 export function resolvePageMetadata(params: ResolvePageMetadataParams): ResolvedPageMetadata {
 	const title = normalizeWhitespace(params.title);
 	const author = normalizeWhitespace(params.author);
+	const published = normalizeWhitespace(params.published);
 
 	if (!isWeiboUrl(params.url)) {
 		return {
 			title,
 			author,
 			authorUrl: '',
+			published,
 		};
 	}
 
@@ -47,11 +62,13 @@ export function resolvePageMetadata(params: ResolvePageMetadataParams): Resolved
 	const fallbackTitle = extractWeiboTitleFromContentHtml(params.contentHtml);
 	const resolvedTitle = shouldReplaceWeiboTitle(title) ? weiboMetadata.title : title;
 	const resolvedAuthor = author || weiboMetadata.author || '';
+	const resolvedPublished = weiboMetadata.published || published;
 
 	return {
 		title: resolvedTitle || fallbackTitle || title,
 		author: resolvedAuthor,
 		authorUrl: weiboMetadata.authorUrl || '',
+		published: resolvedPublished,
 	};
 }
 
@@ -59,11 +76,13 @@ function extractWeiboMetadata(document: Document | undefined, pageUrl: string, m
 	const metaTitle = extractWeiboTitleFromMeta(metaTags);
 	const documentTitle = extractWeiboTitleFromDocument(document);
 	const { author, authorUrl } = extractWeiboAuthor(document, pageUrl, metaTags);
+	const published = extractWeiboPublished(document, pageUrl, metaTags);
 
 	return {
 		title: metaTitle || documentTitle,
 		author,
 		authorUrl,
+		published,
 	};
 }
 
@@ -120,21 +139,127 @@ function extractWeiboTitleFromContentHtml(contentHtml: string | undefined): stri
 		return '';
 	}
 
-	const firstLine = normalizeWhitespace(
-		contentHtml
-			.replace(/<(p|div|h1|h2|h3|li|blockquote|br)\b[^>]*>/gi, '\n')
-			.replace(/<\/(p|div|h1|h2|h3|li|blockquote)>/gi, '\n')
-			.replace(/<[^>]+>/g, ' ')
-			.split('\n')
-			.map(line => normalizeWhitespace(line))
-			.find(Boolean)
-	);
+	const firstLine = contentHtml
+		.replace(/<(p|div|h1|h2|h3|li|blockquote|br)\b[^>]*>/gi, '\n')
+		.replace(/<\/(p|div|h1|h2|h3|li|blockquote)>/gi, '\n')
+		.replace(/<[^>]+>/g, ' ')
+		.split('\n')
+		.map(line => normalizeWhitespace(line))
+		.find(line => line && !isGenericWeiboContentLine(line));
 
 	if (!firstLine) {
 		return '';
 	}
 
-	return firstLine.length > 30 ? firstLine.slice(0, 30) : firstLine;
+	return firstLine.length > 50 ? firstLine.slice(0, 50) : firstLine;
+}
+
+function extractWeiboPublished(document: Document | undefined, pageUrl: string, metaTags: MetaTag[] | undefined): string {
+	const metaPublished = extractWeiboPublishedFromMeta(metaTags);
+	if (metaPublished) {
+		return metaPublished;
+	}
+
+	const documentPublished = extractWeiboPublishedFromDocument(document, pageUrl);
+	if (documentPublished) {
+		return documentPublished;
+	}
+
+	return extractWeiboPublishedFromScripts(document);
+}
+
+function extractWeiboPublishedFromMeta(metaTags: MetaTag[] | undefined): string {
+	if (!metaTags?.length) {
+		return '';
+	}
+
+	const preferredKeys = new Set([
+		'article:published_time',
+		'og:published_time',
+		'publication_date',
+		'pubdate',
+	]);
+
+	for (const meta of metaTags) {
+		const key = (meta.property || meta.name || '').trim().toLowerCase();
+		if (!preferredKeys.has(key)) {
+			continue;
+		}
+
+		const published = normalizeWeiboPublished(meta.content);
+		if (published) {
+			return published;
+		}
+	}
+
+	return '';
+}
+
+function extractWeiboPublishedFromDocument(document: Document | undefined, pageUrl: string): string {
+	if (!document) {
+		return '';
+	}
+
+	const selectors = [
+		'time[datetime]',
+		'a[node-type="feed_list_item_date"][title]',
+		'[node-type="feed_list_item_date"][title]',
+		'a[href*="/status/"][title]',
+		'a[href*="/detail/"][title]',
+	];
+
+	for (const selector of selectors) {
+		const element = document.querySelector(selector);
+		if (!element) {
+			continue;
+		}
+
+		const candidate = normalizeWeiboPublished(
+			element.getAttribute('datetime')
+			|| element.getAttribute('title')
+			|| element.textContent
+		);
+
+		if (candidate) {
+			return candidate;
+		}
+	}
+
+	const anchors = Array.from(document.querySelectorAll('a[href]'))
+		.filter(anchor => !normalizeWeiboProfileUrl(anchor.getAttribute('href') || '', pageUrl));
+
+	for (const anchor of anchors) {
+		const candidate = normalizeWeiboPublished(anchor.getAttribute('title') || anchor.textContent);
+		if (candidate) {
+			return candidate;
+		}
+	}
+
+	return '';
+}
+
+function extractWeiboPublishedFromScripts(document: Document | undefined): string {
+	if (!document) {
+		return '';
+	}
+
+	const scripts = Array.from(document.querySelectorAll('script'))
+		.map(script => script.textContent || '')
+		.filter(Boolean);
+
+	for (const scriptText of scripts) {
+		const match = scriptText.match(/"created_at"\s*:\s*"([^"]+)"/);
+		if (!match) {
+			continue;
+		}
+
+		const published = normalizeWeiboPublished(decodeEscapedString(match[1]));
+		if (published) {
+			return published;
+		}
+	}
+
+	return '';
 }
 
 function extractWeiboAuthor(document: Document | undefined, pageUrl: string, metaTags: MetaTag[] | undefined): { author: string; authorUrl: string } {
@@ -360,6 +485,10 @@ function isGenericWeiboTitle(title: string): boolean {
 	return /^(微博正文)(\s*[-|｜_]\s*微博.*)?$/i.test(title);
 }
 
+function isGenericWeiboContentLine(line: string): boolean {
+	return GENERIC_WEIBO_CONTENT_LINES.has(line);
+}
+
 function isWeiboUrl(url: string): boolean {
 	try {
 		const hostname = new URL(url).hostname.toLowerCase();
@@ -400,4 +529,39 @@ function decodeEscapedString(value: string): string {
 		.replace(/\\"/g, '"')
 		.replace(/\\\//g, '/')
 		.replace(/\\u([\dA-Fa-f]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
+function normalizeWeiboPublished(value: string | null | undefined): string {
+	const normalized = normalizeWhitespace(value)
+		.replace(/\s*来自.*$/i, '')
+		.replace(/\s*发布于.*$/i, '')
+		.trim();
+
+	if (!normalized || /^(公开|微博|全文|网页链接|已编辑)$/i.test(normalized)) {
+		return '';
+	}
+
+	if (/^\d{4}-\d{1,2}-\d{1,2}\s+\d{1,2}:\d{2}$/.test(normalized)) {
+		return normalized;
+	}
+
+	if (/^\d{2}-\d{1,2}-\d{1,2}\s+\d{1,2}:\d{2}$/.test(normalized)) {
+		return `20${normalized}`;
+	}
+
+	if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(normalized)) {
+		return normalized;
+	}
+
+	const parsed = new Date(normalized);
+	if (!Number.isNaN(parsed.getTime())) {
+		const year = parsed.getFullYear();
+		const month = `${parsed.getMonth() + 1}`.padStart(2, '0');
+		const day = `${parsed.getDate()}`.padStart(2, '0');
+		const hour = `${parsed.getHours()}`.padStart(2, '0');
+		const minute = `${parsed.getMinutes()}`.padStart(2, '0');
+		return `${year}-${month}-${day} ${hour}:${minute}`;
+	}
+
+	return '';
 }

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -700,6 +700,7 @@ export class Reader {
 			document: doc,
 			title: defuddled.title,
 			author: defuddled.author,
+			contentHtml: defuddled.content,
 			metaTags: defuddled.metaTags,
 		});
 

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -9,6 +9,7 @@ import { applyHighlights, invalidateHighlightCache, loadHighlights } from './hig
 import { copyToClipboard } from './clipboard-utils';
 import { getMessage, initializeI18n } from './i18n';
 import { getFontCss } from './font-utils';
+import { resolvePageMetadata } from './page-metadata';
 
 // Mobile viewport settings
 const VIEWPORT = 'width=device-width, initial-scale=1, maximum-scale=1';
@@ -694,11 +695,18 @@ export class Reader {
 
 		const defuddle = new Defuddle(doc, { url: doc.URL });
 		const defuddled = await defuddle.parseAsync();
+		const resolvedMetadata = resolvePageMetadata({
+			url: doc.URL,
+			document: doc,
+			title: defuddled.title,
+			author: defuddled.author,
+			metaTags: defuddled.metaTags,
+		});
 
 		return {
 			content: defuddled.content,
-			title: defuddled.title,
-			author: defuddled.author,
+			title: resolvedMetadata.title,
+			author: resolvedMetadata.author,
 			published: defuddled.published,
 			domain: getDomain(doc.URL),
 			wordCount: defuddled.wordCount,

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -700,6 +700,7 @@ export class Reader {
 			document: doc,
 			title: defuddled.title,
 			author: defuddled.author,
+			published: defuddled.published,
 			contentHtml: defuddled.content,
 			metaTags: defuddled.metaTags,
 		});
@@ -708,7 +709,7 @@ export class Reader {
 			content: defuddled.content,
 			title: resolvedMetadata.title,
 			author: resolvedMetadata.author,
-			published: defuddled.published,
+			published: resolvedMetadata.published,
 			domain: getDomain(doc.URL),
 			wordCount: defuddled.wordCount,
 			parseTime: defuddled.parseTime

--- a/src/utils/shared.test.ts
+++ b/src/utils/shared.test.ts
@@ -39,6 +39,9 @@ describe('buildVariables', () => {
 		const vars = buildVariables(makeParams());
 		expect(vars['{{title}}']).toBe('Test Title');
 		expect(vars['{{author}}']).toBe('Test Author');
+		expect(vars['{{authorHandle}}']).toBe('');
+		expect(vars['{{authorLink}}']).toBe('');
+		expect(vars['{{authorUrl}}']).toBe('');
 		expect(vars['{{content}}']).toBe('markdown body');
 		expect(vars['{{contentHtml}}']).toBe('<p>html body</p>');
 		expect(vars['{{url}}']).toBe('https://example.com/page');
@@ -72,6 +75,18 @@ describe('buildVariables', () => {
 		}));
 		expect(vars['{{title}}']).toBe('padded title');
 		expect(vars['{{author}}']).toBe('padded author');
+	});
+
+	test('builds weibo author link variables when author URL is provided', () => {
+		const vars = buildVariables(makeParams({
+			url: 'https://weibo.com/1234567890/AbCdEf',
+			author: '三体观察员',
+			authorUrl: 'https://weibo.com/u/1234567890',
+		}));
+		expect(vars['{{author}}']).toBe('三体观察员');
+		expect(vars['{{authorHandle}}']).toBe('@三体观察员');
+		expect(vars['{{authorUrl}}']).toBe('https://weibo.com/u/1234567890');
+		expect(vars['{{authorLink}}']).toBe('[@三体观察员](https://weibo.com/u/1234567890)');
 	});
 
 	test('handles empty/falsy values', () => {

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -14,6 +14,7 @@ import dayjs from 'dayjs';
 export interface BuildVariablesParams {
 	title: string;
 	author: string;
+	authorUrl?: string;
 	content: string;
 	contentHtml: string;
 	url: string;
@@ -40,10 +41,27 @@ export interface BuildVariablesParams {
 export function buildVariables(params: BuildVariablesParams): Record<string, string> {
 	const currentUrl = params.url.replace(/#:~:text=[^&]+(&|$)/, '');
 	const noteName = sanitizeFileName(params.title);
+	let isWeiboAuthor = false;
+	try {
+		isWeiboAuthor = /(^|\.)weibo\.com$|^m\.weibo\.cn$|^weibo\.cn$/i.test(new URL(currentUrl).hostname);
+	} catch (error) {
+		isWeiboAuthor = false;
+	}
+	const author = (params.author || '').trim();
+	const authorUrl = (params.authorUrl || '').trim();
+	const authorHandle = author
+		? (isWeiboAuthor ? (author.startsWith('@') ? author : `@${author}`) : '')
+		: '';
+	const authorLink = authorUrl
+		? `[${authorHandle || author}](${authorUrl})`
+		: '';
 
 	const timestamp = dayjs().format('YYYY-MM-DDTHH:mm:ssZ');
 	const variables: Record<string, string> = {
-		'{{author}}': (params.author || '').trim(),
+		'{{author}}': author,
+		'{{authorHandle}}': authorHandle,
+		'{{authorLink}}': authorLink,
+		'{{authorUrl}}': authorUrl,
 		'{{content}}': (params.content || '').trim(),
 		'{{contentHtml}}': (params.contentHtml || '').trim(),
 		'{{selection}}': (params.selection || '').trim(),

--- a/src/utils/template-integration.test.ts
+++ b/src/utils/template-integration.test.ts
@@ -7,6 +7,7 @@ import { createMarkdownContent } from 'defuddle/full';
 import { buildVariables, generateFrontmatter, formatPropertyValue } from './shared';
 import { compileTemplate } from './template-compiler';
 import { createAsyncResolver, createSelectorProcessor } from '../api';
+import { resolvePageMetadata } from './page-metadata';
 
 // ---------------------------------------------------------------------------
 // Freeze time so {{date}} is deterministic in expected output
@@ -33,12 +34,20 @@ async function runFixture(html: string, url: string, template: FixtureTemplate):
 	// Run defuddle — same as CLI
 	const defuddle = new DefuddleClass(document as unknown as Document, { url });
 	const defuddleResult = defuddle.parse();
+	const resolvedMetadata = resolvePageMetadata({
+		url,
+		document: document as unknown as Document,
+		title: defuddleResult.title,
+		author: defuddleResult.author,
+		metaTags: defuddleResult.metaTags,
+	});
 	const markdownContent = createMarkdownContent(defuddleResult.content, url);
 
 	// Build variables from defuddle output — same as CLI
 	const variables = buildVariables({
-		title: defuddleResult.title,
-		author: defuddleResult.author,
+		title: resolvedMetadata.title,
+		author: resolvedMetadata.author,
+		authorUrl: resolvedMetadata.authorUrl,
 		content: markdownContent,
 		contentHtml: defuddleResult.content,
 		url,

--- a/src/utils/template-integration.test.ts
+++ b/src/utils/template-integration.test.ts
@@ -39,6 +39,7 @@ async function runFixture(html: string, url: string, template: FixtureTemplate):
 		document: document as unknown as Document,
 		title: defuddleResult.title,
 		author: defuddleResult.author,
+		published: defuddleResult.published,
 		contentHtml: defuddleResult.content,
 		metaTags: defuddleResult.metaTags,
 	});
@@ -56,7 +57,7 @@ async function runFixture(html: string, url: string, template: FixtureTemplate):
 		description: defuddleResult.description,
 		favicon: defuddleResult.favicon,
 		image: defuddleResult.image,
-		published: defuddleResult.published,
+		published: resolvedMetadata.published,
 		site: defuddleResult.site,
 		language: defuddleResult.language,
 		wordCount: defuddleResult.wordCount,

--- a/src/utils/template-integration.test.ts
+++ b/src/utils/template-integration.test.ts
@@ -39,6 +39,7 @@ async function runFixture(html: string, url: string, template: FixtureTemplate):
 		document: document as unknown as Document,
 		title: defuddleResult.title,
 		author: defuddleResult.author,
+		contentHtml: defuddleResult.content,
 		metaTags: defuddleResult.metaTags,
 	});
 	const markdownContent = createMarkdownContent(defuddleResult.content, url);


### PR DESCRIPTION
## Summary
- add a Weibo-specific metadata fallback so title, author, and published time can still be resolved when Defuddle misses them on `weibo.com` and `m.weibo.cn`
- expose `authorHandle`, `authorUrl`, and `authorLink` variables so Weibo authors can be saved as clickable `@name` profile links
- update the default template to prefer `authorLink`, and fall back to the first meaningful content line for title extraction when the page title is generic

## Test plan
- [x] `npm test -- --run src/utils/page-metadata.test.ts src/utils/shared.test.ts`
- [x] `npm run build:chrome`
- [ ] verify a live Weibo clip in the extension UI saves the expected title, clickable author link, and published time

🤖 Generated with [Claude Code](https://claude.com/claude-code)