### PR TITLE
Fix #745: CLI empty title, metaTags, description

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -178,11 +178,13 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 
 	// Use pre-parsed document if provided, otherwise parse
 	const doc = parsedDocument ?? documentParser.parseFromString(html, 'text/html');
-	const documentElement = doc.documentElement || doc;
 
-	// Extract content with defuddle
-	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
-	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
+	// Extract content with defuddle.
+	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document.
+	// Pass the full `doc` rather than `doc.documentElement`; on linkedom the element root
+	// does not expose <head> meta tags, which leaves title/metaTags empty.
+	// This matches the usage in template-integration.test.ts.
+	const defuddle = new DefuddleClass(doc as unknown as Document, { url });
 	const defuddleResult = defuddle.parse();
 
 	// Convert to markdown


### PR DESCRIPTION
## Summary

Closes #745. The CLI’s `clip()` passes `doc.documentElement` to Defuddle, but on linkedom the element root does not expose `<head>` meta tags, so every field sourced from meta (title, description, published, metaTags, `{{meta:name:citation_*}}`, `{{meta:property:og:*}}`) comes back empty.

Passing the full `doc` fixes it. This is already how `src/utils/template-integration.test.ts` instantiates Defuddle, so this change brings `api.ts` in line with the tests.

## Repro

​```bash
npm run build:cli
node dist/cli.cjs https://example.com -t template.json
​```

Before: empty title, empty content, empty meta lookups.
After: populated as expected.

## Scope

`clip()` is only called from `src/cli.ts`. The browser extension goes through its own path (`popup.ts` / `content.ts`) and does not use this function, so this is CLI-only.

## Tests

The 560 passing tests still pass. The 3 pre-existing timezone-related fixture failures (YouTube, edge-cases, minimal) are unrelated—they also fail on `main` without this change, and there's an open PR (#750) addressing them.