### PR TITLE
This PR addresses the bidirectional (BiDi) text rendering issues in the extension popup, as reported in #842.

### DIFF
--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -816,6 +816,9 @@ function buildTemplateFieldsSkeleton(template: Template | null) {
 			inputElement.setAttribute('data-type', propertyType);
 			inputElement.setAttribute('data-template-value', property.value);
 			inputElement.type = propertyType === 'checkbox' ? 'checkbox' : 'text';
+			if (inputElement.type === 'text') {
+				inputElement.setAttribute('dir', 'auto');
+			}
 
 			metadataPropertyValue.appendChild(inputElement);
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -38,24 +38,24 @@
 		</div>
 		<p class="error-message" style="display: none;"></p>
 		<div class="clipper">
-			<textarea id="note-name-field" type="text" data-i18n="noteName" rows="1"></textarea>
+			<textarea id="note-name-field" type="text" data-i18n="noteName" rows="1" dir="auto"></textarea>
 			<div class="metadata-properties-header">
 				<span data-i18n="properties"></span>
 				<i data-lucide="chevron-down"></i>
 			</div>
 			<div class="metadata-properties"></div>
 			<div id="note-content-container">
-				<textarea id="note-content-field" rows="4" data-i18n="notesAboutPage"></textarea>
+				<textarea id="note-content-field" rows="4" data-i18n="notesAboutPage" dir="auto"></textarea>
 			</div>
 			<div class="clipper-footer">
 				<div class="vault-path-container">
 					<div id="vault-container" style="display: none;">
 						<select id="vault-select"></select>
 					</div>
-					<input id="path-name-field" type="text" data-i18n="folder"/>
+					<input id="path-name-field" type="text" data-i18n="folder" dir="auto"/>
 				</div>
 				<div id="interpreter" style="display: none;">
-					<textarea id="prompt-context" rows="3"></textarea>
+					<textarea id="prompt-context" rows="3" dir="auto"></textarea>
 					<div class="interpreter-controls">
 						<select id="model-select" style="display: none;"></select>
 						<button id="interpret-btn" data-i18n="interpret"></button>

--- a/src/popup.html
+++ b/src/popup.html
@@ -38,7 +38,7 @@
 		</div>
 		<p class="error-message" style="display: none;"></p>
 		<div class="clipper">
-			<textarea id="note-name-field" type="text" data-i18n="noteName" rows="1" dir="auto"></textarea>
+			<textarea id="note-name-field" data-i18n="noteName" rows="1" dir="auto"></textarea>
 			<div class="metadata-properties-header">
 				<span data-i18n="properties"></span>
 				<i data-lucide="chevron-down"></i>

--- a/src/side-panel.html
+++ b/src/side-panel.html
@@ -59,7 +59,7 @@
 					<input id="path-name-field" type="text" data-i18n="folder" dir="auto"/>
 				</div>
 				<div id="interpreter" style="display: none;">
-					<textarea id="prompt-context" rows="3"></textarea>
+					<textarea id="prompt-context" rows="3" dir="auto"></textarea>
 					<div class="interpreter-controls">
 						<select id="model-select" style="display: none;"></select>
 						<button id="interpret-btn" data-i18n="interpret"></button>

--- a/src/side-panel.html
+++ b/src/side-panel.html
@@ -42,21 +42,21 @@
 		</div>
 		<p class="error-message" style="display: none;"></p>
 		<div class="clipper">
-			<textarea id="note-name-field" type="text" data-i18n="noteName" rows="1"></textarea>
+			<textarea id="note-name-field" data-i18n="noteName" rows="1" dir="auto"></textarea>
 			<div class="metadata-properties-header">
 				<span data-i18n="properties"></span>
 				<i data-lucide="chevron-down"></i>
 			</div>
 			<div class="metadata-properties"></div>
 			<div id="note-content-container">
-				<textarea id="note-content-field" rows="4" data-i18n="notesAboutPage"></textarea>
+				<textarea id="note-content-field" rows="4" data-i18n="notesAboutPage" dir="auto"></textarea>
 			</div>
 			<div class="clipper-footer">
 				<div class="vault-path-container">
 					<div id="vault-container" style="display: none;">
 						<select id="vault-select"></select>
 					</div>
-					<input id="path-name-field" type="text" data-i18n="folder"/>
+					<input id="path-name-field" type="text" data-i18n="folder" dir="auto"/>
 				</div>
 				<div id="interpreter" style="display: none;">
 					<textarea id="prompt-context" rows="3"></textarea>

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -2,11 +2,16 @@ textarea {
 	resize: vertical;
 	min-height: 3rem;
 	padding: 0.375rem 0.5rem;
+	// Ensure textarea content direction is determined per-element from the
+	// first strong character, not inherited from the document. This fixes
+	// mixed Arabic/English rendering for all users regardless of UI language.
+	unicode-bidi: plaintext;
 }
 input[type="password"],
 input[type="text"] {
 	height: var(--input-height);
 	padding: 0 0.5rem;
+	unicode-bidi: plaintext;
 }
 textarea::placeholder,
 input::placeholder {
@@ -25,6 +30,7 @@ textarea {
 	outline: none;
 	width: 100%;
 	margin: 0;
+	text-align: start;
 
 	@media (hover: hover) {
 		&:hover {

--- a/src/styles/rtl.scss
+++ b/src/styles/rtl.scss
@@ -19,8 +19,4 @@
 	.checkbox-container {
 		transform: scale(-1, 1);
 	}
-	input,
-	textarea {
-		unicode-bidi: plaintext;
-	}
 }


### PR DESCRIPTION
This PR addresses the bidirectional (BiDi) text rendering issues in the extension popup, as reported in #842.

The Problem

While the extension has baseline RTL support, the popup text fields were struggling with mixed-script content (Arabic and English). This caused punctuation and parentheses to flip to the wrong side of the line and led to significant visual clipping where text would disappear past the container edges.

The Solution

I have implemented a fix that relies on native browser text-direction detection rather than forcing a global direction.

HTML & TypeScript: I added dir="auto" to the static textareas in src/popup.html and updated src/core/popup.ts to ensure that any inputs generated dynamically for metadata also receive the dir="auto" attribute. This allows each field to determine its own direction based on the first strong character typed.

CSS: I moved the unicode-bidi: plaintext and text-align: start rules into the global src/styles/inputs.scss. This ensures that even in an LTR interface, a field containing Arabic text will render correctly without scrambling punctuation.

Refactoring: I cleaned up src/styles/rtl.scss to remove text-shaping rules that were previously scoped only to the .mod-rtl class, keeping that file focused strictly on layout and icon mirroring.

Testing & Verification

I performed manual side-by-side testing to verify the fix:

Before: Using the official extension on Chrome, mixed Arabic/English text was scrambled and clipped.

After: Using this updated build on Edge (unpacked extension), the text rendering is stable, parentheses are oriented correctly, and there is no more clipping.

Non-breaking Change

Since these changes utilize dir="auto" and plaintext isolation, they are completely invisible to users writing only in English or other LTR languages. The browser will continue to default to LTR for that content, so there is no risk of layout regressions for the general user base.

I’ve attached screenshots to the original issue (#842) showing the comparison. As I am new to open-source contributions, I would appreciate any feedback you have!

Closes #842
before
<img width="1920" height="1020" alt="Screenshot 2026-05-13 091346" src="https://github.com/user-attachments/assets/8a3fb929-ad19-41d6-adc4-d562dde8f9f8" />
after
<img width="1920" height="1020" alt="Screenshot 2026-05-13 091214" src="https://github.com/user-attachments/assets/d024cca8-1a0b-4dc8-84f0-04ca6061cd8e" />
