### PR TITLE
feat: implement automatic decryption for BOSS Zhipin salary data

### DIFF
--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -380,3 +380,10 @@ Removes duplicate values from arrays and objects.
 - For arrays of objects: `[{"a":1},{"b":2},{"a":1}]|unique` returns `[{"a":1},{"b":2}]`.
 - For objects it removes properties with duplicate values, keeping the last occurrence's key.
 - For strings it returns the input unchanged.
+
+### `boss_decrypt`
+
+Decrypts obfuscated text on BOSS Zhipin (mainly salary data). It converts specific icon-font characters back to numbers.
+
+- `"\ue033\ue034K"|boss_decrypt` returns `"23K"`.
+- Supports mixed text and arrays of strings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1081,7 +1081,6 @@
 			"integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -1428,7 +1427,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1467,7 +1465,6 @@
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -1615,7 +1612,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2888,7 +2884,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3097,7 +3092,6 @@
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.78.0.tgz",
 			"integrity": "sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -3337,7 +3331,6 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
 			"integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -3443,7 +3436,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3555,7 +3547,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
 			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3626,7 +3617,6 @@
 			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -4204,7 +4194,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4356,7 +4345,6 @@
 			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -4406,7 +4394,6 @@
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -4476,7 +4463,6 @@
 			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}

--- a/src/content.ts
+++ b/src/content.ts
@@ -10,6 +10,7 @@ import { saveFile } from './utils/file-utils';
 import { debugLog } from './utils/debug';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './utils/iframe-resize';
 import { parseForClip } from './utils/clip-utils';
+import { boss_decrypt } from './utils/filters/boss_decrypt';
 
 declare global {
 	interface Window {
@@ -219,6 +220,15 @@ declare global {
 				const extractedContent: { [key: string]: string } = {
 					...defuddled.variables,
 				};
+
+                                // Auto-decrypt for BOSS Zhipin (Option A)
+                                if (document.URL.includes("zhipin.com")) {
+                                        Object.keys(extractedContent).forEach(key => {
+                                                extractedContent[key] = boss_decrypt(extractedContent[key]) as string;
+                                        });
+                                        if (defuddled.title) defuddled.title = boss_decrypt(defuddled.title) as string;
+                                        if (defuddled.content) defuddled.content = boss_decrypt(defuddled.content) as string;
+                                }
 
 				// Create a new DOMParser
 				const parser = new DOMParser();

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -3,6 +3,7 @@ import { debugLog } from './debug';
 import { createParserState, processCharacter } from './parser-utils';
 
 import { blockquote } from './filters/blockquote';
+import { boss_decrypt } from './filters/boss_decrypt';
 import { calc, validateCalcParams } from './filters/calc';
 import { callout } from './filters/callout';
 import { camel } from './filters/camel';
@@ -80,6 +81,7 @@ export const filterMetadata: Record<string, FilterMetadata> = {
 	template: { example: 'template:"${name}"', validateParams: validateTemplateParams },
 
 	// Filters with optional parameters (examples for documentation)
+        boss_decrypt: {},
 	blockquote: {},
 	callout: { example: 'callout:info' },
 	camel: {},
@@ -132,6 +134,7 @@ export const validFilterNames = new Set(Object.keys(filterMetadata));
 
 export const filters: { [key: string]: FilterFunction } = {
 	blockquote,
+        boss_decrypt,
 	calc,
 	callout,
 	camel,

--- a/src/utils/filters/boss_decrypt.test.ts
+++ b/src/utils/filters/boss_decrypt.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'vitest';
+import { boss_decrypt } from './boss_decrypt';
+
+describe('boss_decrypt filter', () => {
+        test('decrypts single character obfuscated font', () => {
+                expect(boss_decrypt('\ue032')).toBe('1');
+        });
+
+        test('decrypts full salary string', () => {
+                // '\ue033\ue034K' should be '23K'
+                expect(boss_decrypt('\ue033\ue034K')).toBe('23K');
+        });
+
+        test('decrypts complex salary range', () => {
+                // '\ue033\ue034-\ue035\ue036K' should be '23-45K'
+                expect(boss_decrypt('\ue033\ue034-\ue035\ue036K')).toBe('23-45K');
+        });
+
+        test('handles mixed normal and obfuscated characters', () => {
+                expect(boss_decrypt('薪资: \ue037\ue038K')).toBe('薪资: 67K');
+        });
+
+        test('handles empty string', () => {
+                expect(boss_decrypt('')).toBe('');
+        });
+
+        test('handles array of strings', () => {
+                expect(boss_decrypt(['\ue032', '\ue033'])).toEqual(['1', '2']);
+        });
+
+        test('handles non-obfuscated text', () => {
+                expect(boss_decrypt('Normal Text 123')).toBe('Normal Text 123');
+        });
+});

--- a/src/utils/filters/boss_decrypt.ts
+++ b/src/utils/filters/boss_decrypt.ts
@@ -1,0 +1,18 @@
+export const boss_decrypt = (input: string | string[]): string | string[] => {
+        const FONT_MAP: Record<string, string> = {
+                '\ue030': '0', '\ue031': '0', '\ue032': '1', '\ue033': '2', '\ue034': '3', 
+                '\ue035': '4', '\ue036': '5', '\ue037': '6', '\ue038': '7', '\ue039': '8', 
+                '\ue03a': '9', '\ue03b': '0'
+        };
+
+        const decode = (text: string): string => {
+                if (!text) return '';
+                return text.split('').map(char => FONT_MAP[char] || char).join('');
+        };
+
+        if (Array.isArray(input)) {
+                return input.map(decode);
+        } else {
+                return decode(input);
+        }
+};


### PR DESCRIPTION
#### English
This PR introduces an automatic decryption mechanism for BOSS Zhipin (zhipin.com). BOSS Zhipin obfuscates salary data using a custom icon-font, which results in garbled text when clipped.

**Changes:**
- Created a `boss_decrypt` filter mapping icon-font characters to numbers.
- Integrated automatic decryption in `src/content.ts` for `zhipin.com`.
- Added unit tests and updated documentation.

#### 中文
本 PR 为“BOSS 直聘”(zhipin.com) 引入了自动解密机制。BOSS 直聘使用图标字体混淆薪资数据，导致剪藏乱码。

**主要改动：**
- 实现了 `boss_decrypt` 过滤器，还原混淆字符。
- 在 `src/content.ts` 中为该域名开启了自动解密。
- 补全了单元测试与文档。