### PR TITLE
fix: Fix active template highlight

### DIFF
--- a/src/managers/settings-section-ui.ts
+++ b/src/managers/settings-section-ui.ts
@@ -33,6 +33,9 @@ export function showSettingsSection(section: SettingsSection, templateId?: strin
 		if (templateEditor) {
 			templateEditor.style.display = 'block';
 		}
+		if (templateId) {
+			updateTemplateListActiveState(templateId);
+		}
 	}
 
 	updatePromptContextVisibility();


### PR DESCRIPTION
## What's happening

Two different visible behaviors that turn out to be the same underlying issue:

1. Selecting a template in the sidebar does not highlight that template — the active class stays on whatever item was highlighted before.
2. After duplicating a template, the wrong (unrelated) template gets highlighted, and switching to a different one does not move the highlight.

Both come from the same problem: when a template is selected, the internal `editingTemplateIndex` is updated but the DOM `.active` class on the template list is never re-synced.

## Fix

`updateTemplateListActiveState(templateId)` already exists in `settings-section-ui.ts` for exactly this purpose, but it is no longer called anywhere. 
Call it from `showSettingsSection` whenever the templates section is shown with a `templateId`. 
Since `showTemplateEditor()` always ends with `showSettingsSection('templates', editingTemplate.id)`, this covers all selection paths (click, duplicate, new, delete-then-select-next, import, URL restore, drag-and-drop reorder).

Fixes #440