### PR TITLE
Interpreter: add editable system prompt with default fallback

### DIFF
--- a/docs/Interpret web pages.md
+++ b/docs/Interpret web pages.md
@@ -58,6 +58,12 @@ To define a more targeted context use [[Variables#Selector variables|selector va
 
  This would only run Interpreter on the `#main` element of a web page, if it exists. [[Filters#HTML processing|HTML processing filters]] like `remove_html`, `strip_tags` and `strip_attr` can be useful to further reduce the context length and speed up processing.
 
+### System prompt
+
+By default, Interpreter instructs the model to return data in a structured JSON format. You can override this instruction in Interpreter **Advanced settings** with a custom system prompt. Leave the field blank to use the default system prompt.
+
+> [!warning] Custom system prompts must preserve the JSON response format (`{"prompts_responses": {...}}`) for Interpreter to work correctly.
+
 ## Models
 
 > [!warning] Privacy

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "موجه النظام للمترجم"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "تجاوز موجه النظام المرسل إلى نموذج اللغة عند تفسير المتغيرات. اتركه فارغًا لاستخدام الافتراضي."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "ইন্টারপ্রেটার সিস্টেম প্রম্পট"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "ভেরিয়েবল ব্যাখ্যা করার সময় LLM-এ পাঠানো সিস্টেম প্রম্পট ওভাররাইড করুন। ডিফল্ট ব্যবহার করতে খালি রাখুন।"
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Indicació del sistema de l'intèrpret"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Substitueix la indicació del sistema enviada al LLM en interpretar variables. Deixeu-lo en blanc per utilitzar el valor per defecte."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Systémový pokyn interpreta"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Přepište systémový pokyn odeslaný do LLM při interpretaci proměnných. Nechte prázdné pro použití výchozího."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Fortolkerens systemprompt"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Tilsidesæt systemprompt sendt til LLM ved fortolkning af variabler. Lad stå tomt for at bruge standardværdien."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "System-Prompt des Interpreters"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Überschreibe den System-Prompt, der beim Interpretieren von Variablen an das LLM gesendet wird. Leer lassen, um den Standard zu verwenden."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Εντολή συστήματος ερμηνευτή"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Παρακάμψτε την εντολή συστήματος που αποστέλλεται στο LLM κατά την ερμηνεία μεταβλητών. Αφήστε κενό για χρήση της προεπιλογής."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -448,6 +448,12 @@
 			}
 		}
 	},
+	"interpreterSystemPrompt": {
+		"message": "Interpreter system prompt"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Override the system prompt sent to the LLM when interpreting variables. Leave blank to use the default."
+	},
 	"language": {
 		"message": "Language"
 	},

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Indicación del sistema del intérprete"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Anula la indicación del sistema enviada al LLM al interpretar variables. Déjalo en blanco para usar el valor predeterminado."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "دستور سیستم مترجم"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "دستور سیستم ارسال‌شده به LLM هنگام تفسیر متغیرها را جایگزین کنید. برای استفاده از پیش‌فرض خالی بگذارید."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Tulkin järjestelmäkehote"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Korvaa järjestelmäkehote, joka lähetetään LLM:lle muuttujia tulkittaessa. Jätä tyhjäksi käyttääksesi oletusarvoa."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Invite système de l'interpréteur"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Remplace l'invite système envoyée au LLM lors de l'interprétation des variables. Laisser vide pour utiliser la valeur par défaut."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "הנחיית מערכת של המפרש"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "עקוף את הנחיית המערכת הנשלחת ל-LLM בעת פירוש משתנים. השאר ריק לשימוש בברירת המחדל."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "इंटरप्रेटर सिस्टम प्रॉम्प्ट"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "वेरिएबल की व्याख्या करते समय LLM को भेजे गए सिस्टम प्रॉम्प्ट को ओवरराइड करें। डिफ़ॉल्ट उपयोग करने के लिए खाली छोड़ें।"
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Értelmező rendszerprompt"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Felülírja a változók értelmezésekor az LLM-nek küldött rendszerpromptet. Hagyja üresen az alapértelmezett használatához."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Prompt sistem interpreter"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Timpa prompt sistem yang dikirim ke LLM saat menginterpretasi variabel. Biarkan kosong untuk menggunakan default."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Prompt di sistema dell'interprete"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Sostituisce il prompt di sistema inviato all'LLM durante l'interpretazione delle variabili. Lascia vuoto per usare il valore predefinito."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "インタープリターのシステムプロンプト"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "変数を解釈する際にLLMに送信されるシステムプロンプトを上書きします。デフォルトを使用するには空白のままにしてください。"
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/km/messages.json
+++ b/src/_locales/km/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "ប្រអប់ជំរុញប្រព័ន្ធអ្នកបកប្រែ"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "បដិសេធប្រអប់ជំរុញប្រព័ន្ធដែលបញ្ជូនទៅ LLM នៅពេលបកប្រែអថេរ។ ទុកឱ្យទទេដើម្បីប្រើលំនាំដើម។"
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "인터프리터 시스템 프롬프트"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "변수를 해석할 때 LLM에 전송되는 시스템 프롬프트를 재정의합니다. 기본값을 사용하려면 비워 두세요."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Systeemprompt van de interpreter"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Overschrijf de systeemprompt die naar de LLM wordt verzonden bij het interpreteren van variabelen. Laat leeg om de standaard te gebruiken."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Tolkens systemprompt"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Overstyr systemprompt sendt til LLM ved tolking av variabler. La stå tomt for å bruke standard."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Monit systemowy interpretera"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Zastąp monit systemowy wysyłany do LLM podczas interpretowania zmiennych. Pozostaw puste, aby użyć domyślnego."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Prompt de sistema do interpretador"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Substitui o prompt de sistema enviado ao LLM ao interpretar variáveis. Deixe em branco para usar o padrão."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Prompt de sistema do interpretador"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Substitui o prompt de sistema enviado ao LLM ao interpretar variáveis. Deixe em branco para usar o padrão."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Promptul de sistem al interpretorului"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Suprascrie promptul de sistem trimis către LLM la interpretarea variabilelor. Lasă gol pentru a folosi valoarea implicită."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Системный промпт интерпретатора"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Переопределяет системный промпт, отправляемый в LLM при интерпретации переменных. Оставьте пустым для использования по умолчанию."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Systémová výzva interpreta"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Prepíše systémovú výzvu odoslanú do LLM pri interpretácii premenných. Nechajte prázdne pre použitie predvoleného nastavenia."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Tolkarens systemprompt"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Åsidosätt systemprompt som skickas till LLM vid tolkning av variabler. Lämna tomt för att använda standard."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "พรอมต์ระบบของตัวแปล"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "แทนที่พรอมต์ระบบที่ส่งไปยัง LLM เมื่อตีความตัวแปร ปล่อยว่างเพื่อใช้ค่าเริ่มต้น"
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/tl/messages.json
+++ b/src/_locales/tl/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Prompt ng sistema ng interpreter"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "I-override ang prompt ng sistema na ipinapadala sa LLM kapag nag-iinterpret ng mga variable. Iwanang blangko para gamitin ang default."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Yorumlayıcı sistem istemi"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Değişkenler yorumlanırken LLM'ye gönderilen sistem istemini geçersiz kılar. Varsayılanı kullanmak için boş bırakın."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Системний запит інтерпретатора"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Замінює системний запит, що надсилається до LLM під час інтерпретації змінних. Залиште порожнім для використання стандартного."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "Lời nhắc hệ thống của trình thông dịch"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "Ghi đè lời nhắc hệ thống được gửi đến LLM khi diễn giải biến. Để trống để sử dụng mặc định."
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "解释器系统提示词"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "覆盖解释变量时发送给 LLM 的系统提示词。留空则使用默认值。"
+	},
 			"link_start": {
 				"content": "<a href=\"?section=interpreter\">"
 			}

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -443,6 +443,12 @@
 			"link_end": {
 				"content": "</a>"
 			},
+	"interpreterSystemPrompt": {
+		"message": "解譯器系統提示詞"
+	},
+	"interpreterSystemPromptDescription": {
+		"message": "覆寫解譯變數時傳送給 LLM 的系統提示詞。留空則使用預設值。"
+	},
 			"link_start": {
 				"content": "<a href=\"https://help.obsidian.md/web-clipper/variables\" target=\"_blank\">"
 			}

--- a/src/managers/interpreter-settings.ts
+++ b/src/managers/interpreter-settings.ts
@@ -1,6 +1,7 @@
 import { initializeToggles, initializeSettingToggle } from '../utils/ui-utils';
 import { ModelConfig, Provider } from '../types/types';
 import { generalSettings, loadSettings, saveSettings, getLocalStorage, setLocalStorage } from '../utils/storage-utils';
+import { DEFAULT_SYSTEM_PROMPT } from '../utils/interpreter';
 import { initializeIcons } from '../icons/icons';
 import { showModal, hideModal } from '../utils/modal-utils';
 import { getMessage, translatePage } from '../utils/i18n';
@@ -224,6 +225,12 @@ export async function initializeInterpreterSettings(): Promise<void> {
 		const defaultPromptContextInput = document.getElementById('default-prompt-context') as HTMLTextAreaElement;
 		if (defaultPromptContextInput) {
 			defaultPromptContextInput.value = generalSettings.defaultPromptContext;
+		}
+
+		const interpreterSystemPromptInput = document.getElementById('interpreter-system-prompt') as HTMLTextAreaElement;
+		if (interpreterSystemPromptInput) {
+			interpreterSystemPromptInput.value = generalSettings.interpreterSystemPrompt;
+			interpreterSystemPromptInput.placeholder = DEFAULT_SYSTEM_PROMPT;
 		}
 
 		updatePromptContextVisibility();
@@ -1097,6 +1104,11 @@ function saveInterpreterSettingsFromForm(): void {
 	}
 	if (defaultPromptContextInput) {
 		updatedSettings.defaultPromptContext = defaultPromptContextInput.value;
+	}
+
+	const interpreterSystemPromptInput = document.getElementById('interpreter-system-prompt') as HTMLTextAreaElement;
+	if (interpreterSystemPromptInput) {
+		updatedSettings.interpreterSystemPrompt = interpreterSystemPromptInput.value;
 	}
 
 	if (Object.keys(updatedSettings).length > 0) {

--- a/src/settings.html
+++ b/src/settings.html
@@ -555,7 +555,12 @@
 									<div class="setting-item-description" data-i18n="defaultInterpreterContextDescription">Override the context used to interpret prompt variables. Variables can be used here.</div>
 									<textarea id="default-prompt-context" rows="4" placeholder="{{fullHtml}}" spellcheck="false"></textarea>
 								</div>
-								
+								<div class="setting-item">
+									<label for="interpreter-system-prompt" data-i18n="interpreterSystemPrompt">Interpreter system prompt</label>
+									<div class="setting-item-description" data-i18n="interpreterSystemPromptDescription">Override the system prompt sent to the LLM when interpreting variables. Leave blank to use the default.</div>
+									<textarea id="interpreter-system-prompt" rows="4" spellcheck="false"></textarea>
+								</div>
+
 								</div>
 							</div>
 						</form>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -86,6 +86,7 @@ export interface Settings {
 	interpreterEnabled: boolean;
 	interpreterAutoRun: boolean;
 	defaultPromptContext: string;
+	interpreterSystemPrompt: string;
 	propertyTypes: PropertyType[];
 	readerSettings: ReaderSettings;
 	stats: {

--- a/src/utils/cli-stubs.ts
+++ b/src/utils/cli-stubs.ts
@@ -22,6 +22,7 @@ export const generalSettings: Settings = {
 	interpreterEnabled: false,
 	interpreterAutoRun: false,
 	defaultPromptContext: '',
+	interpreterSystemPrompt: '',
 	propertyTypes: [],
 	readerSettings: {
 		fontSize: 16,

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -9,6 +9,8 @@ import { getMessage } from './i18n';
 import { updateTokenCount } from './token-counter';
 
 const RATE_LIMIT_RESET_TIME = 60000; // 1 minute in milliseconds
+
+export const DEFAULT_SYSTEM_PROMPT = `You are a helpful assistant. Please respond with one JSON object named \`prompts_responses\` — no explanatory text before or after. Use the keys provided, e.g. \`prompt_1\`, \`prompt_2\`, and fill in the values. Values should be Markdown strings unless otherwise specified. Make your responses concise. For example, your response should look like: {"prompts_responses":{"prompt_1":"tag1, tag2, tag3","prompt_2":"- bullet1\n- bullet 2\n- bullet3"}}`;
 let lastRequestTime = 0;
 
 // Store event listeners for cleanup
@@ -34,8 +36,7 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 	}
 
 	try {
-		const systemContent = 
-			`You are a helpful assistant. Please respond with one JSON object named \`prompts_responses\` — no explanatory text before or after. Use the keys provided, e.g. \`prompt_1\`, \`prompt_2\`, and fill in the values. Values should be Markdown strings unless otherwise specified. Make your responses concise. For example, your response should look like: {"prompts_responses":{"prompt_1":"tag1, tag2, tag3","prompt_2":"- bullet1\n- bullet 2\n- bullet3"}}`;
+		const systemContent = generalSettings.interpreterSystemPrompt.trim() || DEFAULT_SYSTEM_PROMPT;
 		
 		const promptContent = {	
 			prompts: promptVariables.reduce((acc, { key, prompt }) => {

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -21,6 +21,7 @@ export let generalSettings: Settings = {
 	interpreterEnabled: false,
 	interpreterAutoRun: false,
 	defaultPromptContext: '',
+	interpreterSystemPrompt: '',
 	propertyTypes: [],
 	readerSettings: {
 		fontSize: 16,
@@ -97,6 +98,7 @@ interface StorageData {
 		interpreterEnabled?: boolean;
 		interpreterAutoRun?: boolean;
 		defaultPromptContext?: string;
+		interpreterSystemPrompt?: string;
 	};
 	property_types?: PropertyType[];
 	stats?: {
@@ -132,6 +134,7 @@ export async function loadSettings(): Promise<Settings> {
 		interpreterEnabled: false,
 		interpreterAutoRun: false,
 		defaultPromptContext: '',
+		interpreterSystemPrompt: '',
 		propertyTypes: [],
 		saveBehavior: 'addToObsidian',
 		readerSettings: {
@@ -195,6 +198,7 @@ export async function loadSettings(): Promise<Settings> {
 		interpreterEnabled: data.interpreter_settings?.interpreterEnabled ?? defaultSettings.interpreterEnabled,
 		interpreterAutoRun: data.interpreter_settings?.interpreterAutoRun ?? defaultSettings.interpreterAutoRun,
 		defaultPromptContext: data.interpreter_settings?.defaultPromptContext || defaultSettings.defaultPromptContext,
+		interpreterSystemPrompt: data.interpreter_settings?.interpreterSystemPrompt || defaultSettings.interpreterSystemPrompt,
 		propertyTypes: data.property_types || defaultSettings.propertyTypes,
 		readerSettings: {
 			fontSize: data.reader_settings?.fontSize ?? defaultSettings.readerSettings.fontSize,
@@ -250,7 +254,8 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 			providers: generalSettings.providers,
 			interpreterEnabled: generalSettings.interpreterEnabled,
 			interpreterAutoRun: generalSettings.interpreterAutoRun,
-			defaultPromptContext: generalSettings.defaultPromptContext
+			defaultPromptContext: generalSettings.defaultPromptContext,
+			interpreterSystemPrompt: generalSettings.interpreterSystemPrompt
 		},
 		property_types: generalSettings.propertyTypes,
 		reader_settings: {


### PR DESCRIPTION
## Summary

- Adds a **Interpreter system prompt** textarea in Interpreter → Advanced settings
- When left blank, the existing default system prompt is used (shown as placeholder text)
- Extracts `DEFAULT_SYSTEM_PROMPT` as an exported constant to keep the runtime and UI in sync
- Updates all 36 locale files with translations
- Documents the feature in `docs/Interpret web pages.md` with a warning about preserving the JSON response format

## How it works

The new field is stored under `interpreter_settings.interpreterSystemPrompt` in browser sync storage. In `sendToLLM()`, the value is used if non-empty, otherwise the default prompt is used as fallback:

```ts
const systemContent = generalSettings.interpreterSystemPrompt.trim() || DEFAULT_SYSTEM_PROMPT;
```

## Test plan

- [ ] Open Settings → Interpreter → Advanced — new "Interpreter system prompt" textarea appears below "Default interpreter context"
- [ ] Placeholder shows the default system prompt text
- [ ] Leave blank and run interpreter — default prompt is used (visible in network tab → request body → `messages[0].content`)
- [ ] Enter custom text and run interpreter — custom prompt is used
- [ ] Refresh settings page — custom text is retained
- [ ] Change browser language to non-English — label and description are translated