### PR TITLE
fix(templates): use date-only value for {{date}} preset variable

### DIFF
--- a/src/utils/fixtures/expected/youtube.md
+++ b/src/utils/fixtures/expected/youtube.md
@@ -5,7 +5,7 @@ author:
 published: 2024-06-15
 source: "https://www.youtube.com/watch?v=abc123"
 image: "https://i.ytimg.com/vi/abc123/maxresdefault.jpg"
-created: "2025-01-15T04:00:00-08:00"
+created: "2025-01-15"
 tags: "videos"
 ---
 ![How to Build a CLI Tool](https://www.youtube.com/watch?v=abc123)

--- a/src/utils/shared.test.ts
+++ b/src/utils/shared.test.ts
@@ -120,12 +120,10 @@ describe('buildVariables', () => {
 		expect(vars['{{highlights}}']).toBe('[{"text":"highlight"}]');
 	});
 
-	test('produces date and time in ISO-like format', () => {
+	test('produces separate date and time variables', () => {
 		const vars = buildVariables(makeParams());
-		// Both should be identical timestamps
-		expect(vars['{{date}}']).toBe(vars['{{time}}']);
-		// Should match YYYY-MM-DDTHH:mm:ssZ pattern
-		expect(vars['{{date}}']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+		expect(vars['{{date}}']).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(vars['{{time}}']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
 	});
 
 	test('adds extracted content as template variables', () => {

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -41,14 +41,16 @@ export function buildVariables(params: BuildVariablesParams): Record<string, str
 	const currentUrl = params.url.replace(/#:~:text=[^&]+(&|$)/, '');
 	const noteName = sanitizeFileName(params.title);
 
-	const timestamp = dayjs().format('YYYY-MM-DDTHH:mm:ssZ');
+	const now = dayjs();
+	const date = now.format('YYYY-MM-DD');
+	const timestamp = now.format('YYYY-MM-DDTHH:mm:ssZ');
 	const variables: Record<string, string> = {
 		'{{author}}': (params.author || '').trim(),
 		'{{content}}': (params.content || '').trim(),
 		'{{contentHtml}}': (params.contentHtml || '').trim(),
 		'{{selection}}': (params.selection || '').trim(),
 		'{{selectionHtml}}': (params.selectionHtml || '').trim(),
-		'{{date}}': timestamp,
+		'{{date}}': date,
 		'{{time}}': timestamp,
 		'{{description}}': (params.description || '').trim(),
 		'{{domain}}': getDomain(currentUrl),

--- a/src/utils/template-compiler.test.ts
+++ b/src/utils/template-compiler.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { buildVariables, BuildVariablesParams } from './shared';
+import { compileTemplate } from './template-compiler';
+
+const FROZEN_DATE = new Date('2025-01-15T12:00:00Z');
+
+beforeAll(() => { vi.useFakeTimers({ now: FROZEN_DATE }); });
+afterAll(() => { vi.useRealTimers(); });
+
+function makeParams(overrides: Partial<BuildVariablesParams> = {}): BuildVariablesParams {
+	return {
+		title: 'Test Title',
+		author: 'Test Author',
+		content: 'markdown body',
+		contentHtml: '<p>html body</p>',
+		url: 'https://example.com/page',
+		fullHtml: '<html></html>',
+		description: 'A description',
+		favicon: 'https://example.com/favicon.ico',
+		image: 'https://example.com/image.png',
+		published: '2024-01-15',
+		site: 'Example',
+		language: 'en',
+		wordCount: 42,
+		...overrides,
+	};
+}
+
+describe('compileTemplate', () => {
+	test('keeps date-only format when date is concatenated with text', async () => {
+		const variables = buildVariables(makeParams());
+
+		const result = await compileTemplate(
+			0,
+			'clips/{{date}}-{{title}}',
+			variables,
+			'https://example.com/page'
+		);
+
+		expect(result).toBe('clips/2025-01-15-Test Title');
+	});
+});


### PR DESCRIPTION
Separates {{date}} (YYYY-MM-DD) from {{time}} (datetime) so concatenation in note paths no longer embeds ISO timestamps. Adds regression test and updates youtube fixture expectation.