### PR TITLE
feat: add image download and embedding support

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1002,5 +1002,44 @@
 	},
 	"version": {
 		"message": "Version"
+	},
+	"images": {
+		"message": "Images"
+	},
+	"downloadImages": {
+		"message": "Download images"
+	},
+	"downloadImagesDescription": {
+		"message": "Images are only downloaded when clicking Add to Obsidian"
+	},
+	"imageSaveMode": {
+		"message": "Image save mode"
+	},
+	"imageSaveModeVault": {
+		"message": "Embed as Base64"
+	},
+	"imageSaveModeVaultApi": {
+		"message": "Download to vault"
+	},
+	"imageSaveModeVaultApiDescription": {
+		"message": "Requires the Obsidian Local REST API plugin. In the plugin settings, enable Allow non-encrypted (HTTP) requests and copy the API key below."
+	},
+	"obsidianApiPort": {
+		"message": "Obsidian Local REST API HTTP Port"
+	},
+	"obsidianApiPortDescription": {
+		"message": "HTTP port only (default: 27123). Extensions cannot connect to self-signed HTTPS certificates."
+	},
+	"obsidianApiKey": {
+		"message": "API key"
+	},
+	"obsidianImageSavedFolder": {
+		"message": "Image saved folder"
+	},
+	"obsidianImageSavedFolderDescription": {
+		"message": "Subfolder under the note's location where images are saved (e.g. NoteLocation/Images)"
+	},
+	"downloadingImages": {
+		"message": "Downloading images..."
 	}
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -497,6 +497,53 @@ declare global {
 		} else if (request.action === "getReaderModeState") {
 			sendResponse({ isActive: document.documentElement.classList.contains('obsidian-reader-active') });
 			return true;
+		} else if (request.action === "fetchImage") {
+			// Fetch an image in page context to bypass CORS restrictions
+			(async () => {
+				try {
+					const response = await fetch(request.url as string);
+					const buffer = await response.arrayBuffer();
+					const contentType = response.headers.get('content-type') || 'image/png';
+					sendResponse({
+						buffer: Array.from(new Uint8Array(buffer)),
+						contentType,
+					});
+				} catch (error) {
+					sendResponse({
+						error: error instanceof Error ? error.message : 'Unknown error',
+					});
+				}
+			})();
+			return true;
+		} else if (request.action === "getImageInitiatorMap") {
+			// Build a URL resolution map using PerformanceResourceTiming + DOM img elements
+			(async () => {
+				try {
+					// Performance-tracked final URLs for image resources
+					const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+					const map: Record<string, string> = {};
+					entries
+						.filter(e => e.initiatorType === 'img')
+						.forEach(e => {
+							map[e.name] = e.name;
+						});
+
+					// DOM-based map: original src attribute → resolved currentSrc
+					const domMap: Record<string, string> = {};
+					document.querySelectorAll('img').forEach(img => {
+						const src = img.getAttribute('src') || '';
+						const currentSrc = img.currentSrc || src;
+						if (src && currentSrc && currentSrc !== src) {
+							domMap[src] = currentSrc;
+						}
+					});
+
+					sendResponse({ map, domMap });
+				} catch (error) {
+					sendResponse({ map: {}, domMap: {} });
+				}
+			})();
+			return true;
 		}
 		return true;
 	});

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -23,6 +23,7 @@ import { sanitizeFileName } from '../utils/string-utils';
 import { saveFile } from '../utils/file-utils';
 import { translatePage, getMessage, setupLanguageAndDirection } from '../utils/i18n';
 import { formatPropertyValue } from '../utils/shared';
+import { processImages } from '../utils/image-processor';
 
 interface ReaderModeResponse {
 	success: boolean;
@@ -457,13 +458,7 @@ function setupEventListeners(tabId: number) {
 
 	if (copyContentButton) {
 		copyContentButton.addEventListener('click', async () => {
-			const properties = getPropertiesFromDOM();
-
-			const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
-			const frontmatter = await generateFrontmatter(properties);
-			const fileContent = frontmatter + noteContentField.value;
-			
-			await copyToClipboard(fileContent);
+			await copyContent();
 		});
 	}
 
@@ -1236,7 +1231,12 @@ async function handleSaveToDownloads() {
 
 		const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
 		const frontmatter = await generateFrontmatter(properties);
-		const fileContent = frontmatter + noteContentField.value;
+		let fileContent = frontmatter + noteContentField.value;
+
+		// Process images in embed (base64) mode only — local-rest-api is not applicable for file save
+		if (loadedSettings.downloadImages && loadedSettings.imageSaveMode === 'embed' && currentTabId) {
+			fileContent = await processImages(fileContent, currentTabId, { ...loadedSettings, imageSaveMode: 'embed' });
+		}
 
 		await saveFile({
 			content: fileContent,
@@ -1301,6 +1301,7 @@ async function handleClipObsidian(): Promise<void> {
 	const noteNameField = document.getElementById('note-name-field') as HTMLInputElement;
 	const pathField = document.getElementById('path-name-field') as HTMLInputElement;
 	const interpretBtn = document.getElementById('interpret-btn') as HTMLButtonElement;
+	const clipBtn = document.getElementById('clip-btn') as HTMLButtonElement;
 
 	if (!vaultDropdown || !noteContentField) {
 		showError('Some required fields are missing. Please try reloading the extension.');
@@ -1322,13 +1323,32 @@ async function handleClipObsidian(): Promise<void> {
 		const properties = getPropertiesFromDOM();
 
 		const frontmatter = await generateFrontmatter(properties);
-		const fileContent = frontmatter + noteContentField.value;
+		let fileContent = frontmatter + noteContentField.value;
 
 		// Save to Obsidian
 		const selectedVault = currentTemplate.vault || vaultDropdown.value;
 		const isDailyNote = currentTemplate.behavior === 'append-daily' || currentTemplate.behavior === 'prepend-daily';
 		const noteName = isDailyNote ? '' : noteNameField?.value || '';
 		const path = isDailyNote ? '' : pathField?.value || '';
+
+		// Process images if enabled in settings
+		if (loadedSettings.downloadImages && currentTabId) {
+			const originalBtnText = clipBtn?.textContent ?? '';
+			if (clipBtn) {
+				clipBtn.classList.add('processing');
+				clipBtn.disabled = true;
+				clipBtn.textContent = getMessage('downloadingImages');
+			}
+			try {
+				fileContent = await processImages(fileContent, currentTabId, loadedSettings, path, noteName);
+			} finally {
+				if (clipBtn) {
+					clipBtn.classList.remove('processing');
+					clipBtn.disabled = false;
+					clipBtn.textContent = originalBtnText;
+				}
+			}
+		}
 
 		await saveToObsidian(fileContent, noteName, path, selectedVault, currentTemplate.behavior);
 		const tabInfo = await getCurrentTabInfo();
@@ -1390,7 +1410,13 @@ async function copyContent() {
 
 	const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
 	const frontmatter = await generateFrontmatter(properties);
-	const fileContent = frontmatter + noteContentField.value;
+	let fileContent = frontmatter + noteContentField.value;
+
+	// Process images in embed (base64) mode only — local-rest-api is not applicable for clipboard
+	if (loadedSettings.downloadImages && loadedSettings.imageSaveMode === 'embed' && currentTabId) {
+		fileContent = await processImages(fileContent, currentTabId, { ...loadedSettings, imageSaveMode: 'embed' });
+	}
+
 	await copyToClipboard(fileContent);
 }
 

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -227,6 +227,7 @@ export function initializeGeneralSettings(): void {
 		initializeHighlighterSettings();
 		initializeExportHighlightsButton();
 		initializeSaveBehaviorDropdown();
+		initializeImageSettings();
 		await initializeUsageChart();
 
 		// Initialize feedback modal close button
@@ -256,6 +257,11 @@ function saveSettingsFromForm(): void {
 	const highlighterToggle = document.getElementById('highlighter-toggle') as HTMLInputElement;
 	const alwaysShowHighlightsToggle = document.getElementById('highlighter-visibility') as HTMLInputElement;
 	const highlightBehaviorSelect = document.getElementById('highlighter-behavior') as HTMLSelectElement;
+	const downloadImagesToggle = document.getElementById('download-images-toggle') as HTMLInputElement;
+	const imageSaveModeSelect = document.getElementById('image-save-mode') as HTMLSelectElement;
+	const obsidianApiPort = document.getElementById('obsidian-api-port') as HTMLInputElement;
+	const obsidianApiKey = document.getElementById('obsidian-api-key') as HTMLInputElement;
+	const obsidianAttachmentFolder = document.getElementById('obsidian-image-saved-folder') as HTMLInputElement;
 
 	const updatedSettings = {
 		...generalSettings, // Keep existing settings
@@ -266,7 +272,14 @@ function saveSettingsFromForm(): void {
 		silentOpen: silentOpenToggle?.checked ?? generalSettings.silentOpen,
 		highlighterEnabled: highlighterToggle?.checked ?? generalSettings.highlighterEnabled,
 		alwaysShowHighlights: alwaysShowHighlightsToggle?.checked ?? generalSettings.alwaysShowHighlights,
-		highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior
+		highlightBehavior: highlightBehaviorSelect?.value ?? generalSettings.highlightBehavior,
+		downloadImages: downloadImagesToggle?.checked ?? generalSettings.downloadImages,
+		imageSaveMode: (imageSaveModeSelect?.value as 'embed' | 'local-rest-api') ?? generalSettings.imageSaveMode,
+		obsidianApiConfig: {
+			port: obsidianApiPort?.value ?? generalSettings.obsidianApiConfig.port,
+			apiKey: obsidianApiKey?.value ?? generalSettings.obsidianApiConfig.apiKey,
+			imageSavedFolder: obsidianAttachmentFolder?.value ?? generalSettings.obsidianApiConfig.imageSavedFolder
+		}
 	};
 
 	saveSettings(updatedSettings);
@@ -370,6 +383,50 @@ function initializeSaveBehaviorDropdown(): void {
         const newValue = dropdown.value as 'addToObsidian' | 'copyToClipboard' | 'saveFile';
         saveSettings({ saveBehavior: newValue });
     });
+}
+
+function initializeImageSettings(): void {
+	initializeSettingToggle('download-images-toggle', generalSettings.downloadImages, (checked) => {
+		saveSettings({ ...generalSettings, downloadImages: checked });
+	});
+
+	const imageSaveModeSelect = document.getElementById('image-save-mode') as HTMLSelectElement;
+	const obsidianApiConfig = document.getElementById('obsidian-api-config') as HTMLElement;
+
+	const updateImageModeVisibility = (mode: string) => {
+		if (obsidianApiConfig) {
+			obsidianApiConfig.style.display = mode === 'local-rest-api' ? 'block' : 'none';
+		}
+	};
+
+	if (imageSaveModeSelect) {
+		imageSaveModeSelect.value = generalSettings.imageSaveMode;
+		updateImageModeVisibility(generalSettings.imageSaveMode);
+		imageSaveModeSelect.addEventListener('change', () => {
+			const newMode = imageSaveModeSelect.value as 'embed' | 'local-rest-api';
+			updateImageModeVisibility(newMode);
+			saveSettings({ ...generalSettings, imageSaveMode: newMode });
+		});
+	}
+
+	const saveObsidianApiConfig = debounce(() => {
+		const port = (document.getElementById('obsidian-api-port') as HTMLInputElement)?.value ?? generalSettings.obsidianApiConfig.port;
+		const apiKey = (document.getElementById('obsidian-api-key') as HTMLInputElement)?.value ?? generalSettings.obsidianApiConfig.apiKey;
+		const imageSavedFolder = (document.getElementById('obsidian-image-saved-folder') as HTMLInputElement)?.value ?? generalSettings.obsidianApiConfig.imageSavedFolder;
+		saveSettings({ ...generalSettings, obsidianApiConfig: { port, apiKey, imageSavedFolder } });
+	}, 500);
+
+	const initObsidianInput = (id: string, defaultValue: string) => {
+		const input = document.getElementById(id) as HTMLInputElement;
+		if (input) {
+			input.value = defaultValue;
+			input.addEventListener('input', saveObsidianApiConfig);
+		}
+	};
+
+	initObsidianInput('obsidian-api-port', generalSettings.obsidianApiConfig.port);
+	initObsidianInput('obsidian-api-key', generalSettings.obsidianApiConfig.apiKey);
+	initObsidianInput('obsidian-image-saved-folder', generalSettings.obsidianApiConfig.imageSavedFolder);
 }
 
 export function resetDefaultTemplate(): void {

--- a/src/settings.html
+++ b/src/settings.html
@@ -199,6 +199,66 @@
 										</div>
 									</div>
 								</div>
+								<div class="setting-item setting-item-heading"><h3 data-i18n="images">Images</h3></div>
+								<div class="setting-items">
+									<div class="setting-item mod-horizontal mod-toggle">
+										<div class="setting-item-info">
+											<label for="download-images-toggle" data-i18n="downloadImages">Download images</label>
+											<div class="setting-item-description" data-i18n="downloadImagesDescription">Images are only downloaded when clicking Add to Obsidian</div>
+										</div>
+										<div class="setting-item-control">
+											<div class="checkbox-container">
+												<input type="checkbox" id="download-images-toggle" />
+											</div>
+										</div>
+									</div>
+									<div class="setting-item mod-horizontal">
+										<div class="setting-item-info">
+											<label for="image-save-mode" data-i18n="imageSaveMode">Image save mode</label>
+										</div>
+										<div class="setting-item-control">
+											<select id="image-save-mode">
+												<option value="embed" data-i18n="imageSaveModeVault">Embed as Base64</option>
+												<option value="local-rest-api" data-i18n="imageSaveModeVaultApi">Download to vault</option>
+											</select>
+										</div>
+									</div>
+									<div id="obsidian-api-config" style="display:none;">
+										<div class="setting-item mod-horizontal">
+											<div class="setting-item-info">
+												<label data-i18n="imageSaveModeVaultApi">Download to vault</label>
+												<div class="setting-item-description" data-i18n="imageSaveModeVaultApiDescription">Requires the Obsidian Local REST API plugin. In the plugin settings, enable Allow non-encrypted (HTTP) requests and copy the API key below.</div>
+												<div class="setting-item-description"><a href="https://github.com/coddingtonbear/obsidian-local-rest-api" target="_blank">https://github.com/coddingtonbear/obsidian-local-rest-api</a></div>
+											</div>
+										</div>
+										<div class="setting-item mod-horizontal">
+											<div class="setting-item-info">
+												<label for="obsidian-api-port" data-i18n="obsidianApiPort">Obsidian Local REST API HTTP Port</label>
+												<div class="setting-item-description" data-i18n="obsidianApiPortDescription">HTTP port only (default: 27123). Extensions cannot connect to self-signed HTTPS certificates.</div>
+											</div>
+											<div class="setting-item-control">
+												<input type="number" id="obsidian-api-port" placeholder="27123" min="1" max="65535" />
+											</div>
+										</div>
+										<div class="setting-item mod-horizontal">
+											<div class="setting-item-info">
+												<label for="obsidian-api-key" data-i18n="obsidianApiKey">API key</label>
+											</div>
+											<div class="setting-item-control">
+												<input type="text" id="obsidian-api-key" />
+											</div>
+										</div>
+										<div class="setting-item mod-horizontal">
+											<div class="setting-item-info">
+												<label for="obsidian-image-saved-folder" data-i18n="obsidianImageSavedFolder">Image saved folder</label>
+												<div class="setting-item-description" data-i18n="obsidianImageSavedFolderDescription">Subfolder under the note's location where images are saved (e.g. NoteLocation/Images)</div>
+											</div>
+											<div class="setting-item-control">
+												<input type="text" id="obsidian-image-saved-folder" placeholder="Images" />
+											</div>
+										</div>
+									</div>
+								</div>
 								<div class="setting-item setting-item-heading"><h3 data-i18n="advanced">Advanced</h3></div>
 								<div class="setting-items">
 									<div class="setting-item mod-horizontal">

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -190,6 +190,11 @@
 	#clip-btn {
 		flex: 1;
 		cursor: default;
+		&.processing {
+			opacity: 0.6;
+			cursor: not-allowed;
+			pointer-events: none;
+		}
 	}
 	#clip-btn:focus ~ .menu-btn #more-btn {
 		box-shadow: none;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -96,6 +96,13 @@ export interface Settings {
 	history: HistoryEntry[];
 	ratings: Rating[];
 	saveBehavior: 'addToObsidian' | 'saveFile' | 'copyToClipboard';
+	downloadImages: boolean;
+	imageSaveMode: 'embed' | 'local-rest-api';
+	obsidianApiConfig: {
+		port: string;
+		apiKey: string;
+		imageSavedFolder: string;
+	};
 }
 
 export interface ModelConfig {

--- a/src/utils/cli-stubs.ts
+++ b/src/utils/cli-stubs.ts
@@ -48,6 +48,13 @@ export const generalSettings: Settings = {
 	history: [],
 	ratings: [],
 	saveBehavior: 'addToObsidian',
+	downloadImages: false,
+	imageSaveMode: 'embed',
+	obsidianApiConfig: {
+		port: '27123',
+		apiKey: '',
+		imageSavedFolder: 'Images',
+	},
 };
 
 export const loadSettings = async () => {};

--- a/src/utils/image-processor.ts
+++ b/src/utils/image-processor.ts
@@ -1,0 +1,246 @@
+import browser from './browser-polyfill';
+import { Settings } from '../types/types';
+
+interface FetchImageResponse {
+	buffer: number[];
+	contentType: string;
+}
+
+interface InitiatorMapResponse {
+	map: Record<string, string>;
+	domMap: Record<string, string>;
+}
+
+/**
+ * Fetch an image from the page context via content script message (bypasses CORS).
+ * Returns the raw bytes and content-type.
+ */
+async function fetchImageViaContentScript(
+	url: string,
+	tabId: number
+): Promise<FetchImageResponse> {
+	const response = await browser.tabs.sendMessage(tabId, {
+		action: 'fetchImage',
+		url,
+	}) as FetchImageResponse;
+
+	if (!response || !response.buffer) {
+		throw new Error(`fetchImage returned no data for ${url}`);
+	}
+	return response;
+}
+
+/**
+ * Convert a byte array and content-type into a base64 data URI.
+ */
+function toDataUri(buffer: number[], contentType: string): string {
+	const uint8 = new Uint8Array(buffer);
+	let binary = '';
+	for (let i = 0; i < uint8.length; i++) {
+		binary += String.fromCharCode(uint8[i]);
+	}
+	const base64 = btoa(binary);
+	return `data:${contentType};base64,${base64}`;
+}
+
+const CONTENT_TYPE_EXT: Record<string, string> = {
+	'image/jpeg': 'jpg',
+	'image/png': 'png',
+	'image/gif': 'gif',
+	'image/webp': 'webp',
+	'image/svg+xml': 'svg',
+	'image/avif': 'avif',
+};
+
+/**
+ * Generate a unique filename for a saved image.
+ * Uses the URL path's last segment, sanitized, with a timestamp prefix.
+ */
+function generateImageFilename(url: string, contentType: string): string {
+	let name = '';
+	try {
+		const pathname = new URL(url).pathname;
+		name = pathname.split('/').filter(Boolean).pop() ?? '';
+	} catch {
+		name = '';
+	}
+
+	// Sanitize: keep alphanumeric, hyphens, underscores, dots
+	name = name.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-{2,}/g, '-').replace(/^-+|-+$/g, '');
+
+	// Ensure a recognizable extension
+	const hasKnownExt = /\.(jpe?g|png|gif|webp|svg|avif|bmp|tiff?)$/i.test(name);
+	if (!hasKnownExt) {
+		const ext = CONTENT_TYPE_EXT[contentType] ?? contentType.split('/')[1] ?? 'bin';
+		name = name ? `${name}.${ext}` : `image.${ext}`;
+	}
+
+	return `${Date.now()}-${name}`;
+}
+
+/**
+ * Save an image to the Obsidian vault via the Local REST API plugin.
+ * Returns an Obsidian wiki-link: ![[folder/filename.ext]]
+ */
+async function saveImageViaObsidianApi(
+	buffer: number[],
+	contentType: string,
+	url: string,
+	config: Settings['obsidianApiConfig'],
+	dynamicAttachmentFolder?: string
+): Promise<string> {
+	const filename = generateImageFilename(url, contentType);
+	const attachmentFolder = dynamicAttachmentFolder
+		?? config.imageSavedFolder?.trim().replace(/^\/+|\/+$/g, '')
+		?? 'Images';
+	const vaultPath = `${attachmentFolder}/${filename}`;
+
+	// Encode each path segment separately so slashes are preserved
+	const encodedPath = vaultPath.split('/').map(encodeURIComponent).join('/');
+	const port = config.port?.trim() || '27123';
+	const baseUrl = `http://127.0.0.1:${port}`;
+	const apiUrl = `${baseUrl}/vault/${encodedPath}`;
+
+	const headers: Record<string, string> = {
+		'Content-Type': contentType,
+	};
+	if (config.apiKey) {
+		headers['Authorization'] = `Bearer ${config.apiKey}`;
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(apiUrl, {
+			method: 'PUT',
+			headers,
+			body: new Uint8Array(buffer),
+		});
+	} catch (networkError) {
+		const msg = networkError instanceof Error ? networkError.message : String(networkError);
+		throw new Error(`Obsidian API network error: ${msg}`);
+	}
+
+	if (!response.ok) {
+		let body = '';
+		try { body = await response.text(); } catch { /* ignore */ }
+		throw new Error(`Obsidian API returned HTTP ${response.status}: ${response.statusText}${body ? ` — ${body}` : ''}`);
+	}
+
+	return `![[${vaultPath}]]`;
+}
+
+/**
+ * Resolve a markdown image URL using the initiator map obtained from the page.
+ * Some pages use lazy-loading or redirects; PerformanceResourceTiming gives us the final URL.
+ */
+async function resolveImageUrl(
+	originalUrl: string,
+	tabId: number
+): Promise<string> {
+	try {
+		const initiatorData = await browser.tabs.sendMessage(tabId, {
+			action: 'getImageInitiatorMap',
+		}) as InitiatorMapResponse;
+
+		// domMap: original attribute src → resolved currentSrc
+		if (initiatorData?.domMap?.[originalUrl]) {
+			return initiatorData.domMap[originalUrl];
+		}
+		// map: final performance-tracked URL (identity map for most cases)
+		if (initiatorData?.map?.[originalUrl]) {
+			return initiatorData.map[originalUrl];
+		}
+	} catch {
+		// If the content script doesn't support this action yet, fall through
+	}
+	return originalUrl;
+}
+
+/**
+ * Process all markdown image references in the given content string.
+ * Downloads or uploads each image and replaces the URL in-place.
+ *
+ * Per-image errors are non-fatal: the original URL is kept and a warning is logged.
+ */
+export async function processImages(
+	markdownContent: string,
+	tabId: number,
+	settings: Settings,
+	notePath?: string,
+	noteName?: string
+): Promise<string> {
+	// Build dynamic attachment folder: <notePath>/Images/<noteName>
+	// Falls back to static config.imageSavedFolder or 'Images'
+	const sanitize = (s: string) => s.trim().replace(/^\/+|\/+$/g, '').replace(/[\\:*?"<>|]/g, '-');
+	const parts = [notePath, 'Images', noteName]
+		.map(s => (s ? sanitize(s) : ''))
+		.filter(Boolean);
+	const dynamicAttachmentFolder = parts.length > 0
+		? parts.join('/')
+		: (settings.obsidianApiConfig?.imageSavedFolder?.trim().replace(/^\/+|\/+$/g, '') || 'Images');
+
+	const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+	const urlCache = new Map<string, string>();
+
+	// Collect all unique image URLs first
+	const imageMatches: Array<{ fullMatch: string; alt: string; url: string }> = [];
+	let match: RegExpExecArray | null;
+
+	while ((match = imageRegex.exec(markdownContent)) !== null) {
+		const [fullMatch, alt, url] = match;
+
+		// Skip data URIs (already embedded) and non-http URLs
+		if (url.startsWith('data:') || (!url.startsWith('http://') && !url.startsWith('https://'))) {
+			continue;
+		}
+
+		imageMatches.push({ fullMatch, alt, url });
+	}
+
+	if (imageMatches.length === 0) {
+		return markdownContent;
+	}
+
+	// Process each unique URL (deduplicated)
+	const uniqueUrls = [...new Set(imageMatches.map(m => m.url))];
+
+	await Promise.all(
+		uniqueUrls.map(async (originalUrl) => {
+			if (urlCache.has(originalUrl)) {
+				return;
+			}
+
+			try {
+				// Resolve to final URL (handles lazy-load / redirects)
+				const resolvedUrl = await resolveImageUrl(originalUrl, tabId);
+
+				// Fetch image bytes via content script
+				const { buffer, contentType } = await fetchImageViaContentScript(resolvedUrl, tabId);
+
+				let newUrl: string;
+
+				if (settings.imageSaveMode === 'local-rest-api') {
+					// Saves file to Obsidian vault via Local REST API, returns wiki-link
+					newUrl = await saveImageViaObsidianApi(buffer, contentType, resolvedUrl, settings.obsidianApiConfig, dynamicAttachmentFolder);
+				} else {
+					// Default: base64 embed (embed mode)
+					newUrl = toDataUri(buffer, contentType);
+				}
+
+				urlCache.set(originalUrl, newUrl);
+			} catch (error) {
+				// Keep original URL on failure
+				urlCache.set(originalUrl, originalUrl);
+			}
+		})
+	);
+
+	// Replace all occurrences in the markdown
+	return markdownContent.replace(imageRegex, (fullMatch, alt, url) => {
+		const newUrl = urlCache.get(url);
+		if (!newUrl || newUrl === url) return fullMatch;
+		// local-rest-api mode returns a complete wiki-link — use it verbatim
+		if (newUrl.startsWith('![[')) return newUrl;
+		return `![${alt}](${newUrl})`;
+	});
+}

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -46,7 +46,14 @@ export let generalSettings: Settings = {
 	},
 	history: [],
 	ratings: [],
-	saveBehavior: 'addToObsidian'
+	saveBehavior: 'addToObsidian',
+	downloadImages: false,
+	imageSaveMode: 'embed',
+	obsidianApiConfig: {
+		port: '27123',
+		apiKey: '',
+		imageSavedFolder: 'Images'
+	}
 };
 
 export function setLocalStorage(key: string, value: any): Promise<void> {
@@ -106,6 +113,15 @@ interface StorageData {
 	history?: HistoryEntry[];
 	ratings?: Rating[];
 	migrationVersion?: number;
+	image_settings?: {
+		downloadImages?: boolean;
+		imageSaveMode?: 'embed' | 'local-rest-api';
+		obsidianApiConfig?: {
+			port?: string;
+			apiKey?: string;
+			imageSavedFolder?: string;
+		};
+	};
 }
 
 const CURRENT_MIGRATION_VERSION = 1;
@@ -156,6 +172,13 @@ export async function loadSettings(): Promise<Settings> {
 		},
 		history: [],
 		ratings: [],
+		downloadImages: false,
+		imageSaveMode: 'embed',
+		obsidianApiConfig: {
+			port: '27123',
+			apiKey: '',
+			imageSavedFolder: 'Images'
+		}
 	};
 
 	// Update migration version if needed
@@ -212,7 +235,14 @@ export async function loadSettings(): Promise<Settings> {
 		stats: data.stats || defaultSettings.stats,
 		history: data.history || defaultSettings.history,
 		ratings: data.ratings || defaultSettings.ratings,
-		saveBehavior: data.general_settings?.saveBehavior ?? defaultSettings.saveBehavior
+		saveBehavior: data.general_settings?.saveBehavior ?? defaultSettings.saveBehavior,
+		downloadImages: data.image_settings?.downloadImages ?? defaultSettings.downloadImages,
+		imageSaveMode: data.image_settings?.imageSaveMode ?? defaultSettings.imageSaveMode,
+		obsidianApiConfig: {
+			port: data.image_settings?.obsidianApiConfig?.port ?? defaultSettings.obsidianApiConfig.port,
+			apiKey: data.image_settings?.obsidianApiConfig?.apiKey ?? defaultSettings.obsidianApiConfig.apiKey,
+			imageSavedFolder: data.image_settings?.obsidianApiConfig?.imageSavedFolder ?? defaultSettings.obsidianApiConfig.imageSavedFolder
+		}
 	};
 
 	generalSettings = loadedSettings;
@@ -265,7 +295,16 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 			highlightActiveLine: generalSettings.readerSettings.highlightActiveLine,
 			customCss: generalSettings.readerSettings.customCss
 		},
-		stats: generalSettings.stats
+		stats: generalSettings.stats,
+		image_settings: {
+			downloadImages: generalSettings.downloadImages,
+			imageSaveMode: generalSettings.imageSaveMode,
+			obsidianApiConfig: {
+				port: generalSettings.obsidianApiConfig.port,
+				apiKey: generalSettings.obsidianApiConfig.apiKey,
+				imageSavedFolder: generalSettings.obsidianApiConfig.imageSavedFolder
+			}
+		}
 	});
 }
 


### PR DESCRIPTION
#769 
feat: add image download and embedding support

## New Features
Introduce image processing for all three save actions (Add to Obsidian,
Save File, Copy to Clipboard) with two modes:

- embed: fetches remote images via the content script (bypasses CORS)
  and replaces URLs with base64 data URIs inline in the Markdown
- local-rest-api: uploads images to the Obsidian vault via the
  Obsidian Local REST API plugin, replacing URLs with wiki-links

## Test

- Run `npm run build` successfully.
- On Chrome and Edge, images from some of my frequently used websites download correctly.