### PR TITLE
Fix inline highlights dropped for fragment selections on DOM-heavy pages

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -7,7 +7,7 @@ import { extractContentBySelector as extractContentBySelectorShared } from './ut
 import Defuddle from 'defuddle';
 import { createMarkdownContent } from 'defuddle/full';
 import { flattenShadowDom } from './utils/flatten-shadow-dom';
-import { serializeChildren } from './utils/dom-utils';
+import { serializeChildren, getElementByXPathInDoc, wrapElementWithMark, wrapTextWithMark } from './utils/dom-utils';
 import { saveFile } from './utils/file-utils';
 import { debugLog } from './utils/debug';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './utils/iframe-resize';
@@ -16,6 +16,53 @@ import { parseForClip } from './utils/clip-utils';
 declare global {
 	interface Window {
 		obsidianClipperGeneration?: number;
+	}
+}
+
+// Apply highlights as inline <mark> tags onto a clone of the live document
+// BEFORE Defuddle extracts it. The stored xpath + offsets are anchored to the
+// live DOM, so they resolve reliably against the clone — including partial /
+// fragment highlights that the post-extraction text-search path silently drops
+// on pages whose DOM Defuddle heavily restructures (e.g. WeChat #js_content,
+// Xiaohongshu). Defuddle then converts the <mark> tags to ==…== markdown.
+// Returns the marked clone, or null if nothing could be applied (caller falls
+// back to parsing the live document, preserving previous behavior).
+function buildHighlightedCloneForExtraction(highlightData: highlighter.AnyHighlightData[]): Document | null {
+	try {
+		const clone = document.cloneNode(true) as Document;
+
+		// Within a single element, apply marks back-to-front so an earlier
+		// insertion can't shift the offsets of a later highlight.
+		const sorted = highlightData
+			.filter(h => !!h.xpath?.trim())
+			.slice()
+			.sort((a, b) => {
+				if (a.xpath === b.xpath && a.type === 'text' && b.type === 'text') {
+					return (b as highlighter.TextHighlightData).startOffset - (a as highlighter.TextHighlightData).startOffset;
+				}
+				return 0;
+			});
+
+		let applied = 0;
+		for (const h of sorted) {
+			const el = getElementByXPathInDoc(h.xpath, clone);
+			if (!el) continue;
+			try {
+				if (h.type === 'element') {
+					wrapElementWithMark(el);
+				} else if (h.type === 'text') {
+					wrapTextWithMark(el, h as highlighter.TextHighlightData);
+				}
+				applied++;
+			} catch (e) {
+				debugLog('Highlights', 'Failed to inline a highlight onto clone:', e);
+			}
+		}
+
+		return applied > 0 ? clone : null;
+	} catch (e) {
+		debugLog('Highlights', 'Clone-based inline highlighting failed, falling back:', e);
+		return null;
 	}
 }
 
@@ -94,6 +141,7 @@ declare global {
 		schemaOrgData: any;
 		fullHtml: string;
 		highlights: string[];
+		highlightsInlined: boolean;
 		title: string;
 		description: string;
 		domain: string;
@@ -211,9 +259,27 @@ declare global {
 					selectedHtml = serializeChildren(div);
 				}
 
+				// When the user wants highlights inlined, mark a clone of the live
+				// DOM before extraction so partial/fragment highlights survive on
+				// DOM-heavy pages (WeChat, Xiaohongshu). Falls back to the live
+				// document when highlighting is off or nothing could be applied.
+				let parseTarget: Document = document;
+				let highlightsInlined = false;
+				if (generalSettings.highlighterEnabled
+					&& generalSettings.highlightBehavior === 'highlight-inline') {
+					const highlightData = highlighter.getHighlightData();
+					if (highlightData.length > 0) {
+						const markedClone = buildHighlightedCloneForExtraction(highlightData);
+						if (markedClone) {
+							parseTarget = markedClone;
+							highlightsInlined = true;
+						}
+					}
+				}
+
 				// Use parseAsync to ensure async variables like {{transcript}} are available.
 				// If it hangs (e.g. another extension has corrupted fetch), fall back to sync parse.
-				const defuddle = new Defuddle(document, { url: document.URL });
+				const defuddle = new Defuddle(parseTarget, { url: document.URL });
 				const parseTimeout = new Promise<never>((_, reject) =>
 					setTimeout(() => reject(new Error('parseAsync timeout')), 8000)
 				);
@@ -274,6 +340,7 @@ declare global {
 					favicon: defuddled.favicon,
 					fullHtml: cleanedHtml,
 					highlights: highlighter.getHighlights(),
+					highlightsInlined,
 					image: defuddled.image,
 					language: defuddled.language || '',
 					parseTime: defuddled.parseTime,

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -719,7 +719,8 @@ async function refreshFields(tabId: number, { checkTemplateTriggers = true, rebu
 				extractedData.site,
 				extractedData.wordCount,
 				extractedData.language || '',
-				extractedData.metaTags
+				extractedData.metaTags,
+				extractedData.highlightsInlined ?? false
 			);
 			if (initializedContent) {
 				currentVariables = initializedContent.currentVariables;

--- a/src/utils/content-extractor.test.ts
+++ b/src/utils/content-extractor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, test, expect } from 'vitest';
-import { processHighlights } from './content-extractor';
+import { initializePageContent, processHighlights } from './content-extractor';
 import { TextHighlightData } from './highlighter';
 
 // Default settings already use highlighterEnabled + 'highlight-inline', the
@@ -45,5 +45,32 @@ describe('processHighlights — highlight-inline', () => {
 		expect(mark!.textContent?.replace(/\s+/g, ' ').trim()).toBe('A seismic shift is rocking the healthcare industry.');
 		// The link must survive inside the mark, proving the range crossed it.
 		expect(mark!.querySelector('a')).not.toBeNull();
+	});
+});
+
+describe('initializePageContent — selected content', () => {
+	test('still applies popup highlight fallback when clone-inlined page content is bypassed by selected HTML', async () => {
+		const initialized = await initializePageContent(
+			'<p><mark>A seismic shift is rocking the healthcare industry.</mark> Much like Uber once did.</p>',
+			'<p>A seismic shift is rocking the healthcare industry. Much like Uber once did.</p>',
+			{},
+			'https://example.com/article',
+			{},
+			'',
+			[textHighlight('<p>A seismic shift is rocking the healthcare industry.</p>')],
+			'Example article',
+			'',
+			'',
+			'',
+			'',
+			'',
+			'Example',
+			100,
+			'en',
+			[],
+			true
+		);
+
+		expect(initialized.currentVariables['{{content}}']).toContain('==A seismic shift is rocking the healthcare industry.==');
 	});
 });

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -157,10 +157,13 @@ export async function initializePageContent(
 			selectedMarkdown = createMarkdownContent(selectedHtml, currentUrl);
 		}
 
+		const shouldSkipHighlightProcessing = highlightsInlined && !selectedHtml;
+
 		// Process highlights after getting the base content. Skip when the content
 		// script already inlined them onto a clone before extraction (the robust
-		// path); re-running here would double-mark or fail the text search.
-		if (!highlightsInlined && generalSettings.highlighterEnabled && generalSettings.highlightBehavior !== 'no-highlights' && highlights && highlights.length > 0) {
+		// path); re-running here would double-mark or fail the text search. Selected
+		// HTML still comes from the live DOM, so it needs the popup fallback.
+		if (!shouldSkipHighlightProcessing && generalSettings.highlighterEnabled && generalSettings.highlightBehavior !== 'no-highlights' && highlights && highlights.length > 0) {
 			content = processHighlights(content, highlights);
 		}
 

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -50,6 +50,10 @@ interface ContentResponse {
 	schemaOrgData: any;
 	fullHtml: string;
 	highlights: AnyHighlightData[];
+	// True when the content script already injected inline <mark> tags into the
+	// extracted content (before Defuddle). The popup then skips its own
+	// post-extraction highlight pass to avoid double-marking.
+	highlightsInlined?: boolean;
 	title: string;
 	author: string;
 	description: string;
@@ -141,7 +145,8 @@ export async function initializePageContent(
 	site: string,
 	wordCount: number,
 	language: string,
-	metaTags: { name?: string | null; property?: string | null; content: string | null }[]
+	metaTags: { name?: string | null; property?: string | null; content: string | null }[],
+	highlightsInlined: boolean = false
 ) {
 	try {
 		currentUrl = currentUrl.replace(/#:~:text=[^&]+(&|$)/, '');
@@ -152,8 +157,10 @@ export async function initializePageContent(
 			selectedMarkdown = createMarkdownContent(selectedHtml, currentUrl);
 		}
 
-		// Process highlights after getting the base content
-		if (generalSettings.highlighterEnabled && generalSettings.highlightBehavior !== 'no-highlights' && highlights && highlights.length > 0) {
+		// Process highlights after getting the base content. Skip when the content
+		// script already inlined them onto a clone before extraction (the robust
+		// path); re-running here would double-mark or fail the text search.
+		if (!highlightsInlined && generalSettings.highlighterEnabled && generalSettings.highlightBehavior !== 'no-highlights' && highlights && highlights.length > 0) {
 			content = processHighlights(content, highlights);
 		}
 

--- a/src/utils/dom-utils.test.ts
+++ b/src/utils/dom-utils.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { getElementByXPathInDoc, wrapTextWithMark, wrapElementWithMark } from './dom-utils';
+
+// These cover the inline-highlight fix: highlights must be markable on a
+// CLONED document (so they can be applied before Defuddle extraction), and a
+// partial highlight that crosses an inline element must not be silently
+// dropped.
+
+function docFrom(html: string): Document {
+	return new DOMParser().parseFromString(html, 'text/html');
+}
+
+describe('wrapTextWithMark (ownerDocument-aware)', () => {
+	it('wraps a partial offset range in <mark> on a cloned/separate document', () => {
+		const doc = docFrom('<p>The reason was buried in the S-1.</p>');
+		const clone = doc.cloneNode(true) as Document;
+		const p = clone.querySelector('p')!;
+
+		// "reason" sits at offset 4..10 of "The reason was buried in the S-1."
+		wrapTextWithMark(p, { startOffset: 4, endOffset: 10 });
+
+		const mark = p.querySelector('mark');
+		expect(mark).not.toBeNull();
+		expect(mark!.textContent).toBe('reason');
+	});
+
+	it('does not throw and still marks when the range crosses an inline element', () => {
+		// A fragment spanning across a <a> boundary makes surroundContents()
+		// throw; the extractContents() fallback must handle it.
+		const doc = docFrom('<p>billions of <a href="#">consumer discounts</a> and driver incentives</p>');
+		const p = doc.querySelector('p')!;
+		const full = p.textContent || '';
+		const start = full.indexOf('of consumer');
+		const end = full.indexOf('and') - 1; // through "...discounts "
+
+		expect(() => wrapTextWithMark(p, { startOffset: start, endOffset: end })).not.toThrow();
+
+		const mark = p.querySelector('mark');
+		expect(mark).not.toBeNull();
+		expect((mark!.textContent || '').includes('consumer discounts')).toBe(true);
+	});
+});
+
+describe('wrapElementWithMark (ownerDocument-aware)', () => {
+	it('wraps an element\'s contents in <mark> on a cloned document', () => {
+		const clone = docFrom('<blockquote>whole block</blockquote>').cloneNode(true) as Document;
+		const bq = clone.querySelector('blockquote')!;
+		wrapElementWithMark(bq);
+		expect(bq.querySelector('mark')?.textContent).toBe('whole block');
+	});
+});
+
+describe('getElementByXPathInDoc', () => {
+	it('resolves an xpath against the passed document, not the global one', () => {
+		const doc = docFrom('<div><section><p>first</p><p>target</p></section></div>');
+		const el = getElementByXPathInDoc('/html/body/div/section/p[2]', doc);
+		expect(el?.textContent).toBe('target');
+	});
+});

--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -74,6 +74,13 @@ export function getElementByXPath(xpath: string): Element | null {
 	return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue as Element | null;
 }
 
+// Resolve an XPath within a specific document rather than the global one.
+// Used to re-anchor highlights inside a cloned document before extraction, so
+// the stored live-DOM xpath resolves against the matching clone structure.
+export function getElementByXPathInDoc(xpath: string, doc: Document): Element | null {
+	return doc.evaluate(xpath, doc, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue as Element | null;
+}
+
 export function isDarkColor(color: string): boolean {
 	// Convert the color to RGB
 	const rgb = color.match(/\d+/g);
@@ -87,47 +94,59 @@ export function isDarkColor(color: string): boolean {
 }
 
 export function wrapElementWithMark(element: Element): void {
-	const mark = document.createElement('mark');
+	// Use the element's own document so this works on a cloned/detached
+	// document, not just the global one.
+	const doc = element.ownerDocument || document;
+	const mark = doc.createElement('mark');
 
 	while (element.firstChild) {
 		mark.appendChild(element.firstChild);
 	}
-	
+
 	element.appendChild(mark);
 }
 
 export function wrapTextWithMark(element: Element, highlight: { startOffset: number; endOffset: number }): void {
-	const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+	const doc = element.ownerDocument || document;
+	const walker = doc.createTreeWalker(element, NodeFilter.SHOW_TEXT);
 	let currentOffset = 0;
 	let startNode = null;
 	let endNode = null;
 	let startOffset = 0;
 	let endOffset = 0;
-	
+
 	let node;
 	while (node = walker.nextNode() as Text) {
 		const length = node.length;
-		
+
 		if (!startNode && currentOffset + length > highlight.startOffset) {
 			startNode = node;
 			startOffset = highlight.startOffset - currentOffset;
 		}
-		
+
 		if (!endNode && currentOffset + length >= highlight.endOffset) {
 			endNode = node;
 			endOffset = highlight.endOffset - currentOffset;
 			break;
 		}
-		
+
 		currentOffset += length;
 	}
-	
+
 	if (startNode && endNode) {
-		const range = document.createRange();
+		const range = doc.createRange();
 		range.setStart(startNode, startOffset);
 		range.setEnd(endNode, endOffset);
-		
-		const mark = document.createElement('mark');
-		range.surroundContents(mark);
+
+		const mark = doc.createElement('mark');
+		// surroundContents() throws when the range crosses element boundaries
+		// (e.g. a link or <strong> sits mid-highlight). extractContents()
+		// handles that case; previously such highlights were silently dropped.
+		try {
+			range.surroundContents(mark);
+		} catch {
+			mark.appendChild(range.extractContents());
+			range.insertNode(mark);
+		}
 	}
 }

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -1087,6 +1087,13 @@ export function getHighlights(): string[] {
 	return highlights.map(h => h.content);
 }
 
+// Raw highlight records, including the live-DOM xpath + offsets that
+// getHighlights() drops. Used by the content script to re-anchor highlights
+// onto a cloned document before extraction (inline-highlight injection).
+export function getHighlightData(): AnyHighlightData[] {
+	return highlights;
+}
+
 // Group highlights that share a groupId (produced by a single multi-block
 // selection) so export/display treats them as one logical highlight. Ungrouped
 // highlights pass through as single-element arrays. Order is preserved.


### PR DESCRIPTION
## Problem

Inline highlights can disappear when clipping pages whose source DOM is heavily restructured by Defuddle.

This is visible on major Chinese-language / Asia-focused content platforms such as WeChat Official Account articles and Xiaohongshu/RedNote posts. A partial sentence highlight may be dropped from the clipped Markdown, while a whole-paragraph highlight survives.

## Why this matters

This is not a site-specific workaround. It fixes a class of highlight anchoring failures that show up on content platforms whose DOM is heavily restructured before Markdown generation.

Two common examples are WeChat Official Account articles and Xiaohongshu/RedNote posts. These are major reading and research surfaces for Chinese-speaking and Asia-based users:

- [Tencent reports](https://static.www.tencent.com/uploads/2025/12/01/3af6dff0737b502faa51405a47f27752.pdf) Weixin/WeChat has over 1.4B combined MAU, with Official Accounts, Search, and Reading as part of the Weixin content ecosystem.
- Xiaohongshu/RedNote is widely reported / estimated at 300M+ MAU ([The Verge](https://www.theverge.com/2025/1/13/24342986/rednote-xiaohongshu-chinese-social-media-app-tiktok-ban), [Sacra](https://sacra-pdfs.s3.us-east-2.amazonaws.com/xiaohongshu.pdf)).
- For many users, especially in China and Chinese-speaking communities, these pages are everyday sources for essays, product research, travel notes, technical writing, and professional content.

Before this fix, partial sentence highlights on these pages could silently disappear from clipped Markdown, while whole-paragraph highlights often still worked. That makes Web Clipper feel unreliable precisely on pages where users are most likely to save nuanced excerpts.

The implementation is still generic: it does not special-case WeChat or Xiaohongshu. It moves inline highlight application earlier, onto a cloned live document, so saved XPath + offsets are resolved before Defuddle changes the document structure.

## Why it happens

With **Highlight behavior → "Highlight the page content"**, inline highlights are currently applied *after* Defuddle extraction, in the popup, by text-searching the extracted HTML for each highlight's `content`.

The stored `xpath` + offsets never reach the popup: `getHighlights()` returns only content strings, and `sendExtractRequest` rebuilds them with `xpath: ''` and zeroed offsets. After Defuddle restructures the DOM, the popup can only do a naive `indexOf()` / `includes()` match, so partial / fragment highlights may drift and fail to re-anchor.

## Fix

Apply highlights as inline `<mark>` tags onto a **clone of the live document in the content script, before Defuddle runs**, where the stored `xpath` + offsets still match the DOM the highlights were created from.

Defuddle then converts `<mark>` to `==...==` during Markdown generation. A `highlightsInlined` flag tells the popup to skip its post-extraction pass so highlights are not double-marked. If nothing can be applied to the clone, it falls back to the previous live-document parse + popup pass, so existing behavior is preserved.

Selected-page clipping still uses the popup fallback, because selected HTML is captured from the live DOM rather than the marked clone.

## Implementation notes

- **highlighter**: expose `getHighlightData()` so the content script can access raw highlight records with `xpath` + offsets.
- **dom-utils**: add `getElementByXPathInDoc()`; make `wrapTextWithMark` / `wrapElementWithMark` `ownerDocument`-aware so they work on cloned documents; add an `extractContents()` fallback so ranges crossing inline elements can still be marked.
- **content**: add `buildHighlightedCloneForExtraction()` to clone the live document, mark highlights back-to-front per element so offsets do not shift, and parse the marked clone.
- **content-extractor / popup**: thread `highlightsInlined` through to skip duplicate post-extraction processing for full-page clips, while preserving fallback behavior for selected HTML.
- **tests**: cover cloned-document marking, inline-element-spanning ranges, XPath resolution in a passed document, and selected-HTML fallback behavior.

## Testing

- `npm test -- --run src/utils/content-extractor.test.ts src/utils/dom-utils.test.ts` — 8 passed.
- `npm run build:chrome` — passes, with existing bundle-size warnings.
- Full `npm test` currently has one unrelated timezone-dependent fixture failure in `template-integration.test.ts` (`-08:00` expected vs local `+08:00`).
- Verified manually on live WeChat / Xiaohongshu articles: partial / mid-sentence highlights, including highlights crossing inline links, now appear inline as `==...==`; standard pages remain unchanged.
