### PR TITLE
Fix highlights across live page and Reading view

### DIFF
--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -103,31 +103,217 @@ function findTextNodeAtOffset(element: Element, offset: number): { node: Node, o
 	return null;
 }
 
-export function renderTextHighlight(highlight: { id: string; xpath: string; startOffset: number; endOffset: number }): void {
-	const hl = ensureUserHighlight();
-	if (!hl) return;
+function getHighlightExactText(highlight: {
+	textQuote?: { exact: string; prefix: string; suffix: string };
+	content: string;
+}): string {
+	return normalizeQuoteText(highlight.textQuote?.exact || htmlToText(highlight.content));
+}
+
+function rangeMatchesHighlight(range: Range, highlight: {
+	textQuote?: { exact: string; prefix: string; suffix: string };
+	content: string;
+}): boolean {
+	const exact = getHighlightExactText(highlight);
+	if (!exact) return true;
+	return normalizeQuoteText(range.toString()) === exact;
+}
+
+function rangeFromElementOffsets(highlight: {
+	xpath: string;
+	startOffset: number;
+	endOffset: number;
+	content: string;
+	textQuote?: { exact: string; prefix: string; suffix: string };
+}): Range | null {
 	const container = getElementByXPath(highlight.xpath);
-	if (!container) return;
+	if (!container) return null;
 	const start = findTextNodeAtOffset(container, highlight.startOffset);
 	const end = findTextNodeAtOffset(container, highlight.endOffset);
-	if (!start || !end) return;
+	if (!start || !end) return null;
 	try {
 		const range = document.createRange();
 		range.setStart(start.node, start.offset);
 		range.setEnd(end.node, end.offset);
-		if (range.collapsed) return;
-		hl.add(range);
-		const existing = textHighlightRanges.get(highlight.id);
-		if (existing) existing.push(range);
-		else textHighlightRanges.set(highlight.id, [range]);
+		if (range.collapsed || !rangeMatchesHighlight(range, highlight)) return null;
+		return range;
 	} catch (e) {
-		console.warn('Failed to build Range for text highlight', highlight.id, e);
+		console.warn('Failed to build Range for text highlight', e);
+		return null;
 	}
+}
+
+interface TextPosition {
+	node: Node;
+	startOffset: number;
+	endOffset: number;
+}
+
+interface NormalizedTextIndex {
+	text: string;
+	positions: TextPosition[];
+}
+
+let normalizedTextIndexCache: NormalizedTextIndex | null = null;
+let normalizedTextIndexRoot: Element | null = null;
+
+function getTextSearchRoot(): Element {
+	return document.querySelector('.obsidian-reader-content article')
+		|| document.querySelector('article')
+		|| document.body;
+}
+
+function isIgnoredTextNode(node: Node): boolean {
+	const parent = node.parentElement;
+	if (!parent) return true;
+	return Boolean(parent.closest('script, style, noscript, .obsidian-highlighter-menu, .obsidian-reader-settings, .obsidian-highlight-delete, .obsidian-selection-action'));
+}
+
+function buildNormalizedTextIndex(root: Element): NormalizedTextIndex {
+	const positions: TextPosition[] = [];
+	let text = '';
+	let previousWasWhitespace = true;
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+		acceptNode: (node) => {
+			if (!node.textContent || !node.textContent.trim() || isIgnoredTextNode(node)) {
+				return NodeFilter.FILTER_REJECT;
+			}
+			return NodeFilter.FILTER_ACCEPT;
+		},
+	});
+
+	let node: Node | null = walker.nextNode();
+	while (node) {
+		const value = node.textContent || '';
+		for (let i = 0; i < value.length; i++) {
+			const char = value[i];
+			if (/\s/.test(char)) {
+				if (!previousWasWhitespace) {
+					text += ' ';
+					positions.push({ node, startOffset: i, endOffset: i + 1 });
+					previousWasWhitespace = true;
+				}
+			} else {
+				text += char;
+				positions.push({ node, startOffset: i, endOffset: i + 1 });
+				previousWasWhitespace = false;
+			}
+		}
+		node = walker.nextNode();
+	}
+
+	if (text.endsWith(' ')) {
+		text = text.slice(0, -1);
+		positions.pop();
+	}
+	return { text, positions };
+}
+
+function getNormalizedTextIndex(): NormalizedTextIndex {
+	const root = getTextSearchRoot();
+	if (normalizedTextIndexCache && normalizedTextIndexRoot === root && root.isConnected) {
+		return normalizedTextIndexCache;
+	}
+	normalizedTextIndexRoot = root;
+	normalizedTextIndexCache = buildNormalizedTextIndex(root);
+	return normalizedTextIndexCache;
+}
+
+function normalizeQuoteText(text: string): string {
+	return text.replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function htmlToText(html: string): string {
+	const parsed = new DOMParser().parseFromString(html, 'text/html');
+	return parsed.body.textContent || html;
+}
+
+function commonPrefixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[i] === b[i]) i++;
+	return i;
+}
+
+function commonSuffixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[a.length - 1 - i] === b[b.length - 1 - i]) i++;
+	return i;
+}
+
+function rangeFromNormalizedOffsets(index: NormalizedTextIndex, start: number, end: number): Range | null {
+	if (start < 0 || end <= start || end > index.positions.length) return null;
+	const startPos = index.positions[start];
+	const endPos = index.positions[end - 1];
+	if (!startPos || !endPos) return null;
+	try {
+		const range = document.createRange();
+		range.setStart(startPos.node, startPos.startOffset);
+		range.setEnd(endPos.node, endPos.endOffset);
+		return range.collapsed ? null : range;
+	} catch (e) {
+		console.warn('Failed to build Range from text quote', e);
+		return null;
+	}
+}
+
+function rangeFromTextQuote(highlight: {
+	textQuote?: { exact: string; prefix: string; suffix: string };
+	content: string;
+}): Range | null {
+	const exact = getHighlightExactText(highlight);
+	if (!exact) return null;
+
+	const index = getNormalizedTextIndex();
+	const prefix = normalizeQuoteText(highlight.textQuote?.prefix || '');
+	const suffix = normalizeQuoteText(highlight.textQuote?.suffix || '');
+
+	let bestStart = -1;
+	let bestScore = -1;
+	let searchFrom = 0;
+	while (searchFrom <= index.text.length) {
+		const start = index.text.indexOf(exact, searchFrom);
+		if (start === -1) break;
+
+		const before = index.text.slice(Math.max(0, start - prefix.length), start);
+		const after = index.text.slice(start + exact.length, start + exact.length + suffix.length);
+		const score = commonSuffixLength(before, prefix) + commonPrefixLength(after, suffix);
+
+		if (score > bestScore) {
+			bestScore = score;
+			bestStart = start;
+		}
+		searchFrom = start + Math.max(1, exact.length);
+	}
+
+	if (bestStart === -1) return null;
+	return rangeFromNormalizedOffsets(index, bestStart, bestStart + exact.length);
+}
+
+export function renderTextHighlight(highlight: {
+	id: string;
+	xpath: string;
+	startOffset: number;
+	endOffset: number;
+	content: string;
+	textQuote?: { exact: string; prefix: string; suffix: string };
+}): void {
+	const hl = ensureUserHighlight();
+	if (!hl) return;
+	const range = rangeFromElementOffsets(highlight) || rangeFromTextQuote(highlight);
+	if (!range) return;
+	hl.add(range);
+	const existing = textHighlightRanges.get(highlight.id);
+	if (existing) existing.push(range);
+	else textHighlightRanges.set(highlight.id, [range]);
 }
 
 export function clearTextHighlights(): void {
 	userHighlight?.clear();
 	textHighlightRanges.clear();
+	normalizedTextIndexCache = null;
+	normalizedTextIndexRoot = null;
 }
 
 function findOverlayAtPoint(x: number, y: number): HTMLElement | null {
@@ -362,11 +548,12 @@ export function handleTouchMove(event: TouchEvent) {
 // Render one highlight. Text highlights go through the CSS Custom Highlight
 // API; element highlights (figure, img, table, pre, picture) get one overlay
 // div positioned over the target element.
-export function planHighlightOverlayRects(target: Element, highlight: AnyHighlightData) {
+export function planHighlightOverlayRects(target: Element | null, highlight: AnyHighlightData) {
 	if (highlight.type === 'text') {
 		renderTextHighlight(highlight);
 		return;
 	}
+	if (!target) return;
 	const rect = target.getBoundingClientRect();
 	const overlay = document.createElement('div');
 	overlay.className = 'obsidian-highlight-overlay';

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -208,10 +208,17 @@ export interface HighlightData {
 	groupId?: string;
 }
 
+export interface TextQuoteAnchor {
+	exact: string;
+	prefix: string;
+	suffix: string;
+}
+
 export interface TextHighlightData extends HighlightData {
 	type: 'text';
 	startOffset: number;
 	endOffset: number;
+	textQuote?: TextQuoteAnchor;
 }
 
 export interface ElementHighlightData extends HighlightData {
@@ -716,6 +723,7 @@ function getHighlightRanges(range: Range): AnyHighlightData[] {
 				id: `${timestamp}_tx_${i}`,
 				startOffset: getTextOffset(blockElement, blockRange.startContainer, blockRange.startOffset),
 				endOffset: getTextOffset(blockElement, blockRange.endContainer, blockRange.endOffset),
+				textQuote: createTextQuoteAnchor(blockElement, blockRange),
 			});
 		} catch (e) {
 			console.warn('Error creating text highlight for block:', blockElement, e);
@@ -851,6 +859,34 @@ function getTextOffset(container: Element, targetNode: Node, targetOffset: numbe
 	return offset;
 }
 
+const TEXT_QUOTE_CONTEXT_LENGTH = 64;
+
+function createTextQuoteAnchor(container: Element, range: Range): TextQuoteAnchor | undefined {
+	const exact = range.toString();
+	if (!exact.trim()) return undefined;
+
+	const startOffset = getTextOffset(container, range.startContainer, range.startOffset);
+	const endOffset = getTextOffset(container, range.endContainer, range.endOffset);
+	const containerText = container.textContent || '';
+
+	return {
+		exact,
+		prefix: containerText.slice(Math.max(0, startOffset - TEXT_QUOTE_CONTEXT_LENGTH), startOffset),
+		suffix: containerText.slice(endOffset, endOffset + TEXT_QUOTE_CONTEXT_LENGTH),
+	};
+}
+
+function createTextQuoteAnchorFromOffsets(container: Element, startOffset: number, endOffset: number): TextQuoteAnchor | undefined {
+	const containerText = container.textContent || '';
+	const exact = containerText.slice(startOffset, endOffset);
+	if (!exact.trim()) return undefined;
+	return {
+		exact,
+		prefix: containerText.slice(Math.max(0, startOffset - TEXT_QUOTE_CONTEXT_LENGTH), startOffset),
+		suffix: containerText.slice(endOffset, endOffset + TEXT_QUOTE_CONTEXT_LENGTH),
+	};
+}
+
 function addHighlight(highlight: AnyHighlightData, notes?: string[]) {
 	const oldHighlights = [...highlights];
 	const newHighlight = { ...highlight, notes: notes || [] };
@@ -965,6 +1001,7 @@ function mergeHighlights(h1: AnyHighlightData, h2: AnyHighlightData): AnyHighlig
 				id: Date.now().toString(),
 				startOffset,
 				endOffset,
+				...(el ? { textQuote: createTextQuoteAnchorFromOffsets(el, startOffset, endOffset) } : {}),
 				...(notes.length > 0 ? { notes } : {}),
 				...(groupId ? { groupId } : {}),
 			};
@@ -1037,7 +1074,7 @@ export function applyHighlights() {
 
 	highlights.forEach((highlight) => {
 		const container = getElementByXPath(highlight.xpath);
-		if (container) {
+		if (container || highlight.type === 'text') {
 			planHighlightOverlayRects(container, highlight);
 		}
 	});
@@ -1199,6 +1236,10 @@ function migrateStoredHighlights(): boolean {
 					h.endOffset -= len;
 					changed = true;
 				}
+				if (!h.textQuote) {
+					h.textQuote = createTextQuoteAnchorFromOffsets(el, h.startOffset, h.endOffset);
+					if (h.textQuote) changed = true;
+				}
 			}
 		}
 	}
@@ -1313,4 +1354,3 @@ function findLastTextNode(element: Element): Text | null {
 	}
 	return lastNode as Text | null;
 }
-


### PR DESCRIPTION
Fixes #824.

## Summary

Text highlights were anchored only by XPath and offsets. The live page DOM and Reading view DOM differ, so highlights created in one mode often could not render in the other.

This adds a portable text quote anchor for text highlights and uses it as a fallback when the stored XPath does not resolve or resolves to different text.

## Changes

- Store `textQuote` anchors for new text highlights.
- Backfill `textQuote` for old XPath-only highlights when possible.
- Render text highlights by trying XPath first, then falling back to quote matching.

## Testing

- Manually verified on the articles from #824:
  - Live page highlight appears in Reading view.
  - Reading view highlight appears on the live page.
  - Highlights persist after reload.


I made one comment in Reading view and one comment on the live page. Both persist and render correctly.
  
<img width="1008" height="735" alt="image" src="https://github.com/user-attachments/assets/3353abb3-6363-4b65-ba14-c50e18ac30fe" />

<img width="1092" height="460" alt="image" src="https://github.com/user-attachments/assets/cd0278d2-8f5a-481d-812c-43ff4bfd6891" />
