### PR TITLE
Add clip directory presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1081,7 +1081,6 @@
 			"integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -1428,7 +1427,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1467,7 +1465,6 @@
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -1615,7 +1612,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2888,7 +2884,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3097,7 +3092,6 @@
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.78.0.tgz",
 			"integrity": "sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -3337,7 +3331,6 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
 			"integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -3443,7 +3436,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3555,7 +3547,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
 			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3626,7 +3617,6 @@
 			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -4204,7 +4194,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4356,7 +4345,6 @@
 			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -4406,7 +4394,6 @@
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -4476,7 +4463,6 @@
 			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -23,6 +23,9 @@
 	"addVaultPlaceholder": {
 		"message": "Press enter to add a vault"
 	},
+	"addDirectoryPlaceholder": {
+		"message": "Press enter to add a directory"
+	},
 	"advanced": {
 		"message": "Advanced"
 	},
@@ -173,6 +176,20 @@
 	},
 	"disableReader": {
 		"message": "Turn off reader"
+	},
+	"directories": {
+		"message": "Directories"
+	},
+	"directoriesDescription": {
+		"message": "Add folder presets for clipped notes. These presets appear in the clipper so you can quickly choose where to save each clip. Press $strong_start$enter$strong_end$ to add a directory.",
+		"placeholders": {
+			"strong_end": {
+				"content": "</strong>"
+			},
+			"strong_start": {
+				"content": "<strong>"
+			}
+		}
 	},
 	"done": {
 		"message": "Done"
@@ -821,6 +838,9 @@
 	},
 	"removeVault": {
 		"message": "Remove vault"
+	},
+	"removeDirectory": {
+		"message": "Remove directory"
 	},
 	"replaceContent": {
 		"message": "Replace the page content"

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -35,6 +35,7 @@ let templates: Template[] = [];
 let currentVariables: { [key: string]: string } = {};
 let currentTabId: number | undefined;
 let lastSelectedVault: string | null = null;
+let lastSelectedDirectory: string | null = null;
 
 const isSidePanel = window.location.pathname.includes('side-panel.html');
 const urlParams = new URLSearchParams(window.location.search);
@@ -189,7 +190,14 @@ async function initializeExtension(tabId: number) {
 		}
 		debugLog('Vaults', 'Last selected vault:', lastSelectedVault);
 
+		lastSelectedDirectory = await getLocalStorage('lastSelectedDirectory');
+		if (!lastSelectedDirectory && loadedSettings.clipDirectories.length > 0) {
+			lastSelectedDirectory = loadedSettings.clipDirectories[0];
+		}
+		debugLog('Directories', 'Last selected directory:', lastSelectedDirectory);
+
 		updateVaultDropdown(loadedSettings.vaults);
+		updateDirectoryDropdown(loadedSettings.clipDirectories);
 
 		const tab = await getTabInfo(tabId);
 		if (!tab.url || isBlankPage(tab.url)) {
@@ -834,13 +842,19 @@ function buildTemplateFieldsSkeleton(template: Template | null) {
 
 	const pathField = document.getElementById('path-name-field') as HTMLInputElement;
 	const pathContainer = document.querySelector('.vault-path-container') as HTMLElement;
+	const directoryContainer = document.getElementById('directory-container');
 	if (pathField && pathContainer) {
 		const isDailyNote = template.behavior === 'append-daily' || template.behavior === 'prepend-daily';
 		if (isDailyNote) {
 			pathField.style.display = 'none';
+			if (directoryContainer) {
+				directoryContainer.style.display = 'none';
+			}
 		} else {
 			pathContainer.style.display = 'flex';
+			pathField.style.display = 'block';
 			pathField.setAttribute('data-template-value', template.path);
+			updateDirectoryDropdown(loadedSettings.clipDirectories);
 		}
 	}
 
@@ -923,6 +937,7 @@ async function fillTemplateFieldValues(currentTabId: number, template: Template 
 	const pathField = document.getElementById('path-name-field') as HTMLInputElement;
 	if (pathField) {
 		pathField.value = formattedPath;
+		syncDirectoryDropdownWithPath(formattedPath);
 	}
 
 	const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
@@ -1066,11 +1081,62 @@ function updateVaultDropdown(vaults: string[]) {
 		vaultContainer.style.display = 'none';
 	}
 
-	// Add event listener to update lastSelectedVault when changed
-	vaultDropdown.addEventListener('change', () => {
+	// Update last selected vault when changed
+	vaultDropdown.onchange = () => {
 		lastSelectedVault = vaultDropdown.value;
 		setLocalStorage('lastSelectedVault', lastSelectedVault);
+	};
+}
+
+function updateDirectoryDropdown(directories: string[]) {
+	const directoryDropdown = document.getElementById('directory-select') as HTMLSelectElement | null;
+	const directoryContainer = document.getElementById('directory-container');
+	const pathField = document.getElementById('path-name-field') as HTMLInputElement | null;
+
+	if (!directoryDropdown || !directoryContainer) return;
+
+	directoryDropdown.textContent = '';
+
+	directories.forEach(directory => {
+		const option = document.createElement('option');
+		option.value = directory;
+		option.textContent = directory;
+		directoryDropdown.appendChild(option);
 	});
+
+	if (directories.length > 0) {
+		directoryContainer.style.display = 'block';
+
+		const preferredDirectory = pathField?.value || lastSelectedDirectory;
+		if (preferredDirectory && directories.includes(preferredDirectory)) {
+			directoryDropdown.value = preferredDirectory;
+		} else {
+			directoryDropdown.value = directories[0];
+		}
+	} else {
+		directoryContainer.style.display = 'none';
+	}
+
+	directoryDropdown.onchange = () => {
+		const selectedDirectory = directoryDropdown.value;
+		lastSelectedDirectory = selectedDirectory;
+		setLocalStorage('lastSelectedDirectory', selectedDirectory);
+		if (pathField) {
+			pathField.value = selectedDirectory;
+		}
+	};
+}
+
+function syncDirectoryDropdownWithPath(pathValue: string) {
+	const directoryDropdown = document.getElementById('directory-select') as HTMLSelectElement | null;
+	if (!directoryDropdown || directoryDropdown.options.length === 0) return;
+
+	const hasMatch = Array.from(directoryDropdown.options).some(option => option.value === pathValue);
+	if (hasMatch) {
+		directoryDropdown.value = pathValue;
+		lastSelectedDirectory = pathValue;
+		setLocalStorage('lastSelectedDirectory', pathValue);
+	}
 }
 
 function refreshPopup() {
@@ -1337,6 +1403,11 @@ async function handleClipObsidian(): Promise<void> {
 		if (!currentTemplate.vault) {
 			lastSelectedVault = selectedVault;
 			await setLocalStorage('lastSelectedVault', lastSelectedVault);
+		}
+
+		if (path) {
+			lastSelectedDirectory = path;
+			await setLocalStorage('lastSelectedDirectory', lastSelectedDirectory);
 		}
 
 		if (!isSidePanel) {

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -67,6 +67,44 @@ export function updateVaultList(): void {
 	initializeIcons(vaultList);
 }
 
+export function updateDirectoryList(): void {
+	const directoryList = document.getElementById('directory-list') as HTMLUListElement;
+	if (!directoryList) return;
+
+	directoryList.textContent = '';
+	generalSettings.clipDirectories.forEach((directory, index) => {
+		const li = document.createElement('li');
+		li.dataset.index = index.toString();
+		li.draggable = true;
+
+		const dragHandle = createElementWithClass('div', 'drag-handle');
+		dragHandle.appendChild(createElementWithHTML('i', '', { 'data-lucide': 'grip-vertical' }));
+		li.appendChild(dragHandle);
+
+		const span = document.createElement('span');
+		span.textContent = directory;
+		li.appendChild(span);
+
+		const removeBtn = createElementWithClass('button', 'setting-item-list-remove clickable-icon');
+		removeBtn.setAttribute('type', 'button');
+		removeBtn.setAttribute('aria-label', getMessage('removeDirectory'));
+		removeBtn.appendChild(createElementWithHTML('i', '', { 'data-lucide': 'trash-2' }));
+		li.appendChild(removeBtn);
+
+		li.addEventListener('dragstart', handleDragStart);
+		li.addEventListener('dragover', handleDragOver);
+		li.addEventListener('drop', handleDrop);
+		li.addEventListener('dragend', handleDragEnd);
+		removeBtn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			removeDirectory(index);
+		});
+		directoryList.appendChild(li);
+	});
+
+	initializeIcons(directoryList);
+}
+
 export function addVault(vault: string): void {
 	generalSettings.vaults.push(vault);
 	saveSettings();
@@ -77,6 +115,18 @@ export function removeVault(index: number): void {
 	generalSettings.vaults.splice(index, 1);
 	saveSettings();
 	updateVaultList();
+}
+
+export function addDirectory(directory: string): void {
+	generalSettings.clipDirectories.push(directory);
+	saveSettings();
+	updateDirectoryList();
+}
+
+export function removeDirectory(index: number): void {
+	generalSettings.clipDirectories.splice(index, 1);
+	saveSettings();
+	updateDirectoryList();
 }
 
 export async function setShortcutInstructions() {
@@ -212,11 +262,13 @@ export function initializeGeneralSettings(): void {
 		}
 
 		updateVaultList();
+		updateDirectoryList();
 		initializeShowMoreActionsToggle();
 		initializeBetaFeaturesToggle();
 		initializeLegacyModeToggle();
 		initializeSilentOpenToggle();
 		initializeVaultInput();
+		initializeDirectoryInput();
 		initializeOpenBehaviorDropdown();
 		initializeKeyboardShortcuts();
 		initializeToggles();
@@ -288,6 +340,22 @@ function initializeVaultInput(): void {
 				if (newVault) {
 					addVault(newVault);
 					vaultInput.value = '';
+				}
+			}
+		});
+	}
+}
+
+function initializeDirectoryInput(): void {
+	const directoryInput = document.getElementById('directory-input') as HTMLInputElement;
+	if (directoryInput) {
+		directoryInput.addEventListener('keypress', (e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				const newDirectory = directoryInput.value.trim();
+				if (newDirectory) {
+					addDirectory(newDirectory);
+					directoryInput.value = '';
 				}
 			}
 		});

--- a/src/popup.html
+++ b/src/popup.html
@@ -52,6 +52,9 @@
 					<div id="vault-container" style="display: none;">
 						<select id="vault-select"></select>
 					</div>
+					<div id="directory-container" style="display: none;">
+						<select id="directory-select" data-i18n-title="directories"></select>
+					</div>
 					<input id="path-name-field" type="text" data-i18n="folder"/>
 				</div>
 				<div id="interpreter" style="display: none;">

--- a/src/settings.html
+++ b/src/settings.html
@@ -131,6 +131,14 @@
 								<ul id="vault-list" class="setting-item-list"></ul>
 								</div>
 							</div>
+							<div class="setting-group">
+								<div class="setting-item setting-item-heading"><h3 data-i18n="directories">Directories</h3></div>
+								<div class="setting-items">
+								<div class="setting-item-description" data-i18n="directoriesDescription">Add folder presets for clipped notes. These presets appear in the clipper so you can quickly choose where to save each clip. Press <strong>enter</strong> to add a directory.</div>
+								<input type="text" id="directory-input" data-i18n="addDirectoryPlaceholder" placeholder="Press enter to add a directory" autocomplete="off" spellcheck="false" />
+								<ul id="directory-list" class="setting-item-list"></ul>
+								</div>
+							</div>
 							<div class="setting-group" id="hotkeys-subsection">
 								<div class="setting-item setting-item-heading"><h3 data-i18n="hotkeys">Hotkeys</h3></div>
 								<div class="setting-items">

--- a/src/side-panel.html
+++ b/src/side-panel.html
@@ -56,6 +56,9 @@
 					<div id="vault-container" style="display: none;">
 						<select id="vault-select"></select>
 					</div>
+					<div id="directory-container" style="display: none;">
+						<select id="directory-select" data-i18n-title="directories"></select>
+					</div>
 					<input id="path-name-field" type="text" data-i18n="folder"/>
 				</div>
 				<div id="interpreter" style="display: none;">

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -161,9 +161,17 @@
 		#vault-container {
 			flex-grow: 1;
 		}
+		#directory-container {
+			flex-grow: 1;
+		}
 		#vault-select {
 			font-weight: var(--clipper-select-font-weight);
 			min-width: 100px;
+			cursor: default;
+		}
+		#directory-select {
+			font-weight: var(--clipper-select-font-weight);
+			min-width: 130px;
 			cursor: default;
 		}
 	}

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -367,6 +367,12 @@
 	}
 }
 
+#directory-list {
+	.setting-item-list-remove {
+		margin-inline-start: auto;
+	}
+}
+
 .setting-item-list {
 	display: flex;
 	flex-direction: column;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -71,6 +71,7 @@ export interface ReaderSettings {
 
 export interface Settings {
 	vaults: string[];
+	clipDirectories: string[];
 	showMoreActionsButton: boolean;
 	betaFeatures: boolean;
 	legacyMode: boolean;

--- a/src/utils/cli-stubs.ts
+++ b/src/utils/cli-stubs.ts
@@ -8,6 +8,7 @@ export default {} as any;
 
 export const generalSettings: Settings = {
 	vaults: [],
+	clipDirectories: [],
 	betaFeatures: false,
 	legacyMode: false,
 	silentOpen: false,

--- a/src/utils/drag-and-drop.ts
+++ b/src/utils/drag-and-drop.ts
@@ -1,7 +1,7 @@
 import { Template, Property } from '../types/types';
 import { templates, getTemplates, saveTemplateSettings, getEditingTemplateIndex } from '../managers/template-manager';
 import { updateTemplateList } from '../managers/template-ui';
-import { updateVaultList } from '../managers/general-settings';
+import { updateVaultList, updateDirectoryList } from '../managers/general-settings';
 import { generalSettings, saveSettings } from './storage-utils';
 import { initializeModelList } from '../managers/interpreter-settings';
 import { initializeIcons } from '../icons/icons';
@@ -13,6 +13,7 @@ export function initializeDragAndDrop(): void {
 		document.getElementById('template-list'),
 		document.getElementById('template-properties'),
 		document.getElementById('vault-list'),
+		document.getElementById('directory-list'),
 		document.getElementById('model-list')
 	];
 
@@ -71,6 +72,8 @@ export function handleDrop(e: DragEvent): void {
 			handlePropertyReorder(draggedItemId, newIndex);
 		} else if (list.id === 'vault-list') {
 			handleVaultReorder(newIndex);
+		} else if (list.id === 'directory-list') {
+			handleDirectoryReorder(newIndex);
 		} else if (list.id === 'model-list') {
 			handleModelReorder(newIndex);
 		}
@@ -158,6 +161,17 @@ function handleVaultReorder(newIndex: number): void {
 		generalSettings.vaults.splice(newIndex, 0, movedVault);
 		saveSettings();
 		updateVaultList();
+	}
+}
+
+function handleDirectoryReorder(newIndex: number): void {
+	if (!draggedElement) return;
+	const oldIndex = parseInt(draggedElement.dataset.index || '-1');
+	if (oldIndex !== -1 && oldIndex !== newIndex) {
+		const [movedDirectory] = generalSettings.clipDirectories.splice(oldIndex, 1);
+		generalSettings.clipDirectories.splice(newIndex, 0, movedDirectory);
+		saveSettings();
+		updateDirectoryList();
 	}
 }
 

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -7,6 +7,7 @@ export type { Settings, ModelConfig, PropertyType, HistoryEntry, Provider, Ratin
 
 export let generalSettings: Settings = {
 	vaults: [],
+	clipDirectories: [],
 	betaFeatures: false,
 	legacyMode: false,
 	silentOpen: false,
@@ -67,6 +68,7 @@ interface StorageData {
 		saveBehavior?: 'addToObsidian' | 'copyToClipboard' | 'saveFile';
 	};
 	vaults?: string[];
+	clip_directories?: string[];
 	highlighter_settings?: {
 		highlighterEnabled?: boolean;
 		alwaysShowHighlights?: boolean;
@@ -116,6 +118,7 @@ export async function loadSettings(): Promise<Settings> {
 	// Load default settings first
 	const defaultSettings: Settings = {
 		vaults: [],
+		clipDirectories: [],
 		showMoreActionsButton: false,
 		betaFeatures: false,
 		legacyMode: false,
@@ -166,6 +169,7 @@ export async function loadSettings(): Promise<Settings> {
 
 	// Validate and sanitize data to prevent corruption
 	const sanitizedVaults = Array.isArray(data.vaults) ? data.vaults.filter(v => typeof v === 'string') : [];
+	const sanitizedClipDirectories = Array.isArray(data.clip_directories) ? data.clip_directories.filter(v => typeof v === 'string') : [];
 	const sanitizedModels = Array.isArray(data.interpreter_settings?.models) 
 		? data.interpreter_settings.models.filter(m => m && typeof m === 'object' && typeof m.id === 'string') 
 		: [];
@@ -176,6 +180,7 @@ export async function loadSettings(): Promise<Settings> {
 	// Load user settings
 	const loadedSettings: Settings = {
 		vaults: sanitizedVaults.length > 0 ? sanitizedVaults : defaultSettings.vaults,
+		clipDirectories: sanitizedClipDirectories.length > 0 ? sanitizedClipDirectories : defaultSettings.clipDirectories,
 		showMoreActionsButton: data.general_settings?.showMoreActionsButton ?? defaultSettings.showMoreActionsButton,
 		betaFeatures: data.general_settings?.betaFeatures ?? defaultSettings.betaFeatures,
 		legacyMode: data.general_settings?.legacyMode ?? defaultSettings.legacyMode,
@@ -227,6 +232,7 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 
 	await browser.storage.sync.set({
 		vaults: generalSettings.vaults,
+		clip_directories: generalSettings.clipDirectories,
 		general_settings: {
 			showMoreActionsButton: generalSettings.showMoreActionsButton,
 			betaFeatures: generalSettings.betaFeatures,


### PR DESCRIPTION
## Summary
- add configurable clip directory presets in General settings
- add directory picker in popup and side panel for quick destination selection
- persist selected directory and sync it with the folder path field
- support add/remove/reorder for directory presets

## Testing
- npm test (baseline failures remain in template integration tests)