### PR TITLE
Improve Polish localization consistency

### DIFF
--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -21,7 +21,7 @@
 		"message": "Zapisz w Obsidian"
 	},
 	"addVaultPlaceholder": {
-		"message": "Kliknij enter, aby dodać sejf"
+		"message": "Kliknij Enter, aby dodać sejf"
 	},
 	"advanced": {
 		"message": "Zaawansowane"
@@ -48,10 +48,10 @@
 		"message": "Korzystając z usług zewnętrznego operatora, użytkownik akceptuje jego regulamin i politykę prywatności. Zapytania użytkowników wysyłane są bezpośrednio do wybranego operatora. Obsidian nie gromadzi ani nie przechowuje żadnych danych dotyczących zapytań."
 	},
 	"appendToDaily": {
-		"message": "Zapisz na końcu w dzienniku"
+		"message": "Dopisz na końcu w dzienniku"
 	},
 	"appendToExisting": {
-		"message": "Zapisz na końcu istniejącej notatki"
+		"message": "Dopisz na końcu istniejącej notatki"
 	},
 	"autoRunInterpreter": {
 		"message": "Uruchom automatycznie"
@@ -75,7 +75,7 @@
 		"message": "Anuluj"
 	},
 	"cannotDeleteProvider": {
-		"message": "Nie można usunąć operatora \"$1\", ponieważ jest używany przez $2 model(e)."
+		"message": "Nie można usunąć operatora \"$1\", ponieważ jest używany przez $2."
 	},
 	"changelog": {
 		"message": "Dziennik zmian"
@@ -93,7 +93,7 @@
 		"message": "Wybierz plik szablonu"
 	},
 	"clipBehavior": {
-		"message": "Sposób działania przechwytywania"
+		"message": "Sposób przechwytywania"
 	},
 	"clipBehaviorDescription": {
 		"message": "Pozwala wybrać sposób zapisywania wyróżnionej zawartości w Obsidian. Definiuje zmienną $strong_start${{content}}$strong_end$.",
@@ -118,7 +118,7 @@
 		"message": "Zamknij"
 	},
 	"commandOpenClipper": {
-		"message": "Otwórz schowek Obsidian"
+		"message": "Otwórz Obsidian Web Clipper"
 	},
 	"commandQuickClip": {
 		"message": "Przechwyć"
@@ -145,7 +145,7 @@
 		"message": "Skopiuj do schowka"
 	},
 	"createNewNote": {
-		"message": "Stwórz nową notatkę"
+		"message": "Utwórz nową notatkę"
 	},
 	"custom": {
 		"message": "Niestandardowe"
@@ -367,7 +367,7 @@
 		"message": "Wyróżnij stronę"
 	},
 	"highlightSelection": {
-		"message": "Podświetl"
+		"message": "Wyróżnij"
 	},
 	"highlighter": {
 		"message": "Zakreślacz"
@@ -467,10 +467,10 @@
 		"message": "Tryb klasyczny"
 	},
 	"legacyModeDescription": {
-		"message": "Używa URI jako sposobu wyodrębniania treści, który jest kompatybilny z Obsidian w wersji 1.6.7 lub starszej. Należy pamiętać, że długość treści, którą można wyodrębnić, jest ograniczona przez przeglądarkę i system operacyjny. Część stron może nie działać pomimo braku błędów."
+		"message": "Używa URI do wyodrębniania treści, kompatybilnego z Obsidian w wersji 1.6.7 lub starszej. Należy pamiętać, że długość treści, którą można wyodrębnić, jest ograniczona przez przeglądarkę i system operacyjny. Część stron może nie działać pomimo braku błędów."
 	},
 	"loadArticle": {
-		"message": "Czytaj artykuł"
+		"message": "Wczytaj artykuł"
 	},
 	"loading": {
 		"message": "Ładowanie…"
@@ -536,7 +536,7 @@
 		"message": "Nazwa notatki"
 	},
 	"noteNameFormatDescription": {
-		"message": "Format nazwy notatki. Możesz użyć zmiennych, takich jak {{title}}, {{date}} i {{published}}, aby wstępnie wypełnić dane ze strony. $link_start$ Dowiedz się więcej$link_end$.",
+		"message": "Format nazwy notatki. Możesz użyć zmiennych, takich jak {{title}}, {{date}} i {{published}}, aby wstępnie wypełnić dane ze strony. $link_start$Dowiedz się więcej$link_end$.",
 		"placeholders": {
 			"link_end": {
 				"content": "</a>"
@@ -643,7 +643,7 @@
 		"message": "Lista"
 	},
 	"propertyTypeNumber": {
-		"message": "Numer"
+		"message": "Liczba"
 	},
 	"propertyTypeText": {
 		"message": "Tekst"
@@ -664,7 +664,7 @@
 		"message": "Adres URL"
 	},
 	"providerBaseUrlDescription": {
-		"message": "URL punktu końcowego API dla tego operatora."
+		"message": "Adres URL punktu końcowego API dla tego operatora."
 	},
 	"providerModelId": {
 		"message": "ID modelu"
@@ -685,7 +685,7 @@
 		"message": "Ustawienie wstępne"
 	},
 	"providerPresetDescription": {
-		"message": "Wybierz operatora lub stwórz niestandardowego."
+		"message": "Wybierz operatora albo utwórz własnego."
 	},
 	"providerRequiredFields": {
 		"message": "Nazwa operatora i adres URL są wymagane."
@@ -922,19 +922,19 @@
 		"message": "Udostępnij..."
 	},
 	"shortcutInstructionsBrave": {
-		"message": "Aby zmienić skróty klawiszowe przejdź do $1"
+		"message": "Aby zmienić skróty klawiszowe, przejdź do $1"
 	},
 	"shortcutInstructionsChrome": {
-		"message": "Aby zmienić skróty klawiszowe przejdź do $1"
+		"message": "Aby zmienić skróty klawiszowe, przejdź do $1"
 	},
 	"shortcutInstructionsDefault": {
-		"message": "Aby zmienić skróty klawiszowe użyj ustawień rozszerzeń przeglądarki."
+		"message": "Aby zmienić skróty klawiszowe, użyj ustawień rozszerzeń przeglądarki."
 	},
 	"shortcutInstructionsEdge": {
-		"message": "Aby zmienić skróty klawiszowe przejdź do $1"
+		"message": "Aby zmienić skróty klawiszowe, przejdź do $1"
 	},
 	"shortcutInstructionsFirefox": {
-		"message": "Aby zmienić skróty klawiszowe przejdź do $1, kliknij ikonę koła zębatego i wybierz „Zarządzaj skrótami klawiszowymi”."
+		"message": "Aby zmienić skróty klawiszowe, przejdź do $1, kliknij ikonę koła zębatego i wybierz „Zarządzaj skrótami klawiszowymi”."
 	},
 	"shortcutInstructionsIntro": {
 		"message": "Skróty klawiszowe zapewniają szybki dostęp do funkcji rozszerzenia."
@@ -943,7 +943,7 @@
 		"message": "Nie można zmieniać skrótów klawiszowych w przeglądarce Safari."
 	},
 	"shortcutNotSet": {
-		"message": "Nie ustawione"
+		"message": "Nieustawione"
 	},
 	"showActionsButton": {
 		"message": "Pokaż przycisk akcji"
@@ -958,7 +958,7 @@
 		"message": "Zapisz notatkę bez jej otwierania"
 	},
 	"silentOpenDescription": {
-		"message": "Notatki będą zapisywane bez otwierania ich w nowej karcie. Obsidian nadal będzie umieszczany na wierzchu."
+		"message": "Notatki będą zapisywane bez otwierania ich w nowej karcie. Obsidian nadal będzie przenoszony na wierzch."
 	},
 	"sort": {
 		"message": "Sortuj"
@@ -1015,7 +1015,7 @@
 		"message": "Wyzwalacze szablonu"
 	},
 	"templateTriggersDescription": {
-		"message": "Zdefiniuj reguły umożliwiające automatyczne wybieranie tego szablonu, jeśli pasuje on do wzorca adresu URL lub zawiera dane schema.org. Jedna reguła na linię."
+		"message": "Zdefiniuj reguły umożliwiające automatyczne wybieranie tego szablonu, jeśli adres URL pasuje do wzorca lub strona zawiera dane schema.org. Jedna reguła na linię."
 	},
 	"templateValid": {
 		"message": "Składnia szablonu jest poprawna"
@@ -1053,7 +1053,7 @@
 		"message": "Sejfy"
 	},
 	"vaultsDescription": {
-		"message": "Domyślnie notatki są zapisywane w obecnie otwartym sejfie. Jeśli chcesz mieć możliwość zapisywania w różnych sejfach, możesz je dodawać w tym miejscu. Nazwy sejfów muszą dokładnie odpowiadać tym w Obsidian. Kliknij $strong_start$enter$strong_end$, aby dodać sejf.",
+		"message": "Domyślnie notatki są zapisywane w obecnie otwartym sejfie. Jeśli chcesz mieć możliwość zapisywania w różnych sejfach, możesz je dodawać w tym miejscu. Nazwy sejfów muszą dokładnie odpowiadać tym w Obsidian. Kliknij $strong_start$Enter$strong_end$, aby dodać sejf.",
 		"placeholders": {
 			"strong_end": {
 				"content": "</strong>"


### PR DESCRIPTION
Refines Polish translation strings by improving terminology, grammar, and UI consistency.

Key updates:
- Use clearer terminology
- Improve phrasing
- Fix Polish grammar issues and unnatural calques from English.
- Standardize Enter key references, and UI action labels.
- Correct minor inconsistencies