### PR TITLE
CLI: make the URL argument optional when reading local HTML

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ Options:
                                If a directory, auto-matches template by URL triggers
   -o, --output <path>          Output .md file path (default: stdout)
       --html <path>            Read HTML from file instead of fetching URL (use - for stdin)
+                               When set, the <url> argument is optional
       --vault <name>           Obsidian vault name
       --open                   Send to Obsidian instead of writing file
       --uri                    Use URI scheme instead of Obsidian CLI
@@ -104,8 +105,8 @@ function parseArgs(argv: string[]): CliArgs {
 		}
 	}
 
-	if (!url) {
-		console.error('Error: URL is required');
+	if (!url && !htmlPath) {
+		console.error('Error: a <url> argument is required (or use --html to read local HTML)');
 		printUsage();
 		process.exit(1);
 	}
@@ -184,6 +185,13 @@ async function main(): Promise<void> {
 			html = fs.readFileSync(0, 'utf-8'); // stdin
 		} else {
 			html = fs.readFileSync(path.resolve(args.htmlPath), 'utf-8');
+		}
+		// Fall back to the page's own canonical URL when none is passed.
+		if (!args.url) {
+			const { document } = parseHTML(html);
+			args.url = document.querySelector('link[rel="canonical"]')?.getAttribute('href')
+				|| document.querySelector('meta[property="og:url"]')?.getAttribute('content')
+				|| 'about:blank';
 		}
 	} else {
 		const response = await fetch(args.url);


### PR DESCRIPTION
## Summary

The CLI supports `--html` to read a page from disk instead of fetching it, but it still required the positional `<url>` argument, so the documented stdin/file mode was unusable on its own:

```bash
curl -L https://example.com > page.html
obsidian-clipper --html page.html -t template.json
# Error: URL is required
``` 

This PR makes `url` required only when the CLI actually needs to fetch. When it is omitted in `--html` mode, the URL is derived from the page's `<link rel="canonical">` or `og:url` (fallback to `about:blank`) so the `{{url}}` variable and `source` property stay populated.

Passing an explicit `<url>` together with `--html` still works and takes precedence, as before.

## Repro

```bash
npm run build:cli
obsidian-clipper --html page.html -t template.json          # file
cat page.html | obsidian-clipper --html - -t template.json  # stdin
``` 

Before: `Error: URL is required`
After: clip completes, `source` is taken from the page's canonical URL.

## Scope

`src/cli.ts` argument validation and the `--html` branch. The fetch path and the extension are unchanged.

## Tests

Verified all three modes (file, stdin, file + explicit URL) produce the expected frontmatter, and that running with neither `<url>` nor `--html` still errors with a clear message.