### PR TITLE
Fix settings link in Arc popup

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -115,6 +115,13 @@ let hasHighlights = false;
 let isContextMenuCreating = false;
 let popupPorts: { [tabId: number]: browser.Runtime.Port } = {};
 
+async function openSettingsPage(section?: string): Promise<void> {
+	const query = section ? `?section=${encodeURIComponent(section)}` : '';
+	await browser.tabs.create({
+		url: browser.runtime.getURL(`settings.html${query}`)
+	});
+}
+
 async function injectContentScript(tabId: number): Promise<void> {
 	if (browser.scripting) {
 		debugLog('Clipper', 'Using scripting API');
@@ -564,21 +571,12 @@ browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime
 		}
 
 		if (typedRequest.action === "openOptionsPage") {
-			try {
-				if (typeof browser.runtime.openOptionsPage === 'function') {
-					// Chrome way
-					browser.runtime.openOptionsPage();
-				} else {
-					// Firefox way
-					browser.tabs.create({
-						url: browser.runtime.getURL('settings.html')
-					});
-				}
-				sendResponse({success: true});
-			} catch (error) {
-				console.error('Error opening options page:', error);
-				sendResponse({success: false, error: error instanceof Error ? error.message : String(error)});
-			}
+			openSettingsPage('general')
+				.then(() => sendResponse({success: true}))
+				.catch((error) => {
+					console.error('Error opening options page:', error);
+					sendResponse({success: false, error: error instanceof Error ? error.message : String(error)});
+				});
 			return true;
 		}
 
@@ -591,16 +589,12 @@ browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime
 		}
 
 		if (typedRequest.action === "openSettings") {
-			try {
-				const section = typedRequest.section ? `?section=${typedRequest.section}` : '';
-				browser.tabs.create({
-					url: browser.runtime.getURL(`settings.html${section}`)
+			openSettingsPage(typedRequest.section)
+				.then(() => sendResponse({success: true}))
+				.catch((error) => {
+					console.error('Error opening settings:', error);
+					sendResponse({success: false, error: error instanceof Error ? error.message : String(error)});
 				});
-				sendResponse({success: true});
-			} catch (error) {
-				console.error('Error opening settings:', error);
-				sendResponse({success: false, error: error instanceof Error ? error.message : String(error)});
-			}
 			return true;
 		}
 

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -357,12 +357,13 @@ document.addEventListener('DOMContentLoaded', async function() {
 		}
 		const settingsButton = document.getElementById('open-settings');
 		if (settingsButton) {
-			settingsButton.addEventListener('click', async function() {
+			settingsButton.addEventListener('click', async function(e) {
+				e.preventDefault();
 				try {
-					await browser.runtime.sendMessage({ action: "openOptionsPage" });
+					await browser.runtime.sendMessage({ action: "openSettings", section: "general" });
 					setTimeout(() => window.close(), 50);
 				} catch (error) {
-					console.error('Error opening options page:', error);
+					console.error('Error opening settings page:', error);
 				}
 			});
 			initializeIcons(settingsButton);


### PR DESCRIPTION
## Summary
- open the settings page through an explicit extension URL instead of `runtime.openOptionsPage()`
- route the popup settings button through the existing `openSettings` message
- prevent the popup settings anchor from falling back to `#`

## Why
In Arc, clicking the popup settings button from a non-clippable page such as `arc://extensions/` can land on the extension error page instead of opening the Web Clipper settings page. Opening `settings.html?section=general` explicitly avoids Arc's `openOptionsPage()` behavior.

## Testing
- `npx webpack --env BROWSER=chrome --mode development`
- loaded the unpacked extension in Arc and verified the popup settings button opens `settings.html?section=general`
