### PR TITLE
Add Codex CLI interpreter provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ builds/
 changelogs/
 assets/shared
 
+# Native messaging generated files
+native/com.obsidian_clipper.codex.chrome.json
+native/com.obsidian_clipper.codex.edge.json
+native/obsidian-clipper-codex-host
+native/obsidian-clipper-codex-host.exe
+
 # Xcode
 *.xcuserstate
 *.xcuserdatad

--- a/native/install-codex-host-unix.sh
+++ b/native/install-codex-host-unix.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST_NAME="com.obsidian_clipper.codex"
+BROWSER="chrome"
+EXTENSION_ID=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--browser)
+			BROWSER="${2:-}"
+			shift 2
+			;;
+		--extension-id)
+			EXTENSION_ID="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "Unknown argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+if [[ -z "$EXTENSION_ID" ]]; then
+	echo "Usage: $0 --browser chrome|edge --extension-id EXTENSION_ID" >&2
+	exit 2
+fi
+
+case "$BROWSER" in
+	chrome|google-chrome)
+		BROWSER="chrome"
+		;;
+	edge|microsoft-edge)
+		BROWSER="edge"
+		;;
+	*)
+		echo "Unsupported browser: $BROWSER" >&2
+		exit 2
+		;;
+esac
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HOST_SCRIPT="$SCRIPT_DIR/obsidian-clipper-codex-host"
+MANIFEST_PATH="$SCRIPT_DIR/$HOST_NAME.$BROWSER.json"
+
+cat > "$HOST_SCRIPT" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$SCRIPT_DIR/obsidian-clipper-codex-host.mjs"
+EOF
+chmod +x "$HOST_SCRIPT"
+
+cat > "$MANIFEST_PATH" <<EOF
+{
+  "name": "$HOST_NAME",
+  "description": "Obsidian Web Clipper Codex CLI native bridge",
+  "path": "$HOST_SCRIPT",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://$EXTENSION_ID/"
+  ]
+}
+EOF
+
+OS_NAME="$(uname -s)"
+if [[ "$OS_NAME" == "Darwin" ]]; then
+	if [[ "$BROWSER" == "edge" ]]; then
+		TARGET_DIR="$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts"
+	else
+		TARGET_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+	fi
+else
+	if [[ "$BROWSER" == "edge" ]]; then
+		TARGET_DIR="$HOME/.config/microsoft-edge/NativeMessagingHosts"
+	else
+		TARGET_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+	fi
+fi
+
+mkdir -p "$TARGET_DIR"
+ln -sf "$MANIFEST_PATH" "$TARGET_DIR/$HOST_NAME.json"
+
+echo "Installed $HOST_NAME for $BROWSER"
+echo "Manifest: $MANIFEST_PATH"
+echo "Registered: $TARGET_DIR/$HOST_NAME.json"
+echo "Host: $HOST_SCRIPT"

--- a/native/install-codex-host-windows.ps1
+++ b/native/install-codex-host-windows.ps1
@@ -1,0 +1,54 @@
+param(
+	[Parameter(Mandatory = $true)]
+	[string]$ExtensionId,
+
+	[ValidateSet('Chrome', 'Edge')]
+	[string]$Browser = 'Chrome'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$hostName = 'com.obsidian_clipper.codex'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$launcherSource = Join-Path $scriptDir 'obsidian-clipper-codex-host-launcher.cs'
+$hostPath = Join-Path $scriptDir 'obsidian-clipper-codex-host.exe'
+$manifestPath = Join-Path $scriptDir "$hostName.$($Browser.ToLowerInvariant()).json"
+
+if (-not (Test-Path $hostPath) -or (Get-Item $hostPath).LastWriteTimeUtc -lt (Get-Item $launcherSource).LastWriteTimeUtc) {
+	$csc = Get-Command csc.exe -ErrorAction SilentlyContinue
+	if (-not $csc) {
+		$csc = Get-ChildItem -Path "$env:WINDIR\Microsoft.NET\Framework64", "$env:WINDIR\Microsoft.NET\Framework" -Recurse -Filter csc.exe -ErrorAction SilentlyContinue |
+			Sort-Object FullName -Descending |
+			Select-Object -First 1
+	}
+
+	if (-not $csc) {
+		throw 'Could not find csc.exe. Install the .NET SDK or .NET Framework developer tools, then rerun this script.'
+	}
+
+	$cscPath = if ($csc.Source) { $csc.Source } else { $csc.FullName }
+	& $cscPath /nologo /target:exe "/out:$hostPath" $launcherSource
+}
+
+$manifest = [ordered]@{
+	name = $hostName
+	description = 'Obsidian Web Clipper Codex CLI native bridge'
+	path = $hostPath
+	type = 'stdio'
+	allowed_origins = @("chrome-extension://$ExtensionId/")
+}
+
+$manifest | ConvertTo-Json -Depth 4 | Set-Content -Path $manifestPath -Encoding UTF8
+
+if ($Browser -eq 'Chrome') {
+	$registryPath = "HKCU:\Software\Google\Chrome\NativeMessagingHosts\$hostName"
+} else {
+	$registryPath = "HKCU:\Software\Microsoft\Edge\NativeMessagingHosts\$hostName"
+}
+
+New-Item -Path $registryPath -Force | Out-Null
+Set-Item -Path $registryPath -Value $manifestPath
+
+Write-Output "Installed $hostName for $Browser"
+Write-Output "Manifest: $manifestPath"
+Write-Output "Host: $hostPath"

--- a/native/obsidian-clipper-codex-host-launcher.cs
+++ b/native/obsidian-clipper-codex-host-launcher.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+public static class Program
+{
+	public static int Main()
+	{
+		try
+		{
+			string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+			string hostScript = Path.Combine(baseDirectory, "obsidian-clipper-codex-host.mjs");
+			string nodePath = Environment.GetEnvironmentVariable("OBSIDIAN_CLIPPER_NODE");
+			if (String.IsNullOrWhiteSpace(nodePath))
+			{
+				nodePath = "node.exe";
+			}
+
+			ProcessStartInfo startInfo = new ProcessStartInfo();
+			startInfo.FileName = nodePath;
+			startInfo.Arguments = Quote(hostScript);
+			startInfo.WorkingDirectory = baseDirectory;
+			startInfo.UseShellExecute = false;
+			startInfo.RedirectStandardInput = true;
+			startInfo.RedirectStandardOutput = true;
+			startInfo.RedirectStandardError = true;
+			startInfo.CreateNoWindow = true;
+
+			using (Process process = Process.Start(startInfo))
+			{
+				if (process == null)
+				{
+					Console.Error.WriteLine("Failed to start Node.js host process.");
+					return 1;
+				}
+
+				Task stdinTask = ForwardSingleNativeMessageAsync(process);
+				Task stdoutTask = process.StandardOutput.BaseStream.CopyToAsync(Console.OpenStandardOutput());
+				Task stderrTask = process.StandardError.BaseStream.CopyToAsync(Console.OpenStandardError());
+
+				process.WaitForExit();
+				Task.WaitAll(new Task[] { stdoutTask, stderrTask }, TimeSpan.FromSeconds(2));
+				if (stdinTask.IsCompleted)
+				{
+					try
+					{
+						stdinTask.Wait();
+					}
+					catch
+					{
+					}
+				}
+				return process.ExitCode;
+			}
+		}
+		catch (Exception error)
+		{
+			Console.Error.WriteLine(error.ToString());
+			return 1;
+		}
+	}
+
+	private static async Task ForwardSingleNativeMessageAsync(Process process)
+	{
+		try
+		{
+			Stream input = Console.OpenStandardInput();
+			Stream output = process.StandardInput.BaseStream;
+			byte[] header = await ReadExactOrNullAsync(input, 4);
+			if (header == null)
+			{
+				return;
+			}
+
+			int length = BitConverter.ToInt32(header, 0);
+			if (length < 0 || length > 64 * 1024 * 1024)
+			{
+				throw new InvalidDataException("Native message length is invalid.");
+			}
+
+			byte[] body = await ReadExactAsync(input, length);
+			await output.WriteAsync(header, 0, header.Length);
+			await output.WriteAsync(body, 0, body.Length);
+			await output.FlushAsync();
+		}
+		catch
+		{
+		}
+		finally
+		{
+			try
+			{
+				process.StandardInput.Close();
+			}
+			catch
+			{
+			}
+		}
+	}
+
+	private static async Task<byte[]> ReadExactAsync(Stream stream, int length)
+	{
+		byte[] buffer = new byte[length];
+		int offset = 0;
+		while (offset < length)
+		{
+			int read = await stream.ReadAsync(buffer, offset, length - offset);
+			if (read == 0)
+			{
+				throw new EndOfStreamException("Unexpected end of native message.");
+			}
+			offset += read;
+		}
+		return buffer;
+	}
+
+	private static async Task<byte[]> ReadExactOrNullAsync(Stream stream, int length)
+	{
+		byte[] buffer = new byte[length];
+		int offset = 0;
+		while (offset < length)
+		{
+			int read = await stream.ReadAsync(buffer, offset, length - offset);
+			if (read == 0)
+			{
+				if (offset == 0)
+				{
+					return null;
+				}
+				throw new EndOfStreamException("Unexpected end of native message header.");
+			}
+			offset += read;
+		}
+		return buffer;
+	}
+
+	private static string Quote(string value)
+	{
+		return "\"" + value.Replace("\"", "\\\"") + "\"";
+	}
+}

--- a/native/obsidian-clipper-codex-host.cmd
+++ b/native/obsidian-clipper-codex-host.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0obsidian-clipper-codex-host.mjs"

--- a/native/obsidian-clipper-codex-host.mjs
+++ b/native/obsidian-clipper-codex-host.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const HOST_NAME = 'com.obsidian_clipper.codex';
+const MAX_MESSAGE_BYTES = 64 * 1024 * 1024;
+const MAX_RESPONSE_BYTES = 900 * 1024;
+const MAX_IMAGE_ATTACHMENTS = 4;
+
+function readExact(stream, length) {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+		let received = 0;
+
+		function cleanup() {
+			stream.off('readable', onReadable);
+			stream.off('end', onEnd);
+			stream.off('error', onError);
+		}
+
+		function onError(error) {
+			cleanup();
+			reject(error);
+		}
+
+		function onEnd() {
+			cleanup();
+			if (received === 0) resolve(null);
+			else reject(new Error(`Unexpected EOF while reading ${length} bytes`));
+		}
+
+		function onReadable() {
+			let chunk;
+			while ((chunk = stream.read(length - received)) !== null) {
+				chunks.push(chunk);
+				received += chunk.length;
+				if (received === length) {
+					cleanup();
+					resolve(Buffer.concat(chunks, length));
+					return;
+				}
+			}
+		}
+
+		stream.on('readable', onReadable);
+		stream.on('end', onEnd);
+		stream.on('error', onError);
+		onReadable();
+	});
+}
+
+async function readNativeMessage() {
+	const lengthBuffer = await readExact(process.stdin, 4);
+	if (!lengthBuffer) return null;
+
+	const length = lengthBuffer.readUInt32LE(0);
+	if (length > MAX_MESSAGE_BYTES) {
+		throw new Error(`Native message too large: ${length} bytes`);
+	}
+
+	const bodyBuffer = await readExact(process.stdin, length);
+	if (!bodyBuffer) return null;
+	return JSON.parse(bodyBuffer.toString('utf8'));
+}
+
+function writeNativeMessage(message) {
+	let body = Buffer.from(JSON.stringify(message), 'utf8');
+	if (body.byteLength > MAX_RESPONSE_BYTES) {
+		body = Buffer.from(JSON.stringify({
+			ok: false,
+			host: HOST_NAME,
+			error: `Response exceeded ${MAX_RESPONSE_BYTES} bytes`,
+		}), 'utf8');
+	}
+
+	const header = Buffer.alloc(4);
+	header.writeUInt32LE(body.byteLength, 0);
+	process.stdout.write(header);
+	process.stdout.write(body);
+}
+
+function run(command, args, options) {
+	return new Promise((resolve) => {
+		const resolved = resolveCommand(command, args);
+		const child = spawn(resolved.command, resolved.args, {
+			cwd: options.cwd,
+			env: { ...process.env, ...(options.env ?? {}) },
+			stdio: ['pipe', 'pipe', 'pipe'],
+			windowsHide: true,
+		});
+
+		let stdout = '';
+		let stderr = '';
+		child.stdout.setEncoding('utf8');
+		child.stderr.setEncoding('utf8');
+		child.stdout.on('data', chunk => { stdout += chunk; });
+		child.stderr.on('data', chunk => { stderr += chunk; });
+		child.on('error', error => resolve({ code: -1, stdout, stderr: String(error.message || error) }));
+		child.on('close', code => resolve({ code: code ?? 0, stdout, stderr }));
+		if (options.stdin !== undefined) {
+			child.stdin.end(options.stdin);
+		} else {
+			child.stdin.end();
+		}
+	});
+}
+
+function resolveCommand(command, args) {
+	if (process.platform !== 'win32') return { command, args };
+
+	const normalized = command.replaceAll('/', '\\').toLowerCase();
+	const isCodexShim = normalized === 'codex' || normalized.endsWith('\\codex') || normalized.endsWith('\\codex.cmd');
+	if (isCodexShim) {
+		const npmPrefix = process.env.APPDATA ? join(process.env.APPDATA, 'npm') : '';
+		const codexEntry = join(npmPrefix, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+		if (existsSync(codexEntry)) {
+			return { command: 'node.exe', args: [codexEntry, ...args] };
+		}
+	}
+
+	if (normalized.endsWith('.js') || normalized.endsWith('.mjs') || normalized.endsWith('.cjs')) {
+		return { command: 'node.exe', args: [command, ...args] };
+	}
+
+	return {
+		command: 'cmd.exe',
+		args: ['/d', '/s', '/c', quoteForCmd(command, args)],
+	};
+}
+
+function quoteForCmd(command, args) {
+	return [command, ...args]
+		.map(arg => `"${String(arg).replaceAll('"', '\\"')}"`)
+		.join(' ');
+}
+
+function buildInterpreterPrompt(payload) {
+	const promptVariables = Array.isArray(payload.promptVariables) ? payload.promptVariables : [];
+	const imageAttachments = Array.isArray(payload.imageAttachments) ? payload.imageAttachments : [];
+	const promptSpec = {};
+	for (const variable of promptVariables) {
+		if (variable?.key && variable?.prompt) {
+			promptSpec[variable.key] = variable.prompt;
+		}
+	}
+
+	return [
+		'You are the interpreter backend for Obsidian Web Clipper.',
+		'Return exactly one JSON object and no surrounding text.',
+		'The JSON object must have this shape:',
+		'{"prompts_responses":{"prompt_1":"Markdown string","prompt_2":"Markdown string"}}',
+		'Use exactly the keys from the prompt variables JSON below.',
+		'For each variable, answer variable.prompt using the clip context as the source material.',
+		imageAttachments.length > 0
+			? 'Use the attached image(s) as additional visual context when the prompt asks about visible layout, screenshots, charts, diagrams, or page appearance.'
+			: 'No image attachments were provided.',
+		'Do not invent facts not present in the clip context.',
+		'Keep values concise unless the prompt asks otherwise.',
+		'If a prompt asks for exact text, return that exact text as the value for that key.',
+		'',
+		`Prompt keys: ${Object.keys(promptSpec).join(', ') || '(none)'}`,
+		'',
+		'Clip context:',
+		'```markdown',
+		String(payload.promptContext || ''),
+		'```',
+		'',
+		'Prompt variables JSON:',
+		'```json',
+		JSON.stringify(promptVariables, null, 2),
+		'```',
+		'',
+		`Attached image count: ${imageAttachments.length}`,
+	].join('\n');
+}
+
+function parseImageAttachment(attachment, index) {
+	if (!attachment || typeof attachment.dataUrl !== 'string') return null;
+
+	const match = attachment.dataUrl.match(/^data:(image\/(?:png|jpe?g|webp));base64,([a-z0-9+/=\r\n]+)$/i);
+	if (!match) return null;
+
+	const extensionByMime = {
+		'image/png': 'png',
+		'image/jpeg': 'jpg',
+		'image/jpg': 'jpg',
+		'image/webp': 'webp',
+	};
+	const extension = extensionByMime[match[1].toLowerCase()] || 'png';
+	const safeName = String(attachment.name || `image-${index + 1}.${extension}`)
+		.replace(/[^a-z0-9._-]/gi, '-')
+		.replace(/-+/g, '-')
+		.slice(0, 80);
+
+	return {
+		filename: safeName.includes('.') ? safeName : `${safeName}.${extension}`,
+		buffer: Buffer.from(match[2].replace(/\s/g, ''), 'base64'),
+	};
+}
+
+async function writeImageAttachments(workdir, payload) {
+	const attachments = Array.isArray(payload.imageAttachments) ? payload.imageAttachments.slice(0, MAX_IMAGE_ATTACHMENTS) : [];
+	const imagePaths = [];
+
+	for (let index = 0; index < attachments.length; index += 1) {
+		const parsed = parseImageAttachment(attachments[index], index);
+		if (!parsed) continue;
+
+		const imagePath = join(workdir, parsed.filename);
+		await writeFile(imagePath, parsed.buffer);
+		imagePaths.push(imagePath);
+	}
+
+	return imagePaths;
+}
+
+async function removeWorkdir(workdir) {
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		try {
+			await rm(workdir, { recursive: true, force: true });
+			return;
+		} catch {
+			await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)));
+		}
+	}
+}
+
+async function handleInterpreter(payload) {
+	const workdir = await mkdtemp(join(tmpdir(), 'obsidian-clipper-codex-'));
+	const outputPath = join(workdir, 'codex-result.json');
+
+	try {
+		await writeFile(join(workdir, 'prompt-context.md'), String(payload.promptContext || ''), 'utf8');
+		await writeFile(join(workdir, 'prompt-variables.json'), JSON.stringify(payload.promptVariables || [], null, 2), 'utf8');
+		const imagePaths = await writeImageAttachments(workdir, payload);
+
+		const args = [
+			'exec',
+			'--cd', workdir,
+			'--sandbox', 'read-only',
+			'--skip-git-repo-check',
+			'--output-last-message', outputPath,
+		];
+
+		if (payload.model) {
+			args.push('--model', String(payload.model));
+		}
+
+		for (const imagePath of imagePaths) {
+			args.push('--image', imagePath);
+		}
+
+		args.push('-');
+
+		const result = await run(payload.codexPath || process.env.CODEX_BIN || 'codex', args, {
+			cwd: workdir,
+			stdin: buildInterpreterPrompt(payload),
+		});
+		if (result.code !== 0) {
+			return {
+				ok: false,
+				host: HOST_NAME,
+				code: result.code,
+				error: result.stderr || result.stdout || 'Codex CLI failed',
+			};
+		}
+
+		const content = await readFile(outputPath, 'utf8').catch(() => result.stdout);
+		return {
+			ok: true,
+			host: HOST_NAME,
+			content,
+			stdout: result.stdout.slice(0, 8192),
+		};
+	} finally {
+		if (!payload.keepTemp) {
+			await removeWorkdir(workdir);
+		}
+	}
+}
+
+async function main() {
+	try {
+		const message = await readNativeMessage();
+		if (!message) return;
+		process.stdin.destroy();
+
+		if (message.type === 'ping') {
+			writeNativeMessage({ ok: true, host: HOST_NAME, pong: true });
+			return;
+		}
+
+		if (message.type !== 'interpreter') {
+			writeNativeMessage({ ok: false, host: HOST_NAME, error: `Unsupported message type: ${message.type}` });
+			return;
+		}
+
+		writeNativeMessage(await handleInterpreter(message));
+	} catch (error) {
+		writeNativeMessage({ ok: false, host: HOST_NAME, error: error instanceof Error ? error.message : String(error) });
+	}
+}
+
+main();

--- a/native/test-codex-host.mjs
+++ b/native/test-codex-host.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+function encodeNativeMessage(message) {
+	const body = Buffer.from(JSON.stringify(message), 'utf8');
+	const header = Buffer.alloc(4);
+	header.writeUInt32LE(body.byteLength, 0);
+	return Buffer.concat([header, body]);
+}
+
+function decodeNativeMessage(buffer) {
+	if (buffer.byteLength < 4) throw new Error('Missing native response header');
+	const length = buffer.readUInt32LE(0);
+	const body = buffer.subarray(4, 4 + length);
+	return JSON.parse(body.toString('utf8'));
+}
+
+const child = spawn(process.platform === 'win32' ? 'cmd.exe' : 'node', process.platform === 'win32'
+	? ['/c', 'native\\obsidian-clipper-codex-host.cmd']
+	: ['native/obsidian-clipper-codex-host.mjs'], {
+	cwd: new URL('..', import.meta.url),
+	stdio: ['pipe', 'pipe', 'inherit'],
+});
+
+const chunks = [];
+child.stdout.on('data', chunk => chunks.push(chunk));
+child.on('close', code => {
+	if (code !== 0) {
+		console.error(`Host exited with code ${code}`);
+		process.exit(code ?? 1);
+	}
+	console.log(JSON.stringify(decodeNativeMessage(Buffer.concat(chunks)), null, 2));
+});
+
+child.stdin.end(encodeNativeMessage({ type: 'ping' }));

--- a/native/test-codex-interpreter.mjs
+++ b/native/test-codex-interpreter.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function encodeNativeMessage(message) {
+	const body = Buffer.from(JSON.stringify(message), 'utf8');
+	const header = Buffer.alloc(4);
+	header.writeUInt32LE(body.byteLength, 0);
+	return Buffer.concat([header, body]);
+}
+
+function decodeNativeMessage(buffer) {
+	if (buffer.byteLength < 4) throw new Error('Missing native response header');
+	const length = buffer.readUInt32LE(0);
+	if (buffer.byteLength < 4 + length) {
+		throw new Error(`Incomplete native response: expected ${length} bytes, got ${buffer.byteLength - 4}`);
+	}
+	const body = buffer.subarray(4, 4 + length);
+	return JSON.parse(body.toString('utf8'));
+}
+
+const cwd = new URL('..', import.meta.url);
+const hostExe = new URL('obsidian-clipper-codex-host.exe', import.meta.url);
+const hostCmd = new URL('obsidian-clipper-codex-host.cmd', import.meta.url);
+const useExe = process.platform === 'win32' && existsSync(hostExe);
+const child = useExe
+	? spawn(fileURLToPath(hostExe), [], { cwd, stdio: ['pipe', 'pipe', 'inherit'], windowsHide: true })
+	: spawn(process.platform === 'win32' ? 'cmd.exe' : 'node', process.platform === 'win32'
+		? ['/c', fileURLToPath(hostCmd)]
+		: ['native/obsidian-clipper-codex-host.mjs'], {
+			cwd,
+			stdio: ['pipe', 'pipe', 'inherit'],
+			windowsHide: true,
+		});
+
+const chunks = [];
+child.stdout.on('data', chunk => chunks.push(chunk));
+child.on('close', code => {
+	if (code !== 0) {
+		console.error(`Host exited with code ${code}`);
+		process.exit(code ?? 1);
+	}
+
+	const response = decodeNativeMessage(Buffer.concat(chunks));
+	console.log(JSON.stringify(response, null, 2));
+
+	if (!response.ok || !String(response.content || '').includes('CODEX_UI_OK')) {
+		process.exit(1);
+	}
+});
+
+child.stdin.end(encodeNativeMessage({
+	type: 'interpreter',
+	model: '',
+	promptContext: 'Title: Codex UI smoke test\nContent: Return the exact requested token only.',
+	promptVariables: [{ key: 'prompt_1', prompt: 'Return exactly CODEX_UI_OK.' }],
+}));

--- a/providers.json
+++ b/providers.json
@@ -84,6 +84,17 @@
 			{ "id": "llama3.3", "name": "Llama 3.3 70B" }
 		]
 	},
+	"codex-cli": {
+		"id": "codex-cli",
+		"name": "Codex CLI",
+		"apiKeyRequired": false,
+		"modelsList": "https://help.openai.com/en/articles/11096431",
+		"baseUrl": "native:com.obsidian_clipper.codex",
+		"popularModels": [
+			{ "id": "default", "name": "Codex CLI default", "recommended": true },
+			{ "id": "gpt-5.3-codex", "name": "GPT 5.3 Codex" }
+		]
+	},
 	"openai": {
 		"id": "openai",
 		"name": "OpenAI",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -129,6 +129,21 @@
 	"commandToggleReader": {
 		"message": "Toggle reader"
 	},
+	"codexNativeHostConnected": {
+		"message": "Codex CLI native host is connected."
+	},
+	"codexNativeHostConnectionFailed": {
+		"message": "Codex CLI native host connection failed."
+	},
+	"codexNativeHostConnectionTimedOut": {
+		"message": "Codex CLI native host connection timed out. Reload the extension and try again."
+	},
+	"codexNativeHostSetup": {
+		"message": "Codex CLI native host"
+	},
+	"codexNativeHostSetupDescription": {
+		"message": "Codex CLI uses Chrome Native Messaging. If the host is not installed, copy and run the command below from the repository root, then reload the extension."
+	},
 	"confirmDeleteTemplate": {
 		"message": "Are you sure you want to delete the template \"$1\"?"
 	},
@@ -140,6 +155,9 @@
 	},
 	"copyAsJson": {
 		"message": "Copy as JSON"
+	},
+	"copyInstallCommand": {
+		"message": "Copy install command"
 	},
 	"copyToClipboard": {
 		"message": "Copy to clipboard"
@@ -246,6 +264,12 @@
 				"content": "<strong>"
 			}
 		}
+	},
+	"enableInterpreterImageInput": {
+		"message": "Enable image input for Codex CLI"
+	},
+	"enableInterpreterImageInputDescription": {
+		"message": "Attach the current visible tab screenshot to Codex CLI interpreter requests. Other providers are not affected."
 	},
 	"enableReader": {
 		"message": "Open reading view"
@@ -427,6 +451,12 @@
 	},
 	"importSettings": {
 		"message": "Import settings"
+	},
+	"installCommandCopied": {
+		"message": "Install command copied."
+	},
+	"installCommandCopyFailed": {
+		"message": "Could not copy install command."
 	},
 	"importTemplate": {
 		"message": "Import template"
@@ -1016,6 +1046,12 @@
 	},
 	"templateTriggersDescription": {
 		"message": "Define rules to automatically select this template if it matches a URL pattern or contains schema.org data. One rule per line."
+	},
+	"testConnection": {
+		"message": "Test connection"
+	},
+	"testingConnection": {
+		"message": "Testing connection..."
 	},
 	"templateValid": {
 		"message": "Template syntax is valid"

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -6,13 +6,13 @@ import { extractPageContent, initializePageContent } from '../utils/content-extr
 import { compileTemplate } from '../utils/template-compiler';
 import { initializeIcons, getPropertyTypeIcon } from '../icons/icons';
 import { findMatchingTemplate, initializeTriggers } from '../utils/triggers';
-import { getLocalStorage, setLocalStorage, loadSettings, generalSettings, Settings } from '../utils/storage-utils';
+import { getLocalStorage, setLocalStorage, loadSettings, saveSettings, generalSettings, Settings } from '../utils/storage-utils';
 import { escapeHtml, unescapeValue } from '../utils/string-utils';
 import { loadTemplates, createDefaultTemplate } from '../managers/template-manager';
 import browser from '../utils/browser-polyfill';
 import { addBrowserClassToHtml, detectBrowser } from '../utils/browser-detection';
 import { createElementWithClass } from '../utils/dom-utils';
-import { initializeInterpreter, handleInterpreterUI, collectPromptVariables } from '../utils/interpreter';
+import { initializeInterpreter, handleInterpreterUI, collectPromptVariables, getActiveInterpreterModel } from '../utils/interpreter';
 import { adjustNoteNameHeight } from '../utils/ui-utils';
 import { debugLog } from '../utils/debug';
 import { showVariables, initializeVariablesPanel, updateVariablesPanel } from '../managers/inspect-variables';
@@ -875,7 +875,12 @@ function buildTemplateFieldsSkeleton(template: Template | null) {
 				option.textContent = model.name;
 				modelSelect.appendChild(option);
 			});
-			modelSelect.value = generalSettings.interpreterModel || (enabledModels[0]?.id ?? '');
+			const activeModel = getActiveInterpreterModel(generalSettings.interpreterModel);
+			modelSelect.value = activeModel?.id || '';
+			if (activeModel && generalSettings.interpreterModel !== activeModel.id) {
+				generalSettings.interpreterModel = activeModel.id;
+				void saveSettings();
+			}
 			modelSelect.style.display = 'inline-block';
 		}
 	}
@@ -946,10 +951,9 @@ async function fillTemplateFieldValues(currentTabId: number, template: Template 
 			try {
 				const interpretBtn = document.getElementById('interpret-btn') as HTMLButtonElement;
 				const modelSelect = document.getElementById('model-select') as HTMLSelectElement;
-				const selectedModelId = modelSelect?.value || generalSettings.interpreterModel;
-				const modelConfig = generalSettings.models.find(m => m.id === selectedModelId);
+				const modelConfig = getActiveInterpreterModel(modelSelect?.value);
 				if (!modelConfig) {
-					throw new Error(`Model configuration not found for ${selectedModelId}`);
+					throw new Error('No enabled interpreter model found. Enable a model in Interpreter settings first.');
 				}
 				await handleInterpreterUI(template, variables, currentTabId!, currentUrl, modelConfig);
 
@@ -1329,8 +1333,17 @@ async function handleClipObsidian(): Promise<void> {
 			if (interpretBtn.classList.contains('processing')) {
 				await waitForInterpreter(interpretBtn);
 			} else if (!interpretBtn.classList.contains('done')) {
-				interpretBtn.click();
-				await waitForInterpreter(interpretBtn);
+				const modelSelect = document.getElementById('model-select') as HTMLSelectElement;
+				const modelConfig = getActiveInterpreterModel(modelSelect?.value);
+				if (!modelConfig) {
+					throw new Error('No enabled interpreter model found. Enable a model in Interpreter settings first.');
+				}
+				const tabId = currentTabId;
+				if (!tabId) {
+					throw new Error('No active tab found for interpreter processing.');
+				}
+				const tab = await getTabInfo(tabId);
+				await handleInterpreterUI(currentTemplate, currentVariables, tabId, tab.url || '', modelConfig);
 			}
 		}
 

--- a/src/managers/interpreter-settings.ts
+++ b/src/managers/interpreter-settings.ts
@@ -5,6 +5,8 @@ import { initializeIcons } from '../icons/icons';
 import { showModal, hideModal } from '../utils/modal-utils';
 import { getMessage, translatePage } from '../utils/i18n';
 import { debugLog } from '../utils/debug';
+import browser from '../utils/browser-polyfill';
+import { copyToClipboard } from '../utils/clipboard-utils';
 
 export interface PresetProvider {
 	id: string;
@@ -26,6 +28,7 @@ interface ProviderPresets {
 }
 
 const PROVIDERS_URL = 'https://raw.githubusercontent.com/obsidianmd/obsidian-clipper/refs/heads/main/providers.json';
+const BUNDLED_PROVIDERS_URL = 'providers.json';
 const PRESET_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 const PRESET_RETRY_DELAY = 60 * 1000; // 1 minute
 const LOCAL_STORAGE_KEY = 'provider_presets';
@@ -36,6 +39,46 @@ let lastErrorTime = 0;
 let isFetching = false;
 
 let cachedPresetProviders: Record<string, PresetProvider> | null = null;
+const CODEX_HOST_NAME = 'com.obsidian_clipper.codex';
+const CODEX_PROVIDER_BASE_URL = `native:${CODEX_HOST_NAME}`;
+const CODEX_NATIVE_HOST_TEST_TIMEOUT_MS = 8000;
+type CodexBrowserTarget = 'Chrome' | 'Edge';
+type CodexHostOS = 'windows' | 'macos' | 'linux';
+
+declare const CODEX_NATIVE_HOST_SCRIPT_DIR: string;
+
+function normalizePresetProviders(data: ProviderPresets): Record<string, PresetProvider> {
+	const providers: Record<string, PresetProvider> = {};
+	for (const key in data) {
+		if (key !== 'version' && Object.prototype.hasOwnProperty.call(data, key)) {
+			const provider = data[key] as PresetProvider;
+			provider.id = key;
+			providers[key] = provider;
+		}
+	}
+	return providers;
+}
+
+async function getBundledPresets(): Promise<Record<string, PresetProvider>> {
+	try {
+		const response = await fetch(BUNDLED_PROVIDERS_URL);
+		if (!response.ok) return {};
+		const data = await response.json() as ProviderPresets;
+		return normalizePresetProviders(data);
+	} catch (error) {
+		debugLog('Providers', 'Failed to load bundled providers:', error);
+		return {};
+	}
+}
+
+async function mergeBundledPresets(providers: Record<string, PresetProvider>): Promise<Record<string, PresetProvider>> {
+	const bundledPresets = await getBundledPresets();
+	const merged = { ...providers };
+	if (bundledPresets['codex-cli']) {
+		merged['codex-cli'] = bundledPresets['codex-cli'];
+	}
+	return merged;
+}
 
 async function fetchPresetProviders(): Promise<Record<string, PresetProvider>> {
 	debugLog('Providers', 'Fetching preset providers from URL:', PROVIDERS_URL);
@@ -49,17 +92,10 @@ async function fetchPresetProviders(): Promise<Record<string, PresetProvider>> {
 		await setLocalStorage(LOCAL_STORAGE_KEY, data);
 		debugLog('Providers', 'Stored providers in local storage:', data);
 
-		const providers: Record<string, PresetProvider> = {};
-		for (const key in data) {
-			if (key !== 'version' && Object.prototype.hasOwnProperty.call(data, key)) {
-				const provider = data[key] as PresetProvider;
-				provider.id = key;
-				providers[key] = provider;
-			}
-		}
+		const providers = normalizePresetProviders(data);
 
 		debugLog('Providers', 'Successfully fetched presets:', providers);
-		return providers;
+		return mergeBundledPresets(providers);
 	} catch (error) {
 		console.error('Failed to fetch preset providers:', error);
 		throw error;
@@ -71,15 +107,7 @@ async function getLocalPresets(): Promise<Record<string, PresetProvider> | null>
 		const data = await getLocalStorage(LOCAL_STORAGE_KEY) as ProviderPresets | null;
 		if (!data) return null;
 
-		const providers: Record<string, PresetProvider> = {};
-		for (const key in data) {
-			if (key !== 'version' && Object.prototype.hasOwnProperty.call(data, key)) {
-				const provider = data[key] as PresetProvider;
-				provider.id = key;
-				providers[key] = provider;
-			}
-		}
-		return providers;
+		return normalizePresetProviders(data);
 	} catch (error) {
 		console.error('Failed to get providers from local storage:', error);
 		return null;
@@ -118,10 +146,10 @@ export async function getPresetProviders(): Promise<Record<string, PresetProvide
 		debugLog('Providers', 'Fetching is already in progress or recently failed');
 		const localPresets = await getLocalPresets();
 		if (localPresets) {
-			cachedPresets = localPresets;
+			cachedPresets = await mergeBundledPresets(localPresets);
 		}
 		debugLog('Providers', 'Returning fallback presets (local or previous cache)');
-		return localPresets || cachedPresets || {};
+		return cachedPresets || await getBundledPresets();
 	}
 
 	isFetching = true;
@@ -131,11 +159,11 @@ export async function getPresetProviders(): Promise<Record<string, PresetProvide
 		if (!needsUpdate) {
 			const localPresets = await getLocalPresets();
 			if (localPresets) {
-				cachedPresets = localPresets;
+				cachedPresets = await mergeBundledPresets(localPresets);
 				lastFetchTime = now;
 				lastErrorTime = 0;
 				debugLog('Providers', 'Using up-to-date local storage presets');
-				return localPresets;
+				return cachedPresets;
 			}
 			debugLog('Providers', 'Local presets missing despite version match or failed check, fetching fresh.');
 		}
@@ -153,10 +181,10 @@ export async function getPresetProviders(): Promise<Record<string, PresetProvide
 		
 		const localPresets = await getLocalPresets();
 		if (localPresets) {
-			cachedPresets = localPresets;
+			cachedPresets = await mergeBundledPresets(localPresets);
 		}
 		debugLog('Providers', 'Fetch failed, returning fallback presets (local or previous cache)');
-		return localPresets || cachedPresets || {};
+		return cachedPresets || await getBundledPresets();
 	} finally {
 		isFetching = false;
 	}
@@ -239,6 +267,9 @@ export async function initializeInterpreterSettings(): Promise<void> {
 		if (addProviderBtn) {
 			addProviderBtn.addEventListener('click', (event) => addProviderToList(event));
 		}
+
+		initializeCodexNativeHostSetup();
+		updateCodexNativeHostSetupVisibility();
 	} catch (error) {
 		console.error('Error in initializeInterpreterSettings:', error);
 		// Reset to safe defaults and re-throw to be handled by caller
@@ -257,6 +288,155 @@ function initializeInterpreterToggles(): void {
 
 	initializeSettingToggle('interpreter-auto-run-toggle', generalSettings.interpreterAutoRun, (checked) => {
 		saveSettings({ ...generalSettings, interpreterAutoRun: checked });
+	});
+
+	initializeSettingToggle('interpreter-image-input-toggle', generalSettings.interpreterImageInput, (checked) => {
+		saveSettings({ ...generalSettings, interpreterImageInput: checked });
+	});
+}
+
+function hasCodexProvider(): boolean {
+	return generalSettings.providers.some(provider => provider.baseUrl === CODEX_PROVIDER_BASE_URL);
+}
+
+function hasCodexModel(): boolean {
+	const codexProviderIds = new Set(generalSettings.providers
+		.filter(provider => provider.baseUrl === CODEX_PROVIDER_BASE_URL)
+		.map(provider => provider.id));
+	return generalSettings.models.some(model => codexProviderIds.has(model.providerId));
+}
+
+function shouldShowCodexNativeHostSetup(): boolean {
+	return hasCodexProvider() || hasCodexModel();
+}
+
+function getBrowserInstallTarget(): CodexBrowserTarget {
+	return navigator.userAgent.includes('Edg/') ? 'Edge' : 'Chrome';
+}
+
+function getCodexHostOS(): CodexHostOS {
+	const platform = String(
+		((navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform)
+		|| navigator.platform
+		|| navigator.userAgent
+	).toLowerCase();
+
+	if (platform.includes('win')) return 'windows';
+	if (platform.includes('mac')) return 'macos';
+	return 'linux';
+}
+
+function quoteForPowerShell(value: string): string {
+	return `"${value.replace(/"/g, '`"')}"`;
+}
+
+function quoteForShell(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function getCodexNativeHostScriptPath(fileName: string, fallbackPath: string): string {
+	const scriptDir = typeof CODEX_NATIVE_HOST_SCRIPT_DIR === 'string' ? CODEX_NATIVE_HOST_SCRIPT_DIR : '';
+	if (!scriptDir) return fallbackPath;
+	const separator = scriptDir.includes('\\') ? '\\' : '/';
+	return `${scriptDir.replace(/[\\/]+$/, '')}${separator}${fileName}`;
+}
+
+function buildCodexNativeHostInstallCommand(): string {
+	const browserName = getBrowserInstallTarget();
+	const extensionId = browser.runtime.id;
+	const osName = getCodexHostOS();
+
+	if (osName === 'windows') {
+		const scriptPath = getCodexNativeHostScriptPath('install-codex-host-windows.ps1', '.\\native\\install-codex-host-windows.ps1');
+		return [
+			'powershell.exe',
+			'-NoProfile',
+			'-ExecutionPolicy Bypass',
+			'-File',
+			quoteForPowerShell(scriptPath),
+			'-Browser',
+			browserName,
+			'-ExtensionId',
+			quoteForPowerShell(extensionId),
+		].join(' ');
+	}
+
+	const scriptPath = getCodexNativeHostScriptPath('install-codex-host-unix.sh', './native/install-codex-host-unix.sh');
+	return [
+		'bash',
+		quoteForShell(scriptPath),
+		'--browser',
+		browserName.toLowerCase(),
+		'--extension-id',
+		quoteForShell(extensionId),
+	].join(' ');
+}
+
+function setCodexNativeHostStatus(message: string, state: 'neutral' | 'success' | 'error' = 'neutral'): void {
+	const status = document.getElementById('codex-native-host-status');
+	if (!status) return;
+	status.textContent = message;
+	status.className = `setting-item-description codex-native-host-status is-${state}`;
+}
+
+function updateCodexNativeHostSetupVisibility(): void {
+	const container = document.getElementById('codex-native-host-setup');
+	const command = document.getElementById('codex-native-host-command') as HTMLTextAreaElement | null;
+	if (!container || !command) return;
+
+	const visible = shouldShowCodexNativeHostSetup();
+	container.style.display = visible ? 'block' : 'none';
+	if (visible) {
+		command.value = buildCodexNativeHostInstallCommand();
+	}
+}
+
+function initializeCodexNativeHostSetup(): void {
+	const copyButton = document.getElementById('copy-codex-native-host-command') as HTMLButtonElement | null;
+	const testButton = document.getElementById('test-codex-native-host') as HTMLButtonElement | null;
+	const command = document.getElementById('codex-native-host-command') as HTMLTextAreaElement | null;
+
+	if (!copyButton || !testButton || !command) return;
+
+	copyButton.addEventListener('click', async () => {
+		command.value = buildCodexNativeHostInstallCommand();
+		const copied = await copyToClipboard(command.value);
+		setCodexNativeHostStatus(
+			copied ? getMessage('installCommandCopied') : getMessage('installCommandCopyFailed'),
+			copied ? 'success' : 'error'
+		);
+	});
+
+	testButton.addEventListener('click', async () => {
+		testButton.disabled = true;
+		setCodexNativeHostStatus(getMessage('testingConnection'));
+		try {
+			const response = await withTimeout(
+				browser.runtime.sendNativeMessage(CODEX_HOST_NAME, { type: 'ping' }) as Promise<{ ok?: boolean; host?: string; pong?: boolean; error?: string }>,
+				CODEX_NATIVE_HOST_TEST_TIMEOUT_MS,
+				getMessage('codexNativeHostConnectionTimedOut')
+			);
+			if (response?.ok && response?.pong) {
+				setCodexNativeHostStatus(getMessage('codexNativeHostConnected'), 'success');
+			} else {
+				setCodexNativeHostStatus(response?.error || getMessage('codexNativeHostConnectionFailed'), 'error');
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			setCodexNativeHostStatus(message || getMessage('codexNativeHostConnectionFailed'), 'error');
+		} finally {
+			testButton.disabled = false;
+		}
+	});
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutMessage: string): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timeoutId = window.setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+		promise
+			.then(resolve)
+			.catch(reject)
+			.finally(() => window.clearTimeout(timeoutId));
 	});
 }
 
@@ -425,6 +605,7 @@ function duplicateProvider(index: number) {
 	generalSettings.providers.push(duplicatedProvider);
 	saveSettings();
 	initializeProviderList();
+	updateCodexNativeHostSetupVisibility();
 
 	const newIndex = generalSettings.providers.length - 1;
 	showProviderModal(duplicatedProvider, newIndex);
@@ -443,6 +624,7 @@ function deleteProvider(index: number): void {
 		generalSettings.providers.splice(index, 1);
 		saveSettings();
 		initializeProviderList();
+		updateCodexNativeHostSetupVisibility();
 	}
 }
 
@@ -623,6 +805,7 @@ async function showProviderModal(provider: Provider, index?: number) {
 			await saveSettings();
 			debugLog('Providers', 'Settings saved');
 			initializeProviderList();
+			updateCodexNativeHostSetupVisibility();
 			hideModal(modal);
 		} catch (error) {
 			console.error('Failed to save settings:', error);
@@ -1053,6 +1236,7 @@ async function showModelModal(model: ModelConfig, index?: number) {
 			try {
 				await saveSettings();
 				initializeModelList();
+				updateCodexNativeHostSetupVisibility();
 				hideModal(modal);
 			} catch (error) {
 				console.error('Failed to save model settings:', error);
@@ -1073,6 +1257,7 @@ function deleteModel(index: number) {
 		generalSettings.models.splice(index, 1);
 		saveSettings();
 		initializeModelList();
+		updateCodexNativeHostSetupVisibility();
 	}
 }
 
@@ -1086,6 +1271,7 @@ function initializeAutoSave(): void {
 function saveInterpreterSettingsFromForm(): void {
 	const interpreterToggle = document.getElementById('interpreter-toggle') as HTMLInputElement;
 	const interpreterAutoRunToggle = document.getElementById('interpreter-auto-run-toggle') as HTMLInputElement;
+	const interpreterImageInputToggle = document.getElementById('interpreter-image-input-toggle') as HTMLInputElement;
 	const defaultPromptContextInput = document.getElementById('default-prompt-context') as HTMLTextAreaElement;
 
 	const updatedSettings: Partial<typeof generalSettings> = {}; 
@@ -1094,6 +1280,9 @@ function saveInterpreterSettingsFromForm(): void {
 	}
 	if (interpreterAutoRunToggle) {
 		updatedSettings.interpreterAutoRun = interpreterAutoRunToggle.checked;
+	}
+	if (interpreterImageInputToggle) {
+		updatedSettings.interpreterImageInput = interpreterImageInputToggle.checked;
 	}
 	if (defaultPromptContextInput) {
 		updatedSettings.defaultPromptContext = defaultPromptContextInput.value;
@@ -1124,6 +1313,7 @@ function duplicateModel(index: number) {
 	
 	saveSettings();
 	initializeModelList();
+	updateCodexNativeHostSetupVisibility();
 
 	const newIndex = index + 1;
 	showModelModal(duplicatedModel, newIndex);

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -10,6 +10,7 @@
 		"clipboardWrite",
 		"commands",
 		"contextMenus",
+		"nativeMessaging",
 		"sidePanel",
 		"storage",
 		"scripting",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -9,6 +9,7 @@
 		"activeTab",
 		"clipboardWrite",
 		"contextMenus",
+		"nativeMessaging",
 		"storage",
 		"scripting",
 		"webRequest",

--- a/src/settings.html
+++ b/src/settings.html
@@ -555,6 +555,27 @@
 									<div class="setting-item-description" data-i18n="defaultInterpreterContextDescription">Override the context used to interpret prompt variables. Variables can be used here.</div>
 									<textarea id="default-prompt-context" rows="4" placeholder="{{fullHtml}}" spellcheck="false"></textarea>
 								</div>
+								<div class="setting-item mod-horizontal mod-toggle">
+									<div class="setting-item-info">
+										<label for="interpreter-image-input-toggle" data-i18n="enableInterpreterImageInput">Enable image input for Codex CLI</label>
+										<div class="setting-item-description" data-i18n="enableInterpreterImageInputDescription">Attach the current visible tab screenshot to Codex CLI interpreter requests. Other providers are not affected.</div>
+									</div>
+									<div class="setting-item-control">
+										<div class="checkbox-container">
+											<input type="checkbox" id="interpreter-image-input-toggle" />
+										</div>
+									</div>
+								</div>
+								<div class="setting-item" id="codex-native-host-setup" style="display: none;">
+									<label data-i18n="codexNativeHostSetup">Codex CLI native host</label>
+									<div class="setting-item-description" id="codex-native-host-description" data-i18n="codexNativeHostSetupDescription">Codex CLI uses Chrome Native Messaging. If the host is not installed, copy and run the command below from the repository root, then reload the extension.</div>
+									<textarea id="codex-native-host-command" rows="3" spellcheck="false" readonly></textarea>
+									<div class="setting-item-control">
+										<button type="button" id="copy-codex-native-host-command" data-i18n="copyInstallCommand">Copy install command</button>
+										<button type="button" id="test-codex-native-host" data-i18n="testConnection">Test connection</button>
+									</div>
+									<div class="setting-item-description" id="codex-native-host-status"></div>
+								</div>
 								
 								</div>
 							</div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -85,6 +85,7 @@ export interface Settings {
 	providers: Provider[];
 	interpreterEnabled: boolean;
 	interpreterAutoRun: boolean;
+	interpreterImageInput: boolean;
 	defaultPromptContext: string;
 	propertyTypes: PropertyType[];
 	readerSettings: ReaderSettings;

--- a/src/utils/__mocks__/webextension-polyfill.ts
+++ b/src/utils/__mocks__/webextension-polyfill.ts
@@ -2,6 +2,7 @@
 export const runtime = {
 	getURL: (path: string) => `chrome-extension://mock-id/${path}`,
 	sendMessage: async () => ({}),
+	sendNativeMessage: async () => ({}),
 	onMessage: {
 		addListener: () => {},
 		removeListener: () => {},
@@ -20,7 +21,9 @@ export const storage = {
 };
 
 export const tabs = {
+	get: async () => ({}),
 	query: async () => [],
+	captureVisibleTab: async () => '',
 	sendMessage: async () => ({}),
 };
 

--- a/src/utils/cli-stubs.ts
+++ b/src/utils/cli-stubs.ts
@@ -21,6 +21,7 @@ export const generalSettings: Settings = {
 	providers: [],
 	interpreterEnabled: false,
 	interpreterAutoRun: false,
+	interpreterImageInput: false,
 	defaultPromptContext: '',
 	propertyTypes: [],
 	readerSettings: {

--- a/src/utils/interpreter-codex.test.ts
+++ b/src/utils/interpreter-codex.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import browser from './browser-polyfill';
+import { collectPromptVariables, getActiveInterpreterModel, sendToLLM } from './interpreter';
+import { generalSettings } from './storage-utils';
+import { ModelConfig } from '../types/types';
+
+describe('Codex CLI interpreter provider', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		generalSettings.interpreterImageInput = false;
+		generalSettings.interpreterModel = '';
+		generalSettings.models = [];
+		generalSettings.providers = [];
+	});
+
+	it('routes Codex CLI providers through Native Messaging', async () => {
+		vi.spyOn(Date, 'now').mockReturnValue(61000);
+		const sendNativeMessage = vi.spyOn(browser.runtime, 'sendNativeMessage').mockResolvedValue({
+			ok: true,
+			content: JSON.stringify({
+				prompts_responses: {
+					prompt_1: 'Codex response',
+				},
+			}),
+		});
+
+		generalSettings.providers = [{
+			id: 'codex-provider',
+			name: 'Codex CLI',
+			baseUrl: 'native:com.obsidian_clipper.codex',
+			apiKey: '',
+			apiKeyRequired: false,
+		}];
+		const model: ModelConfig = {
+			id: 'codex-model',
+			name: 'Codex CLI default',
+			providerId: 'codex-provider',
+			providerModelId: 'default',
+			enabled: true,
+		};
+
+		const result = await sendToLLM('Context', '', [{ key: 'prompt_1', prompt: 'Summarize' }], model);
+
+		expect(sendNativeMessage).toHaveBeenCalledWith('com.obsidian_clipper.codex', {
+			type: 'interpreter',
+			model: '',
+			promptContext: 'Context',
+			promptVariables: [{ key: 'prompt_1', prompt: 'Summarize' }],
+		});
+		expect(result.promptResponses[0].user_response).toBe('Codex response');
+	});
+
+	it('collects unquoted prompt variables', () => {
+		const promptVariables = collectPromptVariables({
+			id: 'template',
+			name: 'Template',
+			behavior: 'create',
+			noteNameFormat: '{{title}}',
+			path: '',
+			noteContentFormat: '{{prompt:Return exactly CODEX_CLIPPER_CONNECTED.}}',
+			properties: [],
+		});
+
+		expect(promptVariables).toEqual([{
+			key: 'prompt_1',
+			prompt: 'Return exactly CODEX_CLIPPER_CONNECTED.',
+			filters: '',
+		}]);
+	});
+
+	it('falls back to the first enabled interpreter model when the selected model is empty or stale', () => {
+		generalSettings.interpreterModel = 'missing-model';
+		generalSettings.models = [
+			{ id: 'disabled-model', name: 'Disabled', providerId: 'provider', providerModelId: 'disabled', enabled: false },
+			{ id: 'enabled-model', name: 'Enabled', providerId: 'provider', providerModelId: 'enabled', enabled: true },
+		];
+
+		expect(getActiveInterpreterModel('')?.id).toBe('enabled-model');
+		expect(getActiveInterpreterModel('missing-model')?.id).toBe('enabled-model');
+	});
+
+	it('fails Codex native responses that do not contain prompt responses', async () => {
+		vi.spyOn(Date, 'now').mockReturnValue(183000);
+		vi.spyOn(browser.runtime, 'sendNativeMessage').mockResolvedValue({
+			ok: true,
+			content: 'not json',
+		});
+
+		generalSettings.providers = [{
+			id: 'codex-provider',
+			name: 'Codex CLI',
+			baseUrl: 'native:com.obsidian_clipper.codex',
+			apiKey: '',
+			apiKeyRequired: false,
+		}];
+		const model: ModelConfig = {
+			id: 'codex-model',
+			name: 'Codex CLI default',
+			providerId: 'codex-provider',
+			providerModelId: 'default',
+			enabled: true,
+		};
+
+		await expect(sendToLLM('Context', '', [{ key: 'prompt_1', prompt: 'Summarize' }], model))
+			.rejects.toThrow('Codex CLI response did not contain valid prompt responses.');
+	});
+
+	it('attaches the visible tab screenshot when Codex image input is enabled', async () => {
+		vi.spyOn(Date, 'now').mockReturnValue(122000);
+		const sendNativeMessage = vi.spyOn(browser.runtime, 'sendNativeMessage').mockResolvedValue({
+			ok: true,
+			content: JSON.stringify({
+				prompts_responses: {
+					prompt_1: 'Image response',
+				},
+			}),
+		});
+		vi.spyOn(browser.tabs, 'get').mockResolvedValue({ windowId: 7 } as any);
+		vi.spyOn(browser.tabs, 'captureVisibleTab').mockResolvedValue('data:image/jpeg;base64,abc123');
+
+		generalSettings.interpreterImageInput = true;
+		generalSettings.providers = [{
+			id: 'codex-provider',
+			name: 'Codex CLI',
+			baseUrl: 'native:com.obsidian_clipper.codex',
+			apiKey: '',
+			apiKeyRequired: false,
+		}];
+		const model: ModelConfig = {
+			id: 'codex-model',
+			name: 'Codex CLI default',
+			providerId: 'codex-provider',
+			providerModelId: 'default',
+			enabled: true,
+		};
+
+		const result = await sendToLLM('Context', '', [{ key: 'prompt_1', prompt: 'Describe the screenshot' }], model, { tabId: 3 });
+
+		expect(browser.tabs.captureVisibleTab).toHaveBeenCalledWith(7, { format: 'jpeg', quality: 75 });
+		expect(sendNativeMessage).toHaveBeenCalledWith('com.obsidian_clipper.codex', {
+			type: 'interpreter',
+			model: '',
+			promptContext: 'Context',
+			promptVariables: [{ key: 'prompt_1', prompt: 'Describe the screenshot' }],
+			imageAttachments: [{ name: 'visible-tab.jpg', dataUrl: 'data:image/jpeg;base64,abc123' }],
+		});
+		expect(result.promptResponses[0].user_response).toBe('Image response');
+	});
+});

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -7,14 +7,113 @@ import { adjustNoteNameHeight } from './ui-utils';
 import { debugLog } from './debug';
 import { getMessage } from './i18n';
 import { updateTokenCount } from './token-counter';
+import browser from './browser-polyfill';
 
 const RATE_LIMIT_RESET_TIME = 60000; // 1 minute in milliseconds
 let lastRequestTime = 0;
+const PROMPT_VARIABLE_REGEX = /{{(?:(?:prompt:)(?:"([\s\S]*?)"|([^|}]*?))|"([\s\S]*?)")(\|[\s\S]*?)?}}/g;
 
 // Store event listeners for cleanup
 const eventListeners = new WeakMap<HTMLElement, { [key: string]: EventListener }>();
 
-export async function sendToLLM(promptContext: string, content: string, promptVariables: PromptVariable[], model: ModelConfig): Promise<{ promptResponses: any[] }> {
+interface CodexNativeResponse {
+	ok?: boolean;
+	content?: string;
+	error?: string;
+	code?: number;
+}
+
+interface CodexImageAttachment {
+	name: string;
+	dataUrl: string;
+}
+
+interface SendToLLMOptions {
+	tabId?: number;
+}
+
+function isCodexProvider(provider: { name: string; baseUrl: string }): boolean {
+	return provider.name.toLowerCase().includes('codex') && provider.baseUrl.startsWith('native:');
+}
+
+export function getActiveInterpreterModel(selectedModelId?: string): ModelConfig | null {
+	const enabledModels = generalSettings.models.filter(model => model.enabled);
+	const candidateIds = [
+		selectedModelId,
+		generalSettings.interpreterModel,
+	].filter(Boolean) as string[];
+
+	for (const candidateId of candidateIds) {
+		const model = enabledModels.find(enabledModel => enabledModel.id === candidateId);
+		if (model) return model;
+	}
+
+	return enabledModels[0] || null;
+}
+
+function getCodexHostName(baseUrl: string): string {
+	const hostName = baseUrl.replace(/^native:/, '').trim();
+	if (!hostName) throw new Error('Codex CLI provider Base URL must be native:<host-name>.');
+	return hostName;
+}
+
+async function captureVisibleTabForCodex(tabId?: number): Promise<CodexImageAttachment[]> {
+	if (!generalSettings.interpreterImageInput || tabId === undefined) return [];
+
+	const tabs = browser.tabs as typeof browser.tabs & {
+		get?: (tabId: number) => Promise<{ windowId?: number }>;
+		captureVisibleTab?: (windowId?: number, options?: { format?: 'jpeg' | 'png'; quality?: number }) => Promise<string>;
+	};
+
+	if (typeof tabs.captureVisibleTab !== 'function') return [];
+
+	const tab = typeof tabs.get === 'function' ? await tabs.get(tabId).catch(() => null) : null;
+	const dataUrl = await tabs.captureVisibleTab(tab?.windowId, { format: 'jpeg', quality: 75 });
+	return [{ name: 'visible-tab.jpg', dataUrl }];
+}
+
+async function sendToCodexNative(
+	promptContext: string,
+	promptVariables: PromptVariable[],
+	model: ModelConfig,
+	provider: { baseUrl: string },
+	options: SendToLLMOptions = {},
+): Promise<{ promptResponses: any[] }> {
+	const runtime = browser.runtime as typeof browser.runtime & {
+		sendNativeMessage?: (application: string, message: unknown) => Promise<CodexNativeResponse>;
+	};
+
+	if (typeof runtime.sendNativeMessage !== 'function') {
+		throw new Error('Native Messaging is not available in this browser build.');
+	}
+
+	const hostName = getCodexHostName(provider.baseUrl);
+	const imageAttachments = await captureVisibleTabForCodex(options.tabId);
+	const message: Record<string, unknown> = {
+		type: 'interpreter',
+		model: model.providerModelId === 'default' ? '' : model.providerModelId,
+		promptContext,
+		promptVariables,
+	};
+	if (imageAttachments.length > 0) {
+		message.imageAttachments = imageAttachments;
+	}
+
+	const response = await runtime.sendNativeMessage(hostName, message) as CodexNativeResponse;
+
+	if (!response?.ok) {
+		const suffix = response?.code !== undefined ? ` (exit ${response.code})` : '';
+		throw new Error(`Codex CLI failed${suffix}: ${response?.error || 'No response from native host'}`);
+	}
+
+	const parsedResponse = parseLLMResponse(response.content || '', promptVariables);
+	if (promptVariables.length > 0 && parsedResponse.promptResponses.length === 0) {
+		throw new Error('Codex CLI response did not contain valid prompt responses.');
+	}
+	return parsedResponse;
+}
+
+export async function sendToLLM(promptContext: string, content: string, promptVariables: PromptVariable[], model: ModelConfig, options: SendToLLMOptions = {}): Promise<{ promptResponses: any[] }> {
 	debugLog('Interpreter', 'Sending request to LLM...');
 	
 	// Find the provider for this model
@@ -34,6 +133,12 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 	}
 
 	try {
+		if (isCodexProvider(provider)) {
+			const result = await sendToCodexNative(promptContext, promptVariables, model, provider, options);
+			lastRequestTime = now;
+			return result;
+		}
+
 		const systemContent = 
 			`You are a helpful assistant. Please respond with one JSON object named \`prompts_responses\` — no explanatory text before or after. Use the keys provided, e.g. \`prompt_1\`, \`prompt_2\`, and fill in the values. Values should be Markdown strings unless otherwise specified. Make your responses concise. For example, your response should look like: {"prompts_responses":{"prompt_1":"tag1, tag2, tag3","prompt_2":"- bullet1\n- bullet 2\n- bullet3"}}`;
 		
@@ -358,10 +463,10 @@ function parseLLMResponse(responseContent: string, promptVariables: PromptVariab
 
 export function collectPromptVariables(template: Template | null): PromptVariable[] {
 	const promptMap = new Map<string, PromptVariable>();
-	const promptRegex = /{{(?:prompt:)?"([\s\S]*?)"(\|.*?)?}}/g;
 	let match;
 
 	function addPrompt(prompt: string, filters: string) {
+		prompt = prompt.trim();
 		if (!promptMap.has(prompt)) {
 			const key = `prompt_${promptMap.size + 1}`;
 			promptMap.set(prompt, { key, prompt, filters });
@@ -369,29 +474,34 @@ export function collectPromptVariables(template: Template | null): PromptVariabl
 	}
 
 	if (template?.noteContentFormat) {
-		while ((match = promptRegex.exec(template.noteContentFormat)) !== null) {
-			addPrompt(match[1], match[2] || '');
+		PROMPT_VARIABLE_REGEX.lastIndex = 0;
+		while ((match = PROMPT_VARIABLE_REGEX.exec(template.noteContentFormat)) !== null) {
+			addPrompt(match[1] || match[2] || match[3] || '', match[4] || '');
 		}
 	}
 
 	if (template?.properties) {
 		for (const property of template.properties) {
 			let propertyValue = property.value;
-			while ((match = promptRegex.exec(propertyValue)) !== null) {
-				addPrompt(match[1], match[2] || '');
+			PROMPT_VARIABLE_REGEX.lastIndex = 0;
+			while ((match = PROMPT_VARIABLE_REGEX.exec(propertyValue)) !== null) {
+				addPrompt(match[1] || match[2] || match[3] || '', match[4] || '');
 			}
 		}
 	}
 
-	const allInputs = document.querySelectorAll('input, textarea');
-	allInputs.forEach((input) => {
-		if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
-			let inputValue = input.value;
-			while ((match = promptRegex.exec(inputValue)) !== null) {
-				addPrompt(match[1], match[2] || '');
+	if (typeof document !== 'undefined') {
+		const allInputs = document.querySelectorAll('input, textarea');
+		allInputs.forEach((input) => {
+			if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+				let inputValue = input.value;
+				PROMPT_VARIABLE_REGEX.lastIndex = 0;
+				while ((match = PROMPT_VARIABLE_REGEX.exec(inputValue)) !== null) {
+					addPrompt(match[1] || match[2] || match[3] || '', match[4] || '');
+				}
 			}
-		}
-	});
+		});
+	}
 
 	return Array.from(promptMap.values());
 }
@@ -461,10 +571,9 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 		// Only add click listener if auto-run is disabled
 		if (interpretBtn && !generalSettings.interpreterAutoRun) {
 			const clickListener = async () => {
-				const selectedModelId = modelSelect.value;
-				const modelConfig = generalSettings.models.find(m => m.id === selectedModelId);
+				const modelConfig = getActiveInterpreterModel(modelSelect?.value);
 				if (!modelConfig) {
-					throw new Error(`Model configuration not found for ${selectedModelId}`);
+					throw new Error('No enabled interpreter model found. Enable a model in Interpreter settings first.');
 				}
 				await handleInterpreterUI(template, variables, tabId, currentUrl, modelConfig);
 			};
@@ -495,12 +604,14 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 
 			// Validate that the selected model is still enabled
 			const enabledModels = generalSettings.models.filter(model => model.enabled);
-			const lastSelectedModel = enabledModels.find(model => model.id === generalSettings.interpreterModel);
+			const activeModel = getActiveInterpreterModel(modelSelect.value);
 
-			if (!lastSelectedModel && enabledModels.length > 0) {
-				generalSettings.interpreterModel = enabledModels[0].id;
+			if (activeModel) {
+				generalSettings.interpreterModel = activeModel.id;
 				await saveSettings();
 				modelSelect.value = generalSettings.interpreterModel;
+			} else if (enabledModels.length === 0) {
+				modelSelect.value = '';
 			}
 		}
 	}
@@ -571,7 +682,7 @@ export async function handleInterpreterUI(
 			responseTimer.textContent = formatDuration(elapsedTime);
 		}, 10);
 
-		const { promptResponses } = await sendToLLM(contextToUse, contentToProcess, promptVariables, modelConfig);
+		const { promptResponses } = await sendToLLM(contextToUse, contentToProcess, promptVariables, modelConfig, { tabId });
 		debugLog('Interpreter', 'LLM response:', { promptResponses });
 
 		// Stop the timer and update UI
@@ -638,7 +749,8 @@ export function replacePromptVariables(promptVariables: PromptVariable[], prompt
 	const allInputs = document.querySelectorAll('input, textarea');
 	allInputs.forEach((input) => {
 		if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
-			input.value = input.value.replace(/{{(?:prompt:)?"([\s\S]*?)"(\|[\s\S]*?)?}}/g, (match, promptText, filters) => {
+			input.value = input.value.replace(PROMPT_VARIABLE_REGEX, (match, quotedPrompt, unquotedPrompt, shorthandPrompt, filters) => {
+				const promptText = String(quotedPrompt || unquotedPrompt || shorthandPrompt || '').trim();
 				const variable = promptVariables.find(v => v.prompt === promptText);
 				if (!variable) return match;
 

--- a/src/utils/parser.test.ts
+++ b/src/utils/parser.test.ts
@@ -13,6 +13,7 @@ import {
 	BinaryExpression,
 	UnaryExpression,
 	FilterExpression,
+	validateVariables,
 } from './parser';
 
 // Type guards
@@ -170,6 +171,17 @@ describe('Parser', () => {
 			const varNode = result.ast[0] as VariableNode;
 			expect(isIdentifier(varNode.expression)).toBe(true);
 			expect((varNode.expression as IdentifierExpression).name).toBe('author.name');
+		});
+
+		test('does not warn for prompt variables', () => {
+			const result = parse([
+				'{{prompt:"Return exactly CODEX_CLIPPER_CONNECTED."}}',
+				'{{prompt:Return exactly CODEX_CLIPPER_CONNECTED.}}',
+				'{{"Return exactly CODEX_CLIPPER_CONNECTED."}}',
+			].join('\n'));
+
+			expect(result.errors).toHaveLength(0);
+			expect(validateVariables(result.ast)).toHaveLength(0);
 		});
 	});
 

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1691,6 +1691,10 @@ export function validateVariables(ast: ASTNode[]): ParserError[] {
 
 	// Check each reference against its scope
 	for (const ref of references) {
+		if (ref.name.startsWith('prompt:') || ref.name.startsWith('"')) {
+			continue;
+		}
+
 		if (!isValidVariable(ref.name, ref.scope)) {
 			const similar = findSimilarVariable(ref.name);
 			let message = `Unknown variable "${ref.name}"`;

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -20,6 +20,7 @@ export let generalSettings: Settings = {
 	providers: [],
 	interpreterEnabled: false,
 	interpreterAutoRun: false,
+	interpreterImageInput: false,
 	defaultPromptContext: '',
 	propertyTypes: [],
 	readerSettings: {
@@ -96,6 +97,7 @@ interface StorageData {
 		providers?: Provider[];
 		interpreterEnabled?: boolean;
 		interpreterAutoRun?: boolean;
+		interpreterImageInput?: boolean;
 		defaultPromptContext?: string;
 	};
 	property_types?: PropertyType[];
@@ -131,6 +133,7 @@ export async function loadSettings(): Promise<Settings> {
 		providers: [],
 		interpreterEnabled: false,
 		interpreterAutoRun: false,
+		interpreterImageInput: false,
 		defaultPromptContext: '',
 		propertyTypes: [],
 		saveBehavior: 'addToObsidian',
@@ -194,6 +197,7 @@ export async function loadSettings(): Promise<Settings> {
 		providers: sanitizedProviders,
 		interpreterEnabled: data.interpreter_settings?.interpreterEnabled ?? defaultSettings.interpreterEnabled,
 		interpreterAutoRun: data.interpreter_settings?.interpreterAutoRun ?? defaultSettings.interpreterAutoRun,
+		interpreterImageInput: data.interpreter_settings?.interpreterImageInput ?? defaultSettings.interpreterImageInput,
 		defaultPromptContext: data.interpreter_settings?.defaultPromptContext || defaultSettings.defaultPromptContext,
 		propertyTypes: data.property_types || defaultSettings.propertyTypes,
 		readerSettings: {
@@ -250,6 +254,7 @@ export async function saveSettings(settings?: Partial<Settings>): Promise<void> 
 			providers: generalSettings.providers,
 			interpreterEnabled: generalSettings.interpreterEnabled,
 			interpreterAutoRun: generalSettings.interpreterAutoRun,
+			interpreterImageInput: generalSettings.interpreterImageInput,
 			defaultPromptContext: generalSettings.defaultPromptContext
 		},
 		property_types: generalSettings.propertyTypes,

--- a/src/utils/variables/prompt.ts
+++ b/src/utils/variables/prompt.ts
@@ -4,15 +4,13 @@ import { generalSettings } from '../storage-utils';
 // so that it's still visible in the input fields in the popup
 export async function processPrompt(match: string, variables: { [key: string]: string }, currentUrl: string): Promise<string> {
 	if (generalSettings.interpreterEnabled) {
-		const promptRegex = /{{(?:prompt:)?"(.*?)"(\|.*?)?}}/;
+		const promptRegex = /{{(?:(?:prompt:)(?:"([\s\S]*?)"|([^|}]*?))|"([\s\S]*?)")(\|[\s\S]*?)?}}/;
 		const matches = match.match(promptRegex);
 		if (!matches) {
 			console.error('Invalid prompt format:', match);
 			return match;
 		}
-	
-		const [, promptText, filters = ''] = matches;
-	
+
 		return match;
 	} else {
 		return '';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,6 +146,7 @@ module.exports = (env, argv) => {
 					{ from: "src/popup.html", to: "popup.html" },
 					{ from: "src/side-panel.html", to: "side-panel.html" },
 					{ from: "src/settings.html", to: "settings.html" },
+					{ from: "providers.json", to: "providers.json" },
 					{ from: "src/highlights.html", to: "highlights.html" },
 					{ from: "src/reader.html", to: "reader.html" },
 					{ from: "src/icons", to: "icons" },
@@ -169,7 +170,8 @@ module.exports = (env, argv) => {
 			},
 			new webpack.DefinePlugin({
 				'process.env.NODE_ENV': JSON.stringify(argv.mode),
-				'DEBUG_MODE': JSON.stringify(!isProduction)
+				'DEBUG_MODE': JSON.stringify(!isProduction),
+				'CODEX_NATIVE_HOST_SCRIPT_DIR': JSON.stringify(process.env.CODEX_NATIVE_HOST_SCRIPT_DIR || '')
 			}),
 			...(isProduction ? [
 				new ZipPlugin({


### PR DESCRIPTION
Closes #880.

## Summary
- Adds Codex CLI as a local interpreter provider through browser Native Messaging.
- Adds native host setup helpers for Windows, macOS, and Linux, plus a settings-panel connection test.
- Supports existing prompt variables, including unquoted prompt syntax such as `{{prompt:Return exactly OK.}}`.
- Adds optional visible-tab screenshot input for Codex CLI interpreter requests.
- Falls back to an enabled interpreter model when the saved selected model is stale or empty.

## Validation
- `npm test -- --run src/utils/interpreter-codex.test.ts src/utils/parser.test.ts`
- `node native/test-codex-host.mjs`
- `node native/test-codex-interpreter.mjs`
- `npm run build:chrome`

The native interpreter smoke test returned `CODEX_UI_OK` through the Codex CLI native host.
