### PR TITLE
Fix highlights across the page and Reading view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"css-loader": "^7.1.2",
 				"dotenv": "^16.4.1",
 				"esbuild": "^0.28.1",
+				"jsdom": "^29.1.1",
 				"mini-css-extract-plugin": "^2.9.1",
 				"sass": "^1.77.8",
 				"sass-loader": "^16.0.1",
@@ -62,6 +63,70 @@
 				"temml": "^0.11.2"
 			}
 		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -82,6 +147,148 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+			"integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -544,6 +751,24 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1108,6 +1333,25 @@
 			"integrity": "sha512-wz7kjjRRj8/Lty4B+Kr0LN6Ypc/3SymeCCGSbaXp2leH0ZVg/PriNiOwNj4bD4uphI7A8NXS4b6Gl373sfO5mA==",
 			"dev": true
 		},
+		"node_modules/@types/whatwg-mimetype": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+			"integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -1566,6 +1810,16 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1645,6 +1899,20 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
+		},
+		"node_modules/buffer-image-size": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+			"integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001777",
@@ -1884,6 +2152,20 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/css-what": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -1914,10 +2196,41 @@
 			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
 			"license": "MIT"
 		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/dayjs": {
 			"version": "1.11.13",
 			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
 			"integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/defuddle": {
 			"version": "0.18.1",
@@ -2073,6 +2386,18 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/envinfo": {
@@ -2362,6 +2687,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -2385,18 +2723,6 @@
 				"domhandler": "^5.0.3",
 				"domutils": "^3.2.2",
 				"entities": "^7.0.1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/entities": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/icss-utils": {
@@ -2515,6 +2841,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2559,6 +2892,57 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.25.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/json-parse-even-better-errors": {
@@ -2893,6 +3277,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/lucide": {
 			"version": "0.359.0",
 			"resolved": "https://registry.npmjs.org/lucide/-/lucide-0.359.0.tgz",
@@ -2931,6 +3325,13 @@
 			"dependencies": {
 				"@xmldom/xmldom": "^0.8.10"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
@@ -3091,6 +3492,32 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5/node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/path-exists": {
@@ -3264,6 +3691,16 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true
 		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3427,6 +3864,19 @@
 				}
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/schema-utils": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -3585,6 +4035,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -3738,6 +4195,26 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+			"integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.3"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+			"integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3748,6 +4225,32 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-loader": {
@@ -3854,6 +4357,16 @@
 			"resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
 			"integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
 			"license": "ISC"
+		},
+		"node_modules/undici": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
 		},
 		"node_modules/undici-types": {
 			"version": "7.18.2",
@@ -4114,6 +4627,19 @@
 				}
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/watchpack": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -4133,6 +4659,16 @@
 			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
 			"integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
 			"dev": true
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/webpack": {
 			"version": "5.105.4",
@@ -4265,6 +4801,32 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/whatwg-mimetype": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4302,6 +4864,46 @@
 			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
 			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
 			"dev": true
+		},
+		"node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yazl": {
 			"version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"css-loader": "^7.1.2",
 		"dotenv": "^16.4.1",
 		"esbuild": "^0.28.1",
+		"jsdom": "^29.1.1",
 		"mini-css-extract-plugin": "^2.9.1",
 		"sass": "^1.77.8",
 		"sass-loader": "^16.0.1",

--- a/src/utils/__mocks__/webextension-polyfill.ts
+++ b/src/utils/__mocks__/webextension-polyfill.ts
@@ -17,6 +17,10 @@ export const storage = {
 		get: async () => ({}),
 		set: async () => {},
 	},
+	onChanged: {
+		addListener: () => {},
+		removeListener: () => {},
+	},
 };
 
 export const tabs = {

--- a/src/utils/content-extractor.test.ts
+++ b/src/utils/content-extractor.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from 'vitest';
+import { processHighlights } from './content-extractor';
+import { TextHighlightData } from './highlighter';
+
+// Default settings already use highlighterEnabled + 'highlight-inline', the
+// behavior these tests exercise.
+
+function textHighlight(content: string): TextHighlightData {
+	// xpath is empty so processing goes straight to the content-based path,
+	// matching the common case where the recorded xpath (live/reader DOM)
+	// doesn't resolve against the extracted article content.
+	return { type: 'text', id: '1', xpath: '', content, startOffset: 0, endOffset: 0 };
+}
+
+describe('processHighlights — highlight-inline', () => {
+	const article = '<p>A seismic shift is rocking the healthcare industry. Much like Uber once did.</p>';
+
+	test('wraps a whole-paragraph highlight', () => {
+		const result = processHighlights(article, [
+			textHighlight('<p>A seismic shift is rocking the healthcare industry. Much like Uber once did.</p>'),
+		]);
+		expect(result).toContain('<mark>A seismic shift is rocking the healthcare industry. Much like Uber once did.</mark>');
+	});
+
+	// Regression for #446 / #852: a sentence highlighted within a paragraph was
+	// dropped because it never equaled the full paragraph text.
+	test('wraps a sentence highlighted within a paragraph', () => {
+		const result = processHighlights(article, [
+			textHighlight('<p>A seismic shift is rocking the healthcare industry.</p>'),
+		]);
+		expect(result).toContain('<mark>A seismic shift is rocking the healthcare industry.</mark>');
+		expect(result).toContain('Much like Uber once did.');
+	});
+});

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -10,8 +10,7 @@ import { generalSettings } from './storage-utils';
 import {
 	getElementByXPath,
 	wrapElementWithMark,
-	wrapTextWithMark,
-	findTextNodeContaining
+	wrapTextWithMark
 } from './dom-utils';
 
 // Define ElementHighlightData type inline since it's not exported from highlighter.ts
@@ -401,14 +400,22 @@ function processInlineContent(content: string, tempDiv: HTMLElement) {
 	const searchText = stripHtml(content).trim();
 	debugLog('Highlights', 'Searching for text:', searchText);
 
-	const match = findTextNodeContaining(tempDiv, searchText);
-	if (!match) return;
+	// Wrap the first text node containing the full text. surroundContents
+	// requires a single text node, which is why this doesn't span inline
+	// elements (sufficient for the partial-paragraph case it handles).
+	const walker = document.createTreeWalker(tempDiv, NodeFilter.SHOW_TEXT);
+	let node: Node | null;
+	while ((node = walker.nextNode())) {
+		const index = (node.textContent || '').indexOf(searchText);
+		if (index === -1) continue;
 
-	const range = document.createRange();
-	range.setStart(match.node, match.index);
-	range.setEnd(match.node, match.index + searchText.length);
+		const range = document.createRange();
+		range.setStart(node, index);
+		range.setEnd(node, index + searchText.length);
 
-	const mark = document.createElement('mark');
-	range.surroundContents(mark);
-	debugLog('Highlights', 'Created mark element:', mark.outerHTML);
+		const mark = document.createElement('mark');
+		range.surroundContents(mark);
+		debugLog('Highlights', 'Created mark element:', mark.outerHTML);
+		return;
+	}
 }

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -201,7 +201,7 @@ export async function initializePageContent(
 	}
 }
 
-function processHighlights(content: string, highlights: AnyHighlightData[]): string {
+export function processHighlights(content: string, highlights: AnyHighlightData[]): string {
 	// First check if highlighter is enabled and we have highlights
 	if (!generalSettings.highlighterEnabled || !highlights?.length) {
 		return content;
@@ -369,17 +369,26 @@ function processContentBasedHighlight(highlight: TextHighlightData | ElementHigh
 function processContentParagraphs(sourceParagraphs: Element[], tempDiv: HTMLDivElement) {
 	sourceParagraphs.forEach(sourceParagraph => {
 		const sourceText = stripHtml(sourceParagraph.outerHTML).trim();
+		if (!sourceText) return;
 		debugLog('Highlights', 'Looking for paragraph:', sourceText);
-		
+
 		const paragraphs = Array.from(tempDiv.querySelectorAll('p'));
-		for (const targetParagraph of paragraphs) {
-			const targetText = stripHtml(targetParagraph.outerHTML).trim();
-			
-			if (targetText === sourceText) {
-				debugLog('Highlights', 'Found matching paragraph:', targetParagraph.outerHTML);
-				wrapElementWithMark(targetParagraph);
-				break;
-			}
+
+		// Try an exact whole-paragraph match first.
+		const exact = paragraphs.find(p => stripHtml(p.outerHTML).trim() === sourceText);
+		if (exact) {
+			debugLog('Highlights', 'Found matching paragraph:', exact.outerHTML);
+			wrapElementWithMark(exact);
+			return;
+		}
+
+		// A sentence highlighted within a paragraph is stored as that fragment
+		// wrapped in a shallow <p>, so it never equals the full paragraph. Mark
+		// the substring inside the containing paragraph (fixes #446 / #852).
+		const container = paragraphs.find(p => stripHtml(p.outerHTML).includes(sourceText));
+		if (container) {
+			debugLog('Highlights', 'Found containing paragraph for partial highlight:', container.outerHTML);
+			processInlineContent(sourceParagraph.outerHTML, container);
 		}
 	});
 }

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -10,7 +10,8 @@ import { generalSettings } from './storage-utils';
 import {
 	getElementByXPath,
 	wrapElementWithMark,
-	wrapTextWithMark
+	wrapTextWithMark,
+	findTextNodeContaining
 } from './dom-utils';
 
 // Define ElementHighlightData type inline since it's not exported from highlighter.ts
@@ -367,28 +368,31 @@ function processContentBasedHighlight(highlight: TextHighlightData | ElementHigh
 }
 
 function processContentParagraphs(sourceParagraphs: Element[], tempDiv: HTMLDivElement) {
+	// Strip each target paragraph's text once, reused across every source
+	// paragraph and both the exact and substring passes below.
+	const targets = Array.from(tempDiv.querySelectorAll('p'))
+		.map(p => ({ el: p, text: stripHtml(p.outerHTML).trim() }));
+
 	sourceParagraphs.forEach(sourceParagraph => {
 		const sourceText = stripHtml(sourceParagraph.outerHTML).trim();
 		if (!sourceText) return;
 		debugLog('Highlights', 'Looking for paragraph:', sourceText);
 
-		const paragraphs = Array.from(tempDiv.querySelectorAll('p'));
-
 		// Try an exact whole-paragraph match first.
-		const exact = paragraphs.find(p => stripHtml(p.outerHTML).trim() === sourceText);
+		const exact = targets.find(t => t.text === sourceText);
 		if (exact) {
-			debugLog('Highlights', 'Found matching paragraph:', exact.outerHTML);
-			wrapElementWithMark(exact);
+			debugLog('Highlights', 'Found matching paragraph:', exact.el.outerHTML);
+			wrapElementWithMark(exact.el);
 			return;
 		}
 
 		// A sentence highlighted within a paragraph is stored as that fragment
 		// wrapped in a shallow <p>, so it never equals the full paragraph. Mark
 		// the substring inside the containing paragraph (fixes #446 / #852).
-		const container = paragraphs.find(p => stripHtml(p.outerHTML).includes(sourceText));
+		const container = targets.find(t => t.text.includes(sourceText));
 		if (container) {
-			debugLog('Highlights', 'Found containing paragraph for partial highlight:', container.outerHTML);
-			processInlineContent(sourceParagraph.outerHTML, container);
+			debugLog('Highlights', 'Found containing paragraph for partial highlight:', container.el.outerHTML);
+			processInlineContent(sourceParagraph.outerHTML, container.el);
 		}
 	});
 }
@@ -396,28 +400,15 @@ function processContentParagraphs(sourceParagraphs: Element[], tempDiv: HTMLDivE
 function processInlineContent(content: string, tempDiv: HTMLElement) {
 	const searchText = stripHtml(content).trim();
 	debugLog('Highlights', 'Searching for text:', searchText);
-	
-	const walker = document.createTreeWalker(tempDiv, NodeFilter.SHOW_TEXT);
-	
-	let node;
-	while (node = walker.nextNode() as Text) {
-		const nodeText = node.textContent || '';
-		const index = nodeText.indexOf(searchText);
-		
-		if (index !== -1) {
-			debugLog('Highlights', 'Found matching text in node:', {
-				text: nodeText,
-				index: index
-			});
-			
-			const range = document.createRange();
-			range.setStart(node, index);
-			range.setEnd(node, index + searchText.length);
-			
-			const mark = document.createElement('mark');
-			range.surroundContents(mark);
-			debugLog('Highlights', 'Created mark element:', mark.outerHTML);
-			break;
-		}
-	}
+
+	const match = findTextNodeContaining(tempDiv, searchText);
+	if (!match) return;
+
+	const range = document.createRange();
+	range.setStart(match.node, match.index);
+	range.setEnd(match.node, match.index + searchText.length);
+
+	const mark = document.createElement('mark');
+	range.surroundContents(mark);
+	debugLog('Highlights', 'Created mark element:', mark.outerHTML);
 }

--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -18,6 +18,29 @@ export function setElementHTML(element: Element, html: string): void {
 	element.replaceChildren(...Array.from(parsed.body.childNodes));
 }
 
+// Walk text nodes under `root` and return the first one containing `searchText`,
+// along with the offset where it starts. `skipSelector` excludes text inside
+// matching ancestors (e.g. UI chrome). Used to re-anchor a highlight by its
+// text when its stored XPath no longer resolves.
+export function findTextNodeContaining(
+	root: Node,
+	searchText: string,
+	skipSelector?: string
+): { node: Text; index: number } | null {
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, skipSelector ? {
+		acceptNode: (node) =>
+			node.parentElement?.closest(skipSelector)
+				? NodeFilter.FILTER_REJECT
+				: NodeFilter.FILTER_ACCEPT,
+	} : null);
+	let node: Node | null;
+	while ((node = walker.nextNode())) {
+		const index = (node.textContent || '').indexOf(searchText);
+		if (index !== -1) return { node: node as Text, index };
+	}
+	return null;
+}
+
 export function setSVGChildren(svgElement: Element, markup: string): void {
 	const doc = new DOMParser()
 		.parseFromString(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`, 'image/svg+xml');

--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -18,29 +18,6 @@ export function setElementHTML(element: Element, html: string): void {
 	element.replaceChildren(...Array.from(parsed.body.childNodes));
 }
 
-// Walk text nodes under `root` and return the first one containing `searchText`,
-// along with the offset where it starts. `skipSelector` excludes text inside
-// matching ancestors (e.g. UI chrome). Used to re-anchor a highlight by its
-// text when its stored XPath no longer resolves.
-export function findTextNodeContaining(
-	root: Node,
-	searchText: string,
-	skipSelector?: string
-): { node: Text; index: number } | null {
-	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, skipSelector ? {
-		acceptNode: (node) =>
-			node.parentElement?.closest(skipSelector)
-				? NodeFilter.FILTER_REJECT
-				: NodeFilter.FILTER_ACCEPT,
-	} : null);
-	let node: Node | null;
-	while ((node = walker.nextNode())) {
-		const index = (node.textContent || '').indexOf(searchText);
-		if (index !== -1) return { node: node as Text, index };
-	}
-	return null;
-}
-
 export function setSVGChildren(svgElement: Element, markup: string): void {
 	const doc = new DOMParser()
 		.parseFromString(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`, 'image/svg+xml');

--- a/src/utils/highlighter-overlays.test.ts
+++ b/src/utils/highlighter-overlays.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeAll, beforeEach } from 'vitest';
+import { renderTextHighlight, clearTextHighlights } from './highlighter-overlays';
+import { getElementXPath } from './dom-utils';
+
+// Capture ranges handed to the CSS Custom Highlight API (not implemented in
+// jsdom), so we can assert what renderTextHighlight resolved.
+const addedRanges: Range[] = [];
+
+beforeAll(() => {
+	class MockHighlight {
+		priority = 0;
+		add(range: Range) { addedRanges.push(range); }
+		clear() { addedRanges.length = 0; }
+	}
+	(window as unknown as { Highlight: unknown }).Highlight = MockHighlight;
+	(globalThis as unknown as { Highlight: unknown }).Highlight = MockHighlight;
+	(globalThis as unknown as { CSS: unknown }).CSS = { highlights: new Map() };
+});
+
+beforeEach(() => {
+	clearTextHighlights();
+	addedRanges.length = 0;
+});
+
+describe('renderTextHighlight', () => {
+	test('resolves a highlight by its stored XPath + offsets', () => {
+		document.body.innerHTML = '<p>Hello world.</p>';
+		const p = document.querySelector('p')!;
+		renderTextHighlight({ id: '1', xpath: getElementXPath(p), startOffset: 0, endOffset: 5 });
+		expect(addedRanges).toHaveLength(1);
+		expect(addedRanges[0].toString()).toBe('Hello');
+	});
+
+	// Regression: a highlight made in a different DOM (live vs reader, or a
+	// regenerated reader view) has a stale XPath. It must still render by
+	// falling back to locating its stored content text.
+	test('falls back to content text when the XPath is stale', () => {
+		document.body.innerHTML =
+			'<article><p>A seismic shift is rocking the healthcare industry. Much like Uber once did.</p></article>';
+		renderTextHighlight({
+			id: '2',
+			xpath: '/html[1]/body[1]/div[7]/p[42]', // does not resolve
+			startOffset: 0,
+			endOffset: 0,
+			content: '<p>A seismic shift is rocking the healthcare industry.</p>',
+		});
+		expect(addedRanges).toHaveLength(1);
+		expect(addedRanges[0].toString()).toBe('A seismic shift is rocking the healthcare industry.');
+	});
+
+	test('skips the highlighter UI chrome when searching by content', () => {
+		// Same text appears in a reader settings panel; the fallback must match
+		// the article copy, not the chrome.
+		document.body.innerHTML =
+			'<div class="obsidian-reader-settings">Reader settings</div>' +
+			'<article><p>Reader settings make the page easier to read.</p></article>';
+		renderTextHighlight({
+			id: '3',
+			xpath: '/nonexistent',
+			startOffset: 0,
+			endOffset: 0,
+			content: '<p>Reader settings make the page easier to read.</p>',
+		});
+		expect(addedRanges).toHaveLength(1);
+		const container = addedRanges[0].startContainer.parentElement;
+		expect(container?.closest('article')).not.toBeNull();
+	});
+
+	test('renders nothing when neither XPath nor content matches', () => {
+		document.body.innerHTML = '<article><p>Unrelated text.</p></article>';
+		renderTextHighlight({
+			id: '4',
+			xpath: '/nonexistent',
+			startOffset: 0,
+			endOffset: 0,
+			content: '<p>This sentence is not on the page.</p>',
+		});
+		expect(addedRanges).toHaveLength(0);
+	});
+});

--- a/src/utils/highlighter-overlays.test.ts
+++ b/src/utils/highlighter-overlays.test.ts
@@ -67,6 +67,76 @@ describe('renderTextHighlight', () => {
 		expect(container?.closest('article')).not.toBeNull();
 	});
 
+	// A highlight spanning an inline element (e.g. a link mid-sentence) is split
+	// across multiple text nodes; the content fallback must still span them.
+	test('falls back across inline elements within the highlighted text', () => {
+		document.body.innerHTML = '<article><p>A <a href="#">seismic</a> shift is here.</p></article>';
+		renderTextHighlight({
+			id: '5',
+			xpath: '/nonexistent',
+			startOffset: 0,
+			endOffset: 0,
+			content: '<p>A seismic shift is here.</p>',
+		});
+		expect(addedRanges).toHaveLength(1);
+		expect(addedRanges[0].toString()).toBe('A seismic shift is here.');
+	});
+
+	// A stale XPath can resolve to a *different* element with different text.
+	// renderTextHighlight must reject that and re-anchor by content.
+	test('rejects an XPath that resolves to the wrong text and falls back', () => {
+		document.body.innerHTML =
+			'<article><p>Wrong paragraph text.</p><p>Correct sentence to find.</p></article>';
+		const wrongP = document.querySelector('p')!;
+		renderTextHighlight({
+			id: '6',
+			xpath: getElementXPath(wrongP), // resolves, but to the wrong paragraph
+			startOffset: 0,
+			endOffset: 'Wrong paragraph text.'.length,
+			content: '<p>Correct sentence to find.</p>',
+		});
+		expect(addedRanges).toHaveLength(1);
+		expect(addedRanges[0].toString()).toBe('Correct sentence to find.');
+	});
+
+	// The same prose can be spaced differently across DOMs (raw textContent
+	// keeps source newlines/indentation). Matching is whitespace-normalized.
+	test('matches across differing whitespace', () => {
+		document.body.innerHTML = '<article><p>the quick   brown\n      fox jumps over</p></article>';
+		renderTextHighlight({
+			id: '7',
+			xpath: '/nonexistent',
+			startOffset: 0,
+			endOffset: 0,
+			content: '<p>the quick brown fox jumps over</p>',
+		});
+		expect(addedRanges).toHaveLength(1);
+		expect(addedRanges[0].toString().replace(/\s+/g, ' ').trim()).toBe('the quick brown fox jumps over');
+	});
+
+	// When the exact text occurs more than once, stored prefix/suffix context
+	// selects the correct occurrence rather than always the first.
+	test('uses prefix/suffix context to pick the right duplicate', () => {
+		document.body.innerHTML =
+			'<article>' +
+			'<p>Intro paragraph. The term applies here. More intro text.</p>' +
+			'<p>Second paragraph. The term applies here. Closing remarks.</p>' +
+			'</article>';
+		const secondP = document.querySelectorAll('p')[1];
+		renderTextHighlight({
+			id: '8',
+			xpath: '/nonexistent',
+			startOffset: 0,
+			endOffset: 0,
+			content: '<p>The term applies here.</p>',
+			textQuote: { prefix: 'Second paragraph. ', suffix: ' Closing remarks.' },
+		});
+		expect(addedRanges).toHaveLength(1);
+		expect(addedRanges[0].toString()).toBe('The term applies here.');
+		// Must anchor inside the *second* paragraph, not the first.
+		expect(secondP.contains(addedRanges[0].startContainer)).toBe(true);
+	});
+
 	test('renders nothing when neither XPath nor content matches', () => {
 		document.body.innerHTML = '<article><p>Unrelated text.</p></article>';
 		renderTextHighlight({

--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -103,26 +103,74 @@ function findTextNodeAtOffset(element: Element, offset: number): { node: Node, o
 	return null;
 }
 
-export function renderTextHighlight(highlight: { id: string; xpath: string; startOffset: number; endOffset: number }): void {
+export function renderTextHighlight(highlight: { id: string; xpath: string; startOffset: number; endOffset: number; content?: string }): void {
 	const hl = ensureUserHighlight();
 	if (!hl) return;
+
+	// Primary: resolve by stored XPath + character offsets.
+	let range = buildTextRangeFromXPath(highlight);
+
+	// Fallback: the XPath didn't resolve against the current DOM. This happens
+	// whenever the highlight was made against a different DOM than the one now
+	// showing — live vs reader, or a reader view regenerated on re-entry. Locate
+	// the highlighted text by its stored content instead so it still renders.
+	if (!range && highlight.content) {
+		range = buildTextRangeFromContent(highlight.content);
+	}
+
+	if (!range) return;
+	hl.add(range);
+	const existing = textHighlightRanges.get(highlight.id);
+	if (existing) existing.push(range);
+	else textHighlightRanges.set(highlight.id, [range]);
+}
+
+function buildTextRangeFromXPath(highlight: { xpath: string; startOffset: number; endOffset: number }): Range | null {
 	const container = getElementByXPath(highlight.xpath);
-	if (!container) return;
+	if (!container) return null;
 	const start = findTextNodeAtOffset(container, highlight.startOffset);
 	const end = findTextNodeAtOffset(container, highlight.endOffset);
-	if (!start || !end) return;
+	if (!start || !end) return null;
 	try {
 		const range = document.createRange();
 		range.setStart(start.node, start.offset);
 		range.setEnd(end.node, end.offset);
-		if (range.collapsed) return;
-		hl.add(range);
-		const existing = textHighlightRanges.get(highlight.id);
-		if (existing) existing.push(range);
-		else textHighlightRanges.set(highlight.id, [range]);
+		return range.collapsed ? null : range;
 	} catch (e) {
-		console.warn('Failed to build Range for text highlight', highlight.id, e);
+		console.warn('Failed to build Range from XPath for text highlight', highlight.xpath, e);
+		return null;
 	}
+}
+
+// Locate a highlight's text in the current document by its stored content.
+// Used when the XPath is stale (cross-DOM). Matches the first text node that
+// contains the full text, skipping the highlighter's own UI chrome.
+function buildTextRangeFromContent(content: string): Range | null {
+	const doc = new DOMParser().parseFromString(content, 'text/html');
+	const searchText = (doc.body.textContent || '').trim();
+	if (!searchText) return null;
+
+	const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+		acceptNode: (node) =>
+			node.parentElement?.closest(IGNORED_BOUNDARY_SELECTOR)
+				? NodeFilter.FILTER_REJECT
+				: NodeFilter.FILTER_ACCEPT,
+	});
+
+	let node: Node | null;
+	while ((node = walker.nextNode())) {
+		const index = (node.textContent || '').indexOf(searchText);
+		if (index === -1) continue;
+		try {
+			const range = document.createRange();
+			range.setStart(node, index);
+			range.setEnd(node, index + searchText.length);
+			if (!range.collapsed) return range;
+		} catch {
+			// Try the next matching node.
+		}
+	}
+	return null;
 }
 
 export function clearTextHighlights(): void {

--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -210,8 +210,18 @@ function buildTextRangeFromQuote(highlight: RenderableTextHighlight): Range | nu
 	}
 }
 
+// The highlighted text, derived from content (which is HTML). Cached by content
+// — it's immutable, so this never goes stale — to avoid re-parsing on every
+// render: applyHighlights re-runs on each resize/scroll reposition.
+const exactTextCache = new Map<string, string>();
 function highlightExactText(highlight: RenderableTextHighlight): string {
-	return highlight.content ? normalizeText(htmlToText(highlight.content)) : '';
+	if (!highlight.content) return '';
+	let exact = exactTextCache.get(highlight.content);
+	if (exact === undefined) {
+		exact = normalizeText(htmlToText(highlight.content));
+		exactTextCache.set(highlight.content, exact);
+	}
+	return exact;
 }
 
 // Prefer the article body so the fallback search ignores nav/chrome/furniture.

--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -315,10 +315,26 @@ function buildNormalizedTextIndex(root: Element): NormalizedTextIndex {
 	return { text, segments };
 }
 
+// Segments are contiguous and sorted by normStart, so binary-search for the one
+// whose [normStart, normEnd) range owns the offset. Empty segments (no emitted
+// chars) are skipped naturally since offset >= normEnd moves the search right.
+function findSegmentForOffset(segments: TextNodeSegment[], offset: number): TextNodeSegment | null {
+	let lo = 0;
+	let hi = segments.length - 1;
+	while (lo <= hi) {
+		const mid = (lo + hi) >> 1;
+		const seg = segments[mid];
+		if (offset < seg.normStart) hi = mid - 1;
+		else if (offset >= seg.normEnd) lo = mid + 1;
+		else return seg;
+	}
+	return null;
+}
+
 // Map an offset in the normalized text back to a live (node, raw offset) by
 // finding the owning text-node segment and replaying its whitespace collapse.
 function domPositionForNormalizedOffset(index: NormalizedTextIndex, offset: number): { node: Text; offset: number } | null {
-	const seg = index.segments.find(s => offset >= s.normStart && offset < s.normEnd);
+	const seg = findSegmentForOffset(index.segments, offset);
 	if (!seg) return null;
 	const target = offset - seg.normStart;
 	const raw = seg.node.textContent || '';

--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -103,19 +103,33 @@ function findTextNodeAtOffset(element: Element, offset: number): { node: Node, o
 	return null;
 }
 
-export function renderTextHighlight(highlight: { id: string; xpath: string; startOffset: number; endOffset: number; content?: string }): void {
+interface TextQuoteAnchor {
+	prefix?: string;
+	suffix?: string;
+}
+
+type RenderableTextHighlight = {
+	id: string;
+	xpath: string;
+	startOffset: number;
+	endOffset: number;
+	content?: string;
+	textQuote?: TextQuoteAnchor;
+};
+
+export function renderTextHighlight(highlight: RenderableTextHighlight): void {
 	const hl = ensureUserHighlight();
 	if (!hl) return;
 
 	// Primary: resolve by stored XPath + character offsets.
 	let range = buildTextRangeFromXPath(highlight);
 
-	// Fallback: the XPath didn't resolve against the current DOM. This happens
-	// whenever the highlight was made against a different DOM than the one now
-	// showing — live vs reader, or a reader view regenerated on re-entry. Locate
-	// the highlighted text by its stored content instead so it still renders.
-	if (!range && highlight.content) {
-		range = buildTextRangeFromContent(highlight.content);
+	// Fallback: the XPath didn't resolve against the current DOM (or resolved to
+	// the wrong text). This happens whenever the highlight was made against a
+	// different DOM than the one now showing — live vs reader, or a reader view
+	// regenerated on re-entry. Re-anchor by the highlighted text instead.
+	if (!range) {
+		range = buildTextRangeFromQuote(highlight);
 	}
 
 	if (!range) return;
@@ -125,7 +139,7 @@ export function renderTextHighlight(highlight: { id: string; xpath: string; star
 	else textHighlightRanges.set(highlight.id, [range]);
 }
 
-function buildTextRangeFromXPath(highlight: { xpath: string; startOffset: number; endOffset: number }): Range | null {
+function buildTextRangeFromXPath(highlight: RenderableTextHighlight): Range | null {
 	const container = getElementByXPath(highlight.xpath);
 	if (!container) return null;
 	const start = findTextNodeAtOffset(container, highlight.startOffset);
@@ -135,39 +149,183 @@ function buildTextRangeFromXPath(highlight: { xpath: string; startOffset: number
 		const range = document.createRange();
 		range.setStart(start.node, start.offset);
 		range.setEnd(end.node, end.offset);
-		return range.collapsed ? null : range;
+		if (range.collapsed) return null;
+		// Guard against a stale XPath that resolves to a *different* element in
+		// the current DOM: if the resolved text doesn't match the stored
+		// content, reject it so the quote fallback can re-anchor by text.
+		const expected = highlightExactText(highlight);
+		if (expected && normalizeText(range.toString()) !== expected) return null;
+		return range;
 	} catch (e) {
 		console.warn('Failed to build Range from XPath for text highlight', highlight.xpath, e);
 		return null;
 	}
 }
 
-// Locate a highlight's text in the current document by its stored content.
-// Used when the XPath is stale (cross-DOM). Matches the first text node that
-// contains the full text, skipping the highlighter's own UI chrome.
-function buildTextRangeFromContent(content: string): Range | null {
-	const doc = new DOMParser().parseFromString(content, 'text/html');
-	const searchText = (doc.body.textContent || '').trim();
-	if (!searchText) return null;
+// Re-anchor a highlight by its text when the XPath is stale. Matching is done
+// in whitespace-normalized space (so the same prose matches across DOMs that
+// space it differently) and scoped to the article (so UI chrome isn't matched).
+// When the exact text occurs more than once, the stored prefix/suffix context
+// picks the right occurrence. The match maps back to live DOM nodes, so a
+// highlight spanning inline elements (a link mid-sentence) still resolves.
+function buildTextRangeFromQuote(highlight: RenderableTextHighlight): Range | null {
+	const exact = highlightExactText(highlight);
+	if (!exact) return null;
 
-	const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+	const index = getNormalizedTextIndex();
+	// Collapse internal whitespace but keep the edge adjacent to the exact text:
+	// commonSuffixLength/commonPrefixLength compare from that boundary, so the
+	// space between the context and the highlighted text must be preserved.
+	const prefix = collapseWhitespace(highlight.textQuote?.prefix || '');
+	const suffix = collapseWhitespace(highlight.textQuote?.suffix || '');
+
+	// Pick the occurrence whose surrounding text best matches the stored context.
+	let bestStart = -1;
+	let bestScore = -1;
+	for (let from = 0; from <= index.text.length;) {
+		const start = index.text.indexOf(exact, from);
+		if (start === -1) break;
+		const before = index.text.slice(Math.max(0, start - prefix.length), start);
+		const after = index.text.slice(start + exact.length, start + exact.length + suffix.length);
+		const score = commonSuffixLength(before, prefix) + commonPrefixLength(after, suffix);
+		if (score > bestScore) {
+			bestScore = score;
+			bestStart = start;
+		}
+		from = start + Math.max(1, exact.length);
+	}
+	if (bestStart === -1) return null;
+
+	const start = domPositionForNormalizedOffset(index, bestStart);
+	const end = domPositionForNormalizedOffset(index, bestStart + exact.length - 1);
+	if (!start || !end) return null;
+	try {
+		const range = document.createRange();
+		range.setStart(start.node, start.offset);
+		range.setEnd(end.node, end.offset + 1); // end is the last matched char; range ends after it
+		return range.collapsed ? null : range;
+	} catch (e) {
+		console.warn('Failed to build Range from text quote', e);
+		return null;
+	}
+}
+
+function highlightExactText(highlight: RenderableTextHighlight): string {
+	return highlight.content ? normalizeText(htmlToText(highlight.content)) : '';
+}
+
+// Prefer the article body so the fallback search ignores nav/chrome/furniture.
+function getTextSearchRoot(): Element {
+	return document.querySelector('.obsidian-reader-content article')
+		|| document.querySelector('article')
+		|| document.body;
+}
+
+function htmlToText(html: string): string {
+	const doc = new DOMParser().parseFromString(html, 'text/html');
+	return (doc.body.textContent || '').trim();
+}
+
+function normalizeText(text: string): string {
+	return collapseWhitespace(text).trim();
+}
+
+function collapseWhitespace(text: string): string {
+	return text.replace(/\s+/g, ' ');
+}
+
+function commonPrefixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[i] === b[i]) i++;
+	return i;
+}
+
+function commonSuffixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[a.length - 1 - i] === b[b.length - 1 - i]) i++;
+	return i;
+}
+
+// A whitespace-normalized view of the search root's text, plus per-text-node
+// segments so a normalized offset can be mapped back to a live (node, offset).
+// Node-granular (not per-character) to keep memory small; the raw offset within
+// the matched node is recomputed on demand. Built lazily and cached for the
+// duration of one render pass (cleared by clearTextHighlights).
+interface TextNodeSegment {
+	node: Text;
+	normStart: number;
+	normEnd: number;
+	prevWasSpace: boolean;
+}
+interface NormalizedTextIndex {
+	text: string;
+	segments: TextNodeSegment[];
+}
+
+let normalizedTextIndexCache: NormalizedTextIndex | null = null;
+let normalizedTextIndexRoot: Element | null = null;
+
+function getNormalizedTextIndex(): NormalizedTextIndex {
+	const root = getTextSearchRoot();
+	if (normalizedTextIndexCache && normalizedTextIndexRoot === root && root.isConnected) {
+		return normalizedTextIndexCache;
+	}
+	normalizedTextIndexRoot = root;
+	normalizedTextIndexCache = buildNormalizedTextIndex(root);
+	return normalizedTextIndexCache;
+}
+
+function buildNormalizedTextIndex(root: Element): NormalizedTextIndex {
+	const segments: TextNodeSegment[] = [];
+	let text = '';
+	let prevWasSpace = true; // treat the start as preceded by space so leading whitespace collapses away
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
 		acceptNode: (node) =>
-			node.parentElement?.closest(IGNORED_BOUNDARY_SELECTOR)
+			node.parentElement?.closest('script, style, noscript, ' + IGNORED_BOUNDARY_SELECTOR)
 				? NodeFilter.FILTER_REJECT
 				: NodeFilter.FILTER_ACCEPT,
 	});
-
 	let node: Node | null;
 	while ((node = walker.nextNode())) {
-		const index = (node.textContent || '').indexOf(searchText);
-		if (index === -1) continue;
-		try {
-			const range = document.createRange();
-			range.setStart(node, index);
-			range.setEnd(node, index + searchText.length);
-			if (!range.collapsed) return range;
-		} catch {
-			// Try the next matching node.
+		const normStart = text.length;
+		const segPrevWasSpace = prevWasSpace;
+		const raw = node.textContent || '';
+		for (let i = 0; i < raw.length; i++) {
+			if (/\s/.test(raw[i])) {
+				if (!prevWasSpace) { text += ' '; prevWasSpace = true; }
+			} else {
+				text += raw[i];
+				prevWasSpace = false;
+			}
+		}
+		segments.push({ node: node as Text, normStart, normEnd: text.length, prevWasSpace: segPrevWasSpace });
+	}
+	return { text, segments };
+}
+
+// Map an offset in the normalized text back to a live (node, raw offset) by
+// finding the owning text-node segment and replaying its whitespace collapse.
+function domPositionForNormalizedOffset(index: NormalizedTextIndex, offset: number): { node: Text; offset: number } | null {
+	const seg = index.segments.find(s => offset >= s.normStart && offset < s.normEnd);
+	if (!seg) return null;
+	const target = offset - seg.normStart;
+	const raw = seg.node.textContent || '';
+	let emitted = 0;
+	let prevWasSpace = seg.prevWasSpace;
+	for (let i = 0; i < raw.length; i++) {
+		const isSpace = /\s/.test(raw[i]);
+		if (isSpace) {
+			if (!prevWasSpace) {
+				if (emitted === target) return { node: seg.node, offset: i };
+				emitted++;
+				prevWasSpace = true;
+			}
+		} else {
+			if (emitted === target) return { node: seg.node, offset: i };
+			emitted++;
+			prevWasSpace = false;
 		}
 	}
 	return null;
@@ -176,6 +334,8 @@ function buildTextRangeFromContent(content: string): Range | null {
 export function clearTextHighlights(): void {
 	userHighlight?.clear();
 	textHighlightRanges.clear();
+	normalizedTextIndexCache = null;
+	normalizedTextIndexRoot = null;
 }
 
 function findOverlayAtPoint(x: number, y: number): HTMLElement | null {
@@ -410,11 +570,16 @@ export function handleTouchMove(event: TouchEvent) {
 // Render one highlight. Text highlights go through the CSS Custom Highlight
 // API; element highlights (figure, img, table, pre, picture) get one overlay
 // div positioned over the target element.
-export function planHighlightOverlayRects(target: Element, highlight: AnyHighlightData) {
+export function planHighlightOverlayRects(target: Element | null, highlight: AnyHighlightData) {
 	if (highlight.type === 'text') {
+		// Text highlights re-anchor themselves (XPath, then content fallback),
+		// so they don't need a resolved target element.
 		renderTextHighlight(highlight);
 		return;
 	}
+	// Element highlights position an overlay over the target, so a stale XPath
+	// (null target) means there's nothing to draw.
+	if (!target) return;
 	const rect = target.getBoundingClientRect();
 	const overlay = document.createElement('div');
 	overlay.className = 'obsidian-highlight-overlay';

--- a/src/utils/highlighter.test.ts
+++ b/src/utils/highlighter.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from 'vitest';
+import { createTextQuoteAnchor } from './highlighter';
+
+function container(text: string): Element {
+	const el = document.createElement('p');
+	el.textContent = text;
+	return el;
+}
+
+describe('createTextQuoteAnchor', () => {
+	test('captures the text on each side of the selection', () => {
+		const el = container('Intro. The term applies here. Outro.');
+		const start = 'Intro. '.length;
+		const end = start + 'The term applies here.'.length;
+		expect(createTextQuoteAnchor(el, start, end)).toEqual({
+			prefix: 'Intro. ',
+			suffix: ' Outro.',
+		});
+	});
+
+	test('returns an empty prefix when the selection starts the block', () => {
+		const el = container('The term applies here. Outro.');
+		const anchor = createTextQuoteAnchor(el, 0, 'The term applies here.'.length);
+		expect(anchor?.prefix).toBe('');
+		expect(anchor?.suffix).toBe(' Outro.');
+	});
+
+	test('caps context at 64 characters per side', () => {
+		const pad = 'x'.repeat(100);
+		const el = container(`${pad}MIDDLE${pad}`);
+		const anchor = createTextQuoteAnchor(el, 100, 106)!;
+		expect(anchor.prefix).toBe('x'.repeat(64));
+		expect(anchor.suffix).toBe('x'.repeat(64));
+	});
+
+	test('returns undefined for a whitespace-only selection', () => {
+		const el = container('before    after');
+		expect(createTextQuoteAnchor(el, 'before'.length, 'before    '.length)).toBeUndefined();
+	});
+});

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -208,10 +208,19 @@ export interface HighlightData {
 	groupId?: string;
 }
 
+// Surrounding text captured at creation, used to disambiguate which occurrence
+// of the highlighted text to re-anchor to when the XPath is stale (cross-DOM).
+// The highlighted text itself is derived from `content`, so it isn't stored here.
+export interface TextQuoteAnchor {
+	prefix: string;
+	suffix: string;
+}
+
 export interface TextHighlightData extends HighlightData {
 	type: 'text';
 	startOffset: number;
 	endOffset: number;
+	textQuote?: TextQuoteAnchor;
 }
 
 export interface ElementHighlightData extends HighlightData {
@@ -709,13 +718,16 @@ function getHighlightRanges(range: Range): AnyHighlightData[] {
 			setElementHTML(wrapper, innerHtml);
 			const htmlContent = wrapper.outerHTML;
 
+			const textStartOffset = getTextOffset(blockElement, blockRange.startContainer, blockRange.startOffset);
+			const textEndOffset = getTextOffset(blockElement, blockRange.endContainer, blockRange.endOffset);
 			newHighlights.push({
 				xpath: getElementXPath(blockElement),
 				content: htmlContent,
 				type: 'text',
 				id: `${timestamp}_tx_${i}`,
-				startOffset: getTextOffset(blockElement, blockRange.startContainer, blockRange.startOffset),
-				endOffset: getTextOffset(blockElement, blockRange.endContainer, blockRange.endOffset),
+				startOffset: textStartOffset,
+				endOffset: textEndOffset,
+				textQuote: createTextQuoteAnchor(blockElement, textStartOffset, textEndOffset),
 			});
 		} catch (e) {
 			console.warn('Error creating text highlight for block:', blockElement, e);
@@ -851,6 +863,19 @@ function getTextOffset(container: Element, targetNode: Node, targetOffset: numbe
 	return offset;
 }
 
+// Capture ~64 chars of text on each side of a highlight within its block, used
+// to pick the right occurrence when re-anchoring by text across DOMs.
+const TEXT_QUOTE_CONTEXT_LENGTH = 64;
+
+function createTextQuoteAnchor(container: Element, startOffset: number, endOffset: number): TextQuoteAnchor | undefined {
+	const text = container.textContent || '';
+	if (!text.slice(startOffset, endOffset).trim()) return undefined;
+	return {
+		prefix: text.slice(Math.max(0, startOffset - TEXT_QUOTE_CONTEXT_LENGTH), startOffset),
+		suffix: text.slice(endOffset, endOffset + TEXT_QUOTE_CONTEXT_LENGTH),
+	};
+}
+
 function addHighlight(highlight: AnyHighlightData, notes?: string[]) {
 	const oldHighlights = [...highlights];
 	const newHighlight = { ...highlight, notes: notes || [] };
@@ -965,6 +990,7 @@ function mergeHighlights(h1: AnyHighlightData, h2: AnyHighlightData): AnyHighlig
 				id: Date.now().toString(),
 				startOffset,
 				endOffset,
+				...(el ? { textQuote: createTextQuoteAnchor(el, startOffset, endOffset) } : {}),
 				...(notes.length > 0 ? { notes } : {}),
 				...(groupId ? { groupId } : {}),
 			};
@@ -1036,16 +1062,12 @@ export function applyHighlights() {
 	removeExistingHighlights();
 
 	highlights.forEach((highlight) => {
+		// container may be null when the stored XPath doesn't resolve against the
+		// current DOM (e.g. highlight made in a different view — live vs reader,
+		// or a regenerated reader). planHighlightOverlayRects handles that: text
+		// highlights re-anchor by content, element highlights skip.
 		const container = getElementByXPath(highlight.xpath);
-		if (container) {
-			planHighlightOverlayRects(container, highlight);
-		} else if (highlight.type === 'text') {
-			// XPath didn't resolve — the highlight was made against a different
-			// DOM (live vs reader, or a regenerated reader). Text highlights can
-			// still render: renderTextHighlight falls back to locating the text
-			// by content. The target arg is unused for text highlights.
-			planHighlightOverlayRects(document.body, highlight);
-		}
+		planHighlightOverlayRects(container, highlight);
 	});
 
 	lastAppliedVersion = highlightsVersion;
@@ -1204,6 +1226,12 @@ function migrateStoredHighlights(): boolean {
 					h.startOffset -= len;
 					h.endOffset -= len;
 					changed = true;
+				}
+				// 3. Backfill the text-quote anchor for highlights saved before it
+				//    existed, so they can re-anchor across DOMs like new ones.
+				if (!h.textQuote) {
+					h.textQuote = createTextQuoteAnchor(el, h.startOffset, h.endOffset);
+					if (h.textQuote) changed = true;
 				}
 			}
 		}

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -867,7 +867,7 @@ function getTextOffset(container: Element, targetNode: Node, targetOffset: numbe
 // to pick the right occurrence when re-anchoring by text across DOMs.
 const TEXT_QUOTE_CONTEXT_LENGTH = 64;
 
-function createTextQuoteAnchor(container: Element, startOffset: number, endOffset: number): TextQuoteAnchor | undefined {
+export function createTextQuoteAnchor(container: Element, startOffset: number, endOffset: number): TextQuoteAnchor | undefined {
 	const text = container.textContent || '';
 	if (!text.slice(startOffset, endOffset).trim()) return undefined;
 	return {

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -1039,6 +1039,12 @@ export function applyHighlights() {
 		const container = getElementByXPath(highlight.xpath);
 		if (container) {
 			planHighlightOverlayRects(container, highlight);
+		} else if (highlight.type === 'text') {
+			// XPath didn't resolve — the highlight was made against a different
+			// DOM (live vs reader, or a regenerated reader). Text highlights can
+			// still render: renderTextHighlight falls back to locating the text
+			// by content. The target arg is unused for text highlights.
+			planHighlightOverlayRects(document.body, highlight);
 		}
 	});
 


### PR DESCRIPTION
Highlights were anchored only by XPath, which doesn't survive the difference between the live page DOM and the Reading view DOM. This fixes two symptoms of that:

- **Clipping:** a sentence highlighted within a paragraph now gets `==markers==` in `{{content}}` (previously only whole-paragraph highlights did), including sentences that span an inline element such as a link. Fixes #446, #852.
- **Rendering:** highlights now show up across the live page and Reading view, and persist when a view is reopened. Fixes #824.

## How

- When the stored XPath doesn't resolve (or resolves to different text), re-anchor the highlight by its text instead.
- Match in whitespace-normalized space, scoped to the article, and use stored prefix/suffix context to pick the right occurrence when the text repeats. Matches map back to live DOM nodes, so a highlight spanning an inline element (a link mid-sentence) still resolves.
- A small text-quote anchor (prefix/suffix only) is stored per new highlight and backfilled for existing ones on load.

## Tests

Added unit tests for the clipping fallback, cross-DOM rendering (stale/wrong XPath, whitespace, inline elements, duplicate disambiguation), and the text-quote anchor.

---

Supersedes #854 (also fixes #446) and #825 (also fixes #824).