### PR TITLE
Clean ad artifacts from clipped content

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { parseHTML } from 'linkedom';
+import { clip, DocumentParser } from './api';
+import { Template } from './types/types';
+
+const documentParser: DocumentParser = {
+	parseFromString(html: string) {
+		return parseHTML(html).document;
+	},
+};
+
+const template: Template = {
+	id: 'clean-page-test',
+	name: 'Clean page test',
+	behavior: 'create',
+	noteNameFormat: '{{title}}',
+	path: '',
+	noteContentFormat: [
+		'Markdown:',
+		'{{content}}',
+		'HTML:',
+		'{{contentHtml}}',
+		'Full:',
+		'{{fullHtml}}',
+	].join('\n'),
+	properties: [],
+};
+
+describe('clip clean page integration', () => {
+	it('builds content variables from cleaned Defuddle HTML', async () => {
+		const result = await clip({
+			html: `
+				<html>
+					<head><title>Clean Page</title></head>
+					<body>
+						<article>
+							<h1>Clean Page</h1>
+							<p>Main story.</p>
+							<div id="div-gpt-ad-123"><p>Advertisement copy</p></div>
+							<iframe src="https://securepubads.g.doubleclick.net/pagead/ads"></iframe>
+							<p class="roadmap">Roadmap stays.</p>
+						</article>
+					</body>
+				</html>
+			`,
+			url: 'https://example.com/clean-page',
+			template,
+			documentParser,
+		});
+
+		expect(result.fullContent).toContain('Main story.');
+		expect(result.fullContent).toContain('Roadmap stays.');
+		expect(result.fullContent).not.toContain('Advertisement copy');
+		expect(result.fullContent).not.toContain('div-gpt-ad');
+		expect(result.variables['{{content}}']).not.toContain('Advertisement copy');
+		expect(result.variables['{{contentHtml}}']).not.toContain('securepubads');
+		expect(result.variables['{{fullHtml}}']).not.toContain('securepubads');
+	});
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,7 @@ import { applyFilters } from './utils/filters';
 import { buildVariables, generateFrontmatter, extractContentBySelector, selectorContentToString, formatPropertyValue } from './utils/shared';
 import { sanitizeFileName } from './utils/string-utils';
 import { Template, Property } from './types/types';
+import { cleanDocumentInPlace, cleanExtractedHtml, cleanFullHtml } from './utils/ad-cleaner';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -81,6 +82,10 @@ export function createSelectorProcessor(doc: DocLike): SelectorProcessor {
 
 		return filtersString ? applyFilters(contentString, filtersString, currentUrl) : contentString;
 	};
+}
+
+function getDefuddleInput(doc: any): Document {
+	return (doc?.nodeType === 9 ? doc : (doc?.ownerDocument || doc)) as unknown as Document;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,24 +183,26 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 
 	// Use pre-parsed document if provided, otherwise parse
 	const doc = parsedDocument ?? documentParser.parseFromString(html, 'text/html');
-	const documentElement = doc.documentElement || doc;
+	cleanDocumentInPlace(getDefuddleInput(doc), { url });
 
 	// Extract content with defuddle
 	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
-	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
+	const defuddle = new DefuddleClass(getDefuddleInput(doc), { url });
 	const defuddleResult = defuddle.parse();
+	const cleanedContentHtml = cleanExtractedHtml(defuddleResult.content, { url, documentParser });
+	const cleanedFullHtml = cleanFullHtml(html, { url, documentParser });
 
 	// Convert to markdown
-	const markdownContent = createMarkdownContent(defuddleResult.content, url);
+	const markdownContent = createMarkdownContent(cleanedContentHtml, url);
 
 	// Build template variables
 	const variables = buildVariables({
 		title: defuddleResult.title,
 		author: defuddleResult.author,
 		content: markdownContent,
-		contentHtml: defuddleResult.content,
+		contentHtml: cleanedContentHtml,
 		url,
-		fullHtml: html,
+		fullHtml: cleanedFullHtml,
 		description: defuddleResult.description,
 		favicon: defuddleResult.favicon,
 		image: defuddleResult.image,

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,6 +12,7 @@ import { saveFile } from './utils/file-utils';
 import { debugLog } from './utils/debug';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './utils/iframe-resize';
 import { parseForClip } from './utils/clip-utils';
+import { cleanDocumentInPlace, cleanExtractedHtml } from './utils/ad-cleaner';
 
 declare global {
 	interface Window {
@@ -154,9 +155,10 @@ declare global {
 			flattenShadowDom(document).then(() => {
 				try {
 					const defuddled = parseForClip(document);
+					const cleanedContent = cleanExtractedHtml(defuddled.content, { url: document.URL });
 
 					// Convert HTML content to markdown
-					const markdown = createMarkdownContent(defuddled.content, document.URL);
+					const markdown = createMarkdownContent(cleanedContent, document.URL);
 
 					// Copy to clipboard
 					const textArea = document.createElement("textarea");
@@ -179,7 +181,8 @@ declare global {
 			flattenShadowDom(document).then(async () => {
 				try {
 					const defuddled = parseForClip(document);
-					const markdown = createMarkdownContent(defuddled.content, document.URL);
+					const cleanedContent = cleanExtractedHtml(defuddled.content, { url: document.URL });
+					const markdown = createMarkdownContent(cleanedContent, document.URL);
 					const title = defuddled.title || document.title || 'Untitled';
 					const fileName = title.replace(/[/\\?%*:|"<>]/g, '-');
 					await saveFile({
@@ -213,12 +216,15 @@ declare global {
 
 				// Use parseAsync to ensure async variables like {{transcript}} are available.
 				// If it hangs (e.g. another extension has corrupted fetch), fall back to sync parse.
-				const defuddle = new Defuddle(document, { url: document.URL });
+				const extractionDoc = new DOMParser().parseFromString(document.documentElement.outerHTML, 'text/html');
+				cleanDocumentInPlace(extractionDoc, { url: document.URL });
+				const defuddle = new Defuddle(extractionDoc, { url: document.URL });
 				const parseTimeout = new Promise<never>((_, reject) =>
 					setTimeout(() => reject(new Error('parseAsync timeout')), 8000)
 				);
 				const defuddled = await Promise.race([defuddle.parseAsync(), parseTimeout])
 					.catch(() => defuddle.parse());
+				const cleanedContent = cleanExtractedHtml(defuddled.content, { url: document.URL });
 				const extractedContent: { [key: string]: string } = {
 					...defuddled.variables,
 				};
@@ -262,12 +268,14 @@ declare global {
 					});
 				});
 
+				cleanDocumentInPlace(doc, { url: document.URL });
+
 				// Get the modified HTML without scripts, styles, and style attributes
 				const cleanedHtml = doc.documentElement.outerHTML;
 
 				const response: ContentResponse = {
 					author: defuddled.author,
-					content: defuddled.content,
+					content: cleanedContent,
 					description: defuddled.description,
 					domain: getDomain(document.URL),
 					extractedContent: extractedContent,

--- a/src/utils/ad-cleaner.test.ts
+++ b/src/utils/ad-cleaner.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { parseHTML } from 'linkedom';
+import { cleanDocumentInPlace, cleanExtractedHtmlWithReport } from './ad-cleaner';
+
+const linkedomParser = {
+	parseFromString(html: string) {
+		return parseHTML(html).document as unknown as Document;
+	},
+};
+
+describe('clean-page ad cleaner', () => {
+	it('removes Google AdSense and Google Publisher Tag remnants', () => {
+		const { html, removed } = cleanExtractedHtmlWithReport(`
+			<main>
+				<article><p>Keep this article.</p></article>
+				<ins class="adsbygoogle" data-ad-client="ca-pub-123"></ins>
+				<div id="div-gpt-ad-123"><iframe src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></iframe></div>
+				<script src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+			</main>
+		`, { documentParser: linkedomParser });
+
+		expect(html).toContain('Keep this article.');
+		expect(html).not.toContain('adsbygoogle');
+		expect(html).not.toContain('div-gpt-ad');
+		expect(html).not.toContain('googlesyndication');
+		expect(removed.googleAds + removed.adIframes + removed.genericAds).toBeGreaterThan(0);
+	});
+
+	it('removes generic ads, sponsored widgets, and overlays without removing article content', () => {
+		const { document } = parseHTML(`
+			<body>
+				<article>
+					<h1>Title</h1>
+					<p>Real body.</p>
+					<aside role="note">Important note to preserve.</aside>
+				</article>
+				<div class="ad-banner">Ad</div>
+				<div class="taboola-widget">Sponsored links</div>
+				<div role="dialog">Subscribe now</div>
+			</body>
+		`);
+
+		const report = cleanDocumentInPlace(document as unknown as Document);
+		const html = document.body.innerHTML || document.documentElement.innerHTML;
+
+		expect(html).toContain('Real body.');
+		expect(html).toContain('Important note to preserve.');
+		expect(html).not.toContain('ad-banner');
+		expect(html).not.toContain('taboola-widget');
+		expect(html).not.toContain('Subscribe now');
+		expect(report.genericAds).toBe(1);
+		expect(report.sponsored).toBe(1);
+		expect(report.overlays).toBe(1);
+	});
+
+	it('does not remove unrelated words that merely contain ad', () => {
+		const { html } = cleanExtractedHtmlWithReport(`
+			<article>
+				<p class="roadmap">Roadmap should stay.</p>
+				<p id="shadow-adventure">Adventure should stay.</p>
+			</article>
+		`, { documentParser: linkedomParser });
+
+		expect(html).toContain('Roadmap should stay.');
+		expect(html).toContain('Adventure should stay.');
+	});
+});

--- a/src/utils/ad-cleaner.ts
+++ b/src/utils/ad-cleaner.ts
@@ -1,0 +1,314 @@
+export interface CleanPageOptions {
+	/** Page URL, used only for reporting and future site-specific tuning. */
+	url?: string;
+	/** Remove modal, cookie, newsletter, paywall, and app-install overlays. Default: true. */
+	removeOverlays?: boolean;
+	/** Remove sponsored/recommendation widgets such as Taboola/Outbrain. Default: true. */
+	removeSponsored?: boolean;
+	/** Remove ad/network iframes. Default: true. */
+	removeIframes?: boolean;
+	/** Remove empty containers left after ad nodes are removed. Default: true. */
+	removeEmpty?: boolean;
+	/** Selectors that should never be removed even if they match an ad selector. */
+	preserveSelectors?: string[];
+}
+
+export interface CleanPageRemovalReport {
+	googleAds: number;
+	adIframes: number;
+	genericAds: number;
+	overlays: number;
+	sponsored: number;
+	empty: number;
+}
+
+export interface CleanPageResult {
+	html: string;
+	removed: CleanPageRemovalReport;
+}
+
+export interface DocumentParserLike {
+	parseFromString(html: string, mimeType: string): Document;
+}
+
+const DEFAULT_REPORT: CleanPageRemovalReport = {
+	googleAds: 0,
+	adIframes: 0,
+	genericAds: 0,
+	overlays: 0,
+	sponsored: 0,
+	empty: 0,
+};
+
+const GOOGLE_AD_SELECTORS = [
+	// Google AdSense
+	'ins.adsbygoogle',
+	'[class~="adsbygoogle" i]',
+	'[class*="adsbygoogle" i]',
+	'[data-ad-client]',
+	'[data-ad-host]',
+	'[data-ad-slot]',
+	'[data-ad-format]',
+	'[data-full-width-responsive]',
+
+	// Google Ad Manager / Publisher Tag slots
+	'[id^="google_ads" i]',
+	'[id*="google_ads" i]',
+	'[id^="div-gpt-ad" i]',
+	'[id*="div-gpt-ad" i]',
+	'[id*="gpt-ad" i]',
+	'[class*="gpt-ad" i]',
+
+	// AMP ads
+	'amp-ad[type="adsense" i]',
+	'amp-ad[type="doubleclick" i]',
+	'amp-embed[type="adsense" i]',
+	'amp-embed[type="doubleclick" i]',
+
+	// Google ad scripts that may survive when fullHtml is post-cleaned.
+	'script[src*="googlesyndication.com" i]',
+	'script[src*="googletagservices.com" i]',
+	'script[src*="securepubads.g.doubleclick.net" i]',
+	'script[src*="pagead2.googlesyndication.com" i]',
+].join(',');
+
+const AD_IFRAME_SELECTOR = [
+	'iframe[src*="googlesyndication.com" i]',
+	'iframe[src*="doubleclick.net" i]',
+	'iframe[src*="googleads.g.doubleclick.net" i]',
+	'iframe[src*="securepubads.g.doubleclick.net" i]',
+	'iframe[src*="googletagservices.com" i]',
+	'iframe[src*="googleadservices.com" i]',
+	'iframe[src*="adservice.google." i]',
+	'iframe[src*="adnxs.com" i]',
+	'iframe[src*="adsystem.com" i]',
+	'iframe[src*="amazon-adsystem.com" i]',
+	'iframe[src*="taboola.com" i]',
+	'iframe[src*="outbrain.com" i]',
+].join(',');
+
+const GENERIC_AD_SELECTORS = [
+	'.ad',
+	'.ads',
+	'.advertisement',
+	'.ad-container',
+	'.ad-wrapper',
+	'.ad-banner',
+	'.ad-slot',
+	'.ad-unit',
+	'.adbox',
+	'.advert',
+	'.advertising',
+	'[id="ad" i]',
+	'[id="ads" i]',
+	'[id^="ad-" i]',
+	'[id$="-ad" i]',
+	'[id*="-ad-" i]',
+	'[id^="ads-" i]',
+	'[id$="-ads" i]',
+	'[class^="ad-" i]',
+	'[class$="-ad" i]',
+	'[class*="-ad-" i]',
+	'[class^="ads-" i]',
+	'[class$="-ads" i]',
+	'[data-ad]',
+	'[data-ad-id]',
+	'[data-ad-unit]',
+	'[data-ad-wrapper]',
+	'[data-advertising]',
+	'[aria-label*="advertisement" i]',
+	'[aria-label*="advertising" i]',
+	'[alt*="advertisement" i]',
+	'[alt*="advertising" i]',
+].join(',');
+
+const OVERLAY_SELECTORS = [
+	'[role="dialog" i]',
+	'[role="alertdialog" i]',
+	'[aria-modal="true" i]',
+	'dialog',
+	'.modal',
+	'.popup',
+	'.pop-up',
+	'.newsletter-popup',
+	'.subscribe-popup',
+	'.subscription-modal',
+	'.cookie-banner',
+	'.cookie-consent',
+	'.cookie-notice',
+	'.consent-banner',
+	'.gdpr-banner',
+	'.paywall',
+	'.metered-paywall',
+	'[id*="cookie" i][class*="banner" i]',
+	'[class*="cookie" i][class*="banner" i]',
+	'[class*="consent" i][class*="banner" i]',
+	'[class*="newsletter" i][class*="modal" i]',
+	'[class*="subscribe" i][class*="modal" i]',
+].join(',');
+
+const SPONSORED_SELECTORS = [
+	'[rel="sponsored" i]',
+	'[data-sponsored]',
+	'[class*="sponsored" i]',
+	'[id*="sponsored" i]',
+	'[class*="promoted" i]',
+	'[id*="promoted" i]',
+	'[class*="taboola" i]',
+	'[id*="taboola" i]',
+	'[class*="outbrain" i]',
+	'[id*="outbrain" i]',
+	'[class*="revcontent" i]',
+	'[id*="revcontent" i]',
+	'[class*="recommendation-widget" i]',
+	'[id*="recommendation-widget" i]',
+].join(',');
+
+function cloneReport(): CleanPageRemovalReport {
+	return { ...DEFAULT_REPORT };
+}
+
+function queryAll(root: ParentNode, selector: string): Element[] {
+	try {
+		return Array.from(root.querySelectorAll(selector));
+	} catch (error) {
+		console.warn('[Obsidian Clipper] Invalid clean-page selector:', selector, error);
+		return [];
+	}
+}
+
+function shouldPreserve(element: Element, preserveSelectors: string[]): boolean {
+	for (const selector of preserveSelectors) {
+		try {
+			if (element.matches(selector) || element.closest(selector)) {
+				return true;
+			}
+		} catch {
+			// Ignore invalid user-provided selectors.
+		}
+	}
+	return false;
+}
+
+function removeMatches(
+	root: ParentNode,
+	selector: string,
+	bucket: keyof CleanPageRemovalReport,
+	report: CleanPageRemovalReport,
+	preserveSelectors: string[],
+): void {
+	for (const element of queryAll(root, selector)) {
+		if (shouldPreserve(element, preserveSelectors)) continue;
+		element.remove();
+		report[bucket] += 1;
+	}
+}
+
+function removeEmptyContainers(doc: Document, report: CleanPageRemovalReport): void {
+	const selectors = 'div, section, aside, nav, header, footer, ins, span';
+	const keepIfContains = 'article, main, p, h1, h2, h3, h4, h5, h6, pre, code, blockquote, table, img, picture, video, audio, canvas, svg, math, iframe';
+
+	for (const element of queryAll(doc, selectors).reverse()) {
+		const tagName = element.tagName.toLowerCase();
+		if (tagName === 'main' || tagName === 'article' || element.id === 'content') continue;
+
+		const text = element.textContent?.replace(/\u00a0/g, ' ').trim() ?? '';
+		if (text.length > 0) continue;
+		if (element.querySelector(keepIfContains)) continue;
+
+		element.remove();
+		report.empty += 1;
+	}
+}
+
+function serializeExtractedHtml(doc: Document, fallback: string): string {
+	const bodyHtml = doc.body?.innerHTML ?? '';
+	if (bodyHtml.trim()) return bodyHtml;
+
+	const root = doc.documentElement;
+	if (!root) return fallback;
+
+	const tagName = root.tagName.toLowerCase();
+	if (tagName === 'html' || tagName === 'body') {
+		return root.innerHTML;
+	}
+
+	root.querySelectorAll(':scope > head:empty, :scope > body:empty').forEach(element => element.remove());
+	return root.outerHTML;
+}
+
+export function cleanDocumentInPlace(doc: Document, options: CleanPageOptions = {}): CleanPageRemovalReport {
+	const report = cloneReport();
+	const preserveSelectors = options.preserveSelectors ?? [
+		'article aside',
+		'main aside',
+		'pre',
+		'code',
+		'figure',
+		'figcaption',
+		'[role="note" i]',
+	];
+
+	removeMatches(doc, GOOGLE_AD_SELECTORS, 'googleAds', report, preserveSelectors);
+
+	if (options.removeIframes !== false) {
+		removeMatches(doc, AD_IFRAME_SELECTOR, 'adIframes', report, preserveSelectors);
+	}
+
+	removeMatches(doc, GENERIC_AD_SELECTORS, 'genericAds', report, preserveSelectors);
+
+	if (options.removeOverlays !== false) {
+		removeMatches(doc, OVERLAY_SELECTORS, 'overlays', report, preserveSelectors);
+	}
+
+	if (options.removeSponsored !== false) {
+		removeMatches(doc, SPONSORED_SELECTORS, 'sponsored', report, preserveSelectors);
+	}
+
+	if (options.removeEmpty !== false) {
+		removeEmptyContainers(doc, report);
+	}
+
+	return report;
+}
+
+export function cleanExtractedHtmlWithReport(
+	html: string,
+	options: CleanPageOptions & { documentParser?: DocumentParserLike } = {},
+): CleanPageResult {
+	if (!html) {
+		return { html, removed: cloneReport() };
+	}
+
+	const parser = options.documentParser ?? (typeof DOMParser !== 'undefined' ? new DOMParser() : undefined);
+	if (!parser) {
+		return { html, removed: cloneReport() };
+	}
+
+	const doc = parser.parseFromString(html, 'text/html');
+	const removed = cleanDocumentInPlace(doc, options);
+	const cleaned = serializeExtractedHtml(doc, html);
+
+	return { html: cleaned, removed };
+}
+
+export function cleanExtractedHtml(
+	html: string,
+	options: CleanPageOptions & { documentParser?: DocumentParserLike } = {},
+): string {
+	return cleanExtractedHtmlWithReport(html, options).html;
+}
+
+export function cleanFullHtml(
+	html: string,
+	options: CleanPageOptions & { documentParser?: DocumentParserLike } = {},
+): string {
+	if (!html) return html;
+
+	const parser = options.documentParser ?? (typeof DOMParser !== 'undefined' ? new DOMParser() : undefined);
+	if (!parser) return html;
+
+	const doc = parser.parseFromString(html, 'text/html');
+	cleanDocumentInPlace(doc, options);
+	return doc.documentElement?.outerHTML ?? html;
+}

--- a/src/utils/clip-utils.ts
+++ b/src/utils/clip-utils.ts
@@ -1,5 +1,6 @@
 import Defuddle from 'defuddle/full';
 import { setElementHTML } from './dom-utils';
+import { cleanDocumentInPlace } from './ad-cleaner';
 
 // Parse document content for clipping. In reader mode, extracts from
 // the article's original HTML to avoid reader UI artifacts.
@@ -15,7 +16,12 @@ export function parseForClip(doc: Document) {
 				...Array.from(readerArticle.childNodes).map(n => readerDoc.importNode(n, true))
 			);
 		}
+		cleanDocumentInPlace(readerDoc, { url: doc.URL });
 		return new Defuddle(readerDoc, { url: '' }).parse();
 	}
-	return new Defuddle(doc, { url: doc.URL }).parse();
+
+	const parser = new DOMParser();
+	const cleanDoc = parser.parseFromString(doc.documentElement.outerHTML, 'text/html');
+	cleanDocumentInPlace(cleanDoc, { url: doc.URL });
+	return new Defuddle(cleanDoc, { url: doc.URL }).parse();
 }


### PR DESCRIPTION
Title: Clean ad artifacts from clipped content

## Summary

This PR adds a focused cleanup pass that removes common ad, sponsored, iframe, paywall, cookie, newsletter, overlay, and empty layout artifacts before clipped content is converted to Markdown or exposed through the API.

The goal is to reduce noisy clipping output without changing the template system or the core Defuddle extraction behavior.

## Changes

- Adds `src/utils/ad-cleaner.ts` with conservative DOM and extracted-HTML cleanup helpers.
- Cleans cloned documents before Defuddle extraction for normal clipping paths.
- Cleans extracted `contentHtml` before Markdown conversion.
- Cleans `fullHtml` in the public API output while preserving the original page document.
- Applies the same cleanup to popup copy/save content, page content extraction, reader-mode clipping, and API `clip()` variables.
- Adds focused tests for ad/sponsored removal, false-positive preservation, and API integration.

## Validation

- `npm test -- --run src/utils/ad-cleaner.test.ts src/api.test.ts`
  - 2 test files passed
  - 4 tests passed
- `npm run build:chrome`
  - Passed
  - Existing webpack bundle-size warnings only

## Notes

The selector cleanup is intentionally narrow. It targets high-confidence ad and overlay patterns and avoids removing article content such as notes, code blocks, figures, or regular content that happens to contain words like "roadmap".
