### PR TITLE
fix: use Gemini native API to fix #790

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -45,7 +45,7 @@
 		"apiKeyUrl": "https://aistudio.google.com/apikey",
 		"apiKeyRequired": true,
 		"modelsList": "https://ai.google.dev/gemini-api/docs/models",
-		"baseUrl": "https://generativelanguage.googleapis.com/v1beta/chat/completions",
+		"baseUrl": "https://generativelanguage.googleapis.com/v1beta/models/{model-id}:generateContent",
 		"popularModels": [
 			{ "id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash" },
 			{ "id": "gemini-2.5-flash-lite", "name": "Gemini 2.5 Flash Lite" },

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -134,6 +134,23 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 				temperature: 0.5,
 				stream: false
 			};
+		} else if (provider.name.toLowerCase().includes('gemini')) {
+			requestUrl = provider.baseUrl.replace('{model-id}', model.providerModelId);
+			requestBody = {
+				system_instruction: {
+					parts: [{ text: systemContent }]
+				},
+				contents: [{
+					parts: [
+						{ text: `${promptContext}` },
+						{ text: `${JSON.stringify(promptContent)}` }
+					]
+				}]
+			};
+			headers = {
+				...headers,
+				'x-goog-api-key': `${provider.apiKey}`
+			};
 		} else {
 			// Default request format
 			requestUrl = provider.baseUrl;
@@ -215,6 +232,18 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 					llmResponseContent = JSON.stringify(parsed);
 				} catch {
 					llmResponseContent = messageContent;
+				}
+			} else {
+				llmResponseContent = JSON.stringify(data);
+			}
+		} else if (provider.name.toLowerCase().includes('gemini')) {
+			const textContent = data.candidates?.[0].content.parts.find((p: any) => !p.thought)?.text;
+			if (textContent) {
+				try {
+					const parsed = JSON.parse(textContent);
+					llmResponseContent = JSON.stringify(parsed);
+				} catch {
+					llmResponseContent = textContent;
 				}
 			} else {
 				llmResponseContent = JSON.stringify(data);


### PR DESCRIPTION
fixes #790 

Trying to use Gemini just gives an error: `Multiple authentication credentials received. Please pass only one`. This is because they recently changed their API key format to this AQ-prefix (AQ.8BRn...) which broke the OpenAI-compatible endpoint. So I just made it call the native API instead.

Changes:
- use `generateContent` instead of `chat/completions`.
- add Gemini's unique request & response formatting.

It works from my testing:
<img width="1564" height="465" alt="Screenshot 2026-04-17 214936" src="https://github.com/user-attachments/assets/4c318d8d-ebf2-4b5d-b814-4545ba198aba" />
