### PR TITLE
Fix: Prevent double evaluation of literal template tags in variable output

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,7 +4,7 @@
 
 import DefuddleClass from 'defuddle';
 import { createMarkdownContent } from 'defuddle/full';
-import { compileTemplate, SelectorProcessor } from './utils/template-compiler';
+import { compileTemplate, restoreBraces, SelectorProcessor } from './utils/template-compiler';
 import { AsyncResolver, RenderContext } from './utils/renderer';
 import { applyFilters } from './utils/filters';
 import { buildVariables, generateFrontmatter, extractContentBySelector, selectorContentToString, formatPropertyValue } from './utils/shared';
@@ -248,12 +248,13 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 
 	// Assemble full content
 	const fullContent = frontmatter ? frontmatter + content : content;
+	const finalOutput = restoreBraces(fullContent);
 
 	return {
 		noteName,
 		frontmatter,
 		content,
-		fullContent,
+		fullContent: finalOutput,
 		properties: compiledProperties,
 		variables,
 	};

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -3,7 +3,7 @@ import { Template, Property, PromptVariable } from '../types/types';
 import { incrementStat, addHistoryEntry, getClipHistory } from '../utils/storage-utils';
 import { generateFrontmatter, saveToObsidian } from '../utils/obsidian-note-creator';
 import { extractPageContent, initializePageContent } from '../utils/content-extractor';
-import { compileTemplate } from '../utils/template-compiler';
+import { compileTemplate, restoreBraces } from '../utils/template-compiler';
 import { initializeIcons, getPropertyTypeIcon } from '../icons/icons';
 import { findMatchingTemplate, initializeTriggers } from '../utils/triggers';
 import { getLocalStorage, setLocalStorage, loadSettings, generalSettings, Settings } from '../utils/storage-utils';
@@ -469,8 +469,9 @@ function setupEventListeners(tabId: number) {
 			const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
 			const frontmatter = await generateFrontmatter(properties);
 			const fileContent = frontmatter + noteContentField.value;
+			const finalOutput = restoreBraces(fileContent);
 			
-			await copyToClipboard(fileContent);
+			await copyToClipboard(finalOutput);
 		});
 	}
 
@@ -493,6 +494,7 @@ function setupEventListeners(tabId: number) {
 					Promise.resolve(noteContentField.value)
 				]).then(([frontmatter, noteContent]) => {
 					const fileContent = frontmatter + noteContent;
+					const finalOutput = restoreBraces(fileContent);
 					
 					// Call share directly from the click handler
 					const noteNameField = document.getElementById('note-name-field') as HTMLInputElement;
@@ -503,7 +505,7 @@ function setupEventListeners(tabId: number) {
 					}
 
 					if (navigator.share && navigator.canShare) {
-						const blob = new Blob([fileContent], { type: 'text/markdown;charset=utf-8' });
+						const blob = new Blob([finalOutput], { type: 'text/markdown;charset=utf-8' });
 						const file = new File([blob], fileName, { type: 'text/markdown;charset=utf-8' });
 						
 						const shareData = {
@@ -1253,9 +1255,10 @@ async function handleSaveToDownloads() {
 		const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
 		const frontmatter = await generateFrontmatter(properties);
 		const fileContent = frontmatter + noteContentField.value;
+		const finalOutput = restoreBraces(fileContent);
 
 		await saveFile({
-			content: fileContent,
+			content: finalOutput,
 			fileName,
 			mimeType: 'text/markdown',
 			tabId: currentTabId,
@@ -1339,6 +1342,7 @@ async function handleClipObsidian(): Promise<void> {
 
 		const frontmatter = await generateFrontmatter(properties);
 		const fileContent = frontmatter + noteContentField.value;
+		const finalOutput = restoreBraces(fileContent);
 
 		// Save to Obsidian
 		const selectedVault = vaultDropdown.value || currentTemplate.vault || '';
@@ -1346,7 +1350,7 @@ async function handleClipObsidian(): Promise<void> {
 		const noteName = isDailyNote ? '' : noteNameField?.value || '';
 		const path = isDailyNote ? '' : pathField?.value || '';
 
-		await saveToObsidian(fileContent, noteName, path, selectedVault, currentTemplate.behavior);
+		await saveToObsidian(finalOutput, noteName, path, selectedVault, currentTemplate.behavior);
 		const tabInfo = await getCurrentTabInfo();
 		await incrementStat('addToObsidian', selectedVault, path, tabInfo.url, tabInfo.title);
 
@@ -1405,7 +1409,8 @@ async function copyContent() {
 	const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
 	const frontmatter = await generateFrontmatter(properties);
 	const fileContent = frontmatter + noteContentField.value;
-	await copyToClipboard(fileContent);
+	const finalOutput = restoreBraces(fileContent);
+	await copyToClipboard(finalOutput);
 }
 
 // Update the resize event listener to use the debounced version

--- a/src/utils/fixtures/expected/double-evaluation.md
+++ b/src/utils/fixtures/expected/double-evaluation.md
@@ -1,0 +1,17 @@
+---
+title: "Double Evalutaion"
+---
+{{ content }}
+
+{{contentHtml}}
+
+{{ fullHtml}}
+
+{{selectorHtml:body|markdown }}
+{{ content }}
+
+{{contentHtml}}
+
+{{ fullHtml}}
+
+{{selectorHtml:body|markdown }}

--- a/src/utils/fixtures/templates/double-evaluation.html
+++ b/src/utils/fixtures/templates/double-evaluation.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Double Evalutaion</title>
+	</head>
+	<body>
+		<p>{{ content }}</p>
+		<p>{{contentHtml}}</p>
+		<p>{{ fullHtml}}</p>
+		<p>{{selectorHtml:body|markdown }}</p>
+	</body>
+</html>

--- a/src/utils/fixtures/templates/double-evaluation.json
+++ b/src/utils/fixtures/templates/double-evaluation.json
@@ -1,0 +1,5 @@
+{
+	"noteNameFormat": "{{title}}",
+	"noteContentFormat": "{{content}}\n{{selectorHtml:body|markdown}}\n{{'summary'}}",
+	"properties": [{ "name": "title", "value": "{{title}}", "type": "text" }]
+}

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -1,6 +1,6 @@
 import { generalSettings, saveSettings } from './storage-utils';
 import { PromptVariable, Template, ModelConfig } from '../types/types';
-import { compileTemplate } from './template-compiler';
+import { compileTemplate, restoreBraces } from './template-compiler';
 import { applyFilters } from './filters';
 import { formatDuration } from './string-utils';
 import { adjustNoteNameHeight } from './ui-utils';
@@ -449,7 +449,7 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 			|| generalSettings.defaultPromptContext
 			|| '{{fullHtml|remove_html:("#navbar,.footer,#footer,header,footer,style,script")|strip_tags:("script,h1,h2,h3,h4,h5,h6,meta,a,ol,ul,li,p,em,strong,i,b,s,strike,u,sup,sub,img,video,audio,math,table,cite,td,th,tr,caption")|strip_attr:("alt,src,href,id,content,property,name,datetime,title")}}';
 		promptToDisplay = await compileTemplate(tabId, promptToDisplay, variables, currentUrl);
-		promptContextTextarea.value = promptToDisplay;
+		promptContextTextarea.value = restoreBraces(promptToDisplay);
 		
 		// Initial token count
 		if (tokenCounter) {

--- a/src/utils/template-compiler.ts
+++ b/src/utils/template-compiler.ts
@@ -16,6 +16,39 @@ import { processPrompt } from './variables/prompt';
 export type SelectorProcessor = (match: string, currentUrl: string) => Promise<string>;
 
 /**
+ * Escapes template variables (e.g., {{variable}}) by injecting zero-width 
+ * spaces (\u200B) between the braces.
+ * * This prevents from accidentally parsing or evaluating the braces,
+ * while keeping the text visually identical for the user.
+ * * @param value - The input value. If it's not a string, it returns the value untouched.
+ * @returns The escaped string, or the original value if it wasn't a string.
+ */
+export function escapeBraces(value: any) {
+	const regex = /{{([\s\S]*?)}}/g;
+	if (typeof value === "string") {
+		return value.replace(
+			regex,
+			"\u200B{\u200B{\u200B$1\u200B}\u200B}\u200B",
+		);
+	} else {
+		return value;
+	}
+}
+
+/**
+ * Restores previously escaped template variables back to their original, 
+ * unescaped form ({{variable}}).
+ * * It specifically targets braces wrapped in the exact zero-width space (\u200B) 
+ * pattern injected by `escapeBraces`, leaving legitimate zero-width spaces alone.
+ * * @param value - The escaped string containing the invisible characters.
+ * @returns The cleaned string with standard {{...}} braces.
+ */
+export function restoreBraces(value: string) {
+	const regex = /\u200B{\u200B{\u200B([\s\S]*?)\u200B}\u200B}\u200B/g;
+	return value.replace(regex, "{{$1}}");
+}
+
+/**
  * Main function to compile a template with the given variables.
  *
  * @param tabId - Browser tab ID for selector resolution (0 if not applicable)
@@ -38,16 +71,36 @@ export async function compileTemplate(
 	currentUrl = currentUrl.replace(/#:~:text=[^&]+(&|$)/, '');
 
 	// Use provided resolver or default browser-based one
-	const asyncResolver = customAsyncResolver ?? (async (name: string, ctx: RenderContext): Promise<any> => {
+	const baseResolver = customAsyncResolver ?? (async (name: string, ctx: RenderContext): Promise<any> => {
 		if (name.startsWith('selector:') || name.startsWith('selectorHtml:')) {
 			return resolveSelector(ctx.tabId!, name);
 		}
 		return undefined;
 	});
 
+	// Wrap asyncResolver to intercept the result and escape the braces
+	const asyncResolver = async (
+		name: string,
+		ctx: RenderContext,
+	): Promise<any> => {
+		const result = await baseResolver(name, ctx);
+		if (Array.isArray(result)) {
+			return result.map((value) => {
+				return escapeBraces(value);
+			});
+		}
+		return escapeBraces(result);
+	};
+
+	// Disarm standard variables so literal {{}} don't pollute the output
+	const safeVariables: typeof variables = {};
+	Object.entries(variables).forEach(([key, value]) => {
+		safeVariables[key] = escapeBraces(value);
+	});
+
 	// Create render context with custom variable resolver
 	const context: RenderContext = {
-		variables,
+		variables: safeVariables,
 		currentUrl,
 		tabId,
 		applyFilterDirect,

--- a/src/utils/template-integration.test.ts
+++ b/src/utils/template-integration.test.ts
@@ -10,7 +10,7 @@ import { parseHTML } from 'linkedom';
 import DefuddleClass from 'defuddle';
 import { createMarkdownContent } from 'defuddle/full';
 import { buildVariables, generateFrontmatter, formatPropertyValue } from './shared';
-import { compileTemplate } from './template-compiler';
+import { compileTemplate, restoreBraces } from './template-compiler';
 import { createAsyncResolver, createSelectorProcessor } from '../api';
 
 // ---------------------------------------------------------------------------
@@ -85,8 +85,9 @@ async function runFixture(html: string, url: string, template: FixtureTemplate):
 
 	const frontmatter = generateFrontmatter(compiledProperties, typeMap);
 	const compiledContent = await compileFn(template.noteContentFormat);
+	const finalOutput = frontmatter ? frontmatter + compiledContent : compiledContent;
 
-	return frontmatter ? frontmatter + compiledContent : compiledContent;
+	return restoreBraces(finalOutput);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #860. This PR addresses a template injection/double evaluation bug where literal string values containing `{{ }}` were erroneously parsed and executed during the post-processing phase.

## The Problem

Previously, the AST renderer resolved standard variables and flattened the output into a single string. If a variable naturally contained literal template brackets (e.g., `<p>The main content variable is {{content}}</p>`), those brackets were dumped directly into the rendered text.

When `processVariables` subsequently ran its Regex sweep over the flattened string to catch deferred AI prompts or special commands, it could not distinguish between a legitimate deferred command and a literal string from a user variable. This resulted in the application attempting to process standard text as an AI prompt, schema, variable or selector.

## The Solution

Added invisible "Input Escaping" approach using zero-width spaces to safely preserve literal variables through the compilation pipeline:

1. **Escaping (`escapeBraces`):** Before passing variables to the render context, we sweep string-based variables and inject zero-width spaces (`\u200B`) between the curly braces (e.g., transforming `{{` into `\u200B{\u200B{\u200B`). This visually preserves the text for the user/debugger but breaks the regex match.
2. **Safe Rendering & Post-Processing:** The AST renderer safely processes the template. When `processVariables` runs its Regex sweep, it completely ignores the escaped user variables because the contiguous `{{` pattern is broken by the invisible characters. Only legitimate, unescaped deferred commands are processed.
3. **Restoration (`restoreBraces`):** After post-processing is complete, we run a targeted regex to strip out those specific zero-width spaces, restoring the user's literal braces perfectly in the final output.

## Impact & Risks

- **Risk:** Low. The transformation targets a highly specific and intentional byte pattern. Legitimate zero-width spaces used elsewhere in text remain unaffected.
- **Impact:** High. It completely patches the template injection vulnerability and ensures AI prompt logic is not polluted by unexpected user data.

## Testing Steps

Integration tests have been updated to cover this edge case automatically. A fixture was added to verify that literal variable brackets are safely ignored during post-processing and accurately restored in the final string.

You can verify the fix by running the updated test suite:

```bash
npm run test src/utils/template-integration.test.ts -t

```
