### PR TITLE
Fix lazy-loaded image URL extraction

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from 'vitest';
+import { parseHTML } from 'linkedom';
+import { clip } from './api';
+
+describe('clip API image URL normalization', () => {
+	test('includes promoted lazy image URLs in generated content', async () => {
+		const result = await clip({
+			html: `
+				<html>
+					<head><title>Lazy image article</title></head>
+					<body>
+						<article>
+							<h1>Lazy image article</h1>
+							<p>Article text with enough content for extraction.</p>
+							<img data-src="/images/a.jpg" alt="A">
+						</article>
+					</body>
+				</html>
+			`,
+			url: 'https://example.com/articles/post',
+			template: {
+				id: 'lazy-image-test',
+				name: 'Lazy image test',
+				behavior: 'create',
+				noteNameFormat: '{{title}}',
+				path: '',
+				noteContentFormat: '{{content}}',
+				properties: [],
+			},
+			documentParser: {
+				parseFromString: (html: string) => parseHTML(html).document,
+			},
+		});
+
+		expect(result.content).toContain('https://example.com/images/a.jpg');
+	});
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,6 +9,7 @@ import { AsyncResolver, RenderContext } from './utils/renderer';
 import { applyFilters } from './utils/filters';
 import { buildVariables, generateFrontmatter, extractContentBySelector, selectorContentToString, formatPropertyValue } from './utils/shared';
 import { sanitizeFileName } from './utils/string-utils';
+import { normalizeImageUrls } from './utils/image-url-normalization';
 import { Template, Property } from './types/types';
 
 // ---------------------------------------------------------------------------
@@ -182,18 +183,20 @@ export async function clip(options: ClipOptions): Promise<ClipResult> {
 
 	// Extract content with defuddle
 	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
-	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
+	const defuddleInput = doc?.nodeType === 9 ? doc : documentElement;
+	const defuddle = new DefuddleClass(defuddleInput as unknown as Document, { url });
 	const defuddleResult = defuddle.parse();
+	const normalizedContent = normalizeImageUrls(defuddleResult.content, url, documentParser);
 
 	// Convert to markdown
-	const markdownContent = createMarkdownContent(defuddleResult.content, url);
+	const markdownContent = createMarkdownContent(normalizedContent, url);
 
 	// Build template variables
 	const variables = buildVariables({
 		title: defuddleResult.title,
 		author: defuddleResult.author,
 		content: markdownContent,
-		contentHtml: defuddleResult.content,
+		contentHtml: normalizedContent,
 		url,
 		fullHtml: html,
 		description: defuddleResult.description,

--- a/src/content.ts
+++ b/src/content.ts
@@ -11,6 +11,7 @@ import { serializeChildren } from './utils/dom-utils';
 import { saveFile } from './utils/file-utils';
 import { debugLog } from './utils/debug';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './utils/iframe-resize';
+import { normalizeImageUrls } from './utils/image-url-normalization';
 import { parseForClip } from './utils/clip-utils';
 
 declare global {
@@ -156,7 +157,7 @@ declare global {
 					const defuddled = parseForClip(document);
 
 					// Convert HTML content to markdown
-					const markdown = createMarkdownContent(defuddled.content, document.URL);
+					const markdown = createMarkdownContent(normalizeImageUrls(defuddled.content, document.URL), document.URL);
 
 					// Copy to clipboard
 					const textArea = document.createElement("textarea");
@@ -179,7 +180,7 @@ declare global {
 			flattenShadowDom(document).then(async () => {
 				try {
 					const defuddled = parseForClip(document);
-					const markdown = createMarkdownContent(defuddled.content, document.URL);
+					const markdown = createMarkdownContent(normalizeImageUrls(defuddled.content, document.URL), document.URL);
 					const title = defuddled.title || document.title || 'Untitled';
 					const fileName = title.replace(/[/\\?%*:|"<>]/g, '-');
 					await saveFile({

--- a/src/utils/content-extractor.test.ts
+++ b/src/utils/content-extractor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, test, expect } from 'vitest';
-import { processHighlights } from './content-extractor';
+import { initializePageContent, processHighlights } from './content-extractor';
 import { TextHighlightData } from './highlighter';
 
 // Default settings already use highlighterEnabled + 'highlight-inline', the
@@ -45,5 +45,31 @@ describe('processHighlights — highlight-inline', () => {
 		expect(mark!.textContent?.replace(/\s+/g, ' ').trim()).toBe('A seismic shift is rocking the healthcare industry.');
 		// The link must survive inside the mark, proving the range crossed it.
 		expect(mark!.querySelector('a')).not.toBeNull();
+	});
+});
+
+describe('initializePageContent image URL normalization', () => {
+	test('includes promoted lazy image URLs in markdown content', async () => {
+		const result = await initializePageContent(
+			'<article><p><img data-src="/images/a.jpg" alt="A"></p></article>',
+			'',
+			{},
+			'https://example.com/articles/post',
+			{},
+			'',
+			[],
+			'Lazy image article',
+			'',
+			'',
+			'',
+			'',
+			'',
+			'',
+			0,
+			'',
+			[]
+		);
+
+		expect(result.currentVariables['{{content}}']).toContain('https://example.com/images/a.jpg');
 	});
 });

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -7,6 +7,7 @@ import { debugLog } from './debug';
 import dayjs from 'dayjs';
 import { AnyHighlightData, TextHighlightData, HighlightData, collapseGroupsForExport } from './highlighter';
 import { generalSettings } from './storage-utils';
+import { normalizeImageUrls } from './image-url-normalization';
 import {
 	getElementByXPath,
 	wrapElementWithMark,
@@ -148,8 +149,9 @@ export async function initializePageContent(
 
 		let selectedMarkdown = '';
 		if (selectedHtml) {
-			content = selectedHtml;
-			selectedMarkdown = createMarkdownContent(selectedHtml, currentUrl);
+			const normalizedSelectedHtml = normalizeImageUrls(selectedHtml, currentUrl);
+			content = normalizedSelectedHtml;
+			selectedMarkdown = createMarkdownContent(normalizedSelectedHtml, currentUrl);
 		}
 
 		// Process highlights after getting the base content
@@ -157,6 +159,7 @@ export async function initializePageContent(
 			content = processHighlights(content, highlights);
 		}
 
+		content = normalizeImageUrls(content, currentUrl);
 		const markdownBody = createMarkdownContent(content, currentUrl);
 
 		const highlightsData = collapseGroupsForExport(highlights, c => createMarkdownContent(c, currentUrl));

--- a/src/utils/image-url-normalization.test.ts
+++ b/src/utils/image-url-normalization.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from 'vitest';
+import { normalizeImageUrls } from './image-url-normalization';
+
+const pageUrl = 'https://example.com/articles/post';
+
+function firstImage(html: string): HTMLImageElement {
+	const doc = new DOMParser().parseFromString(html, 'text/html');
+	const img = doc.querySelector('img');
+	if (!img) throw new Error('Expected normalized HTML to contain an image');
+	return img as HTMLImageElement;
+}
+
+describe('normalizeImageUrls', () => {
+	test('promotes data-src when an image has no src', () => {
+		const img = firstImage(normalizeImageUrls('<p><img data-src="https://cdn.example.com/a.jpg"></p>', pageUrl));
+
+		expect(img.getAttribute('src')).toBe('https://cdn.example.com/a.jpg');
+	});
+
+	test.each([
+		'data-original',
+		'data-lazy-src',
+		'data-actualsrc',
+		'data-backup',
+	])('promotes %s when it is the first valid lazy candidate', attribute => {
+		const img = firstImage(normalizeImageUrls(`<img ${attribute}="https://cdn.example.com/a.jpg">`, pageUrl));
+
+		expect(img.getAttribute('src')).toBe('https://cdn.example.com/a.jpg');
+	});
+
+	test('replaces a data image placeholder with a lazy image candidate', () => {
+		const img = firstImage(normalizeImageUrls(
+			'<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" data-src="https://cdn.example.com/a.jpg">',
+			pageUrl
+		));
+
+		expect(img.getAttribute('src')).toBe('https://cdn.example.com/a.jpg');
+	});
+
+	test('preserves an existing usable src when a lazy candidate is present', () => {
+		const img = firstImage(normalizeImageUrls(
+			'<img src="https://cdn.example.com/current.jpg" data-src="https://cdn.example.com/lazy.jpg">',
+			pageUrl
+		));
+
+		expect(img.getAttribute('src')).toBe('https://cdn.example.com/current.jpg');
+	});
+
+	test('resolves root-relative and path-relative lazy image URLs against the page URL', () => {
+		const html = normalizeImageUrls(
+			'<img data-src="/images/root.jpg"><img data-src="images/path.jpg">',
+			pageUrl
+		);
+		const doc = new DOMParser().parseFromString(html, 'text/html');
+		const images = Array.from(doc.querySelectorAll('img'));
+
+		expect(images[0].getAttribute('src')).toBe('https://example.com/images/root.jpg');
+		expect(images[1].getAttribute('src')).toBe('https://example.com/articles/images/path.jpg');
+	});
+
+	test('resolves relative srcset candidates without removing descriptors', () => {
+		const img = firstImage(normalizeImageUrls(
+			'<img srcset="/a-1x.jpg 1x, a-2x.jpg 2x, https://cdn.example.com/a-3x.jpg 3x">',
+			pageUrl
+		));
+
+		expect(img.getAttribute('srcset')).toBe(
+			'https://example.com/a-1x.jpg 1x, https://example.com/articles/a-2x.jpg 2x, https://cdn.example.com/a-3x.jpg 3x'
+		);
+	});
+
+	test('does not invent src when no lazy candidate is valid', () => {
+		const img = firstImage(normalizeImageUrls('<img data-src="http://[::1">', pageUrl));
+
+		expect(img.hasAttribute('src')).toBe(false);
+	});
+
+	test('does not replace a usable src with an invalid lazy candidate', () => {
+		const img = firstImage(normalizeImageUrls(
+			'<img src="https://cdn.example.com/current.jpg" data-src="http://[::1">',
+			pageUrl
+		));
+
+		expect(img.getAttribute('src')).toBe('https://cdn.example.com/current.jpg');
+	});
+});

--- a/src/utils/image-url-normalization.ts
+++ b/src/utils/image-url-normalization.ts
@@ -1,0 +1,103 @@
+export interface HtmlDocumentParser {
+	parseFromString(html: string, mimeType: string): Document;
+}
+
+const LAZY_IMAGE_ATTRIBUTES = [
+	'data-src',
+	'data-original',
+	'data-lazy-src',
+	'data-actualsrc',
+	'data-backup',
+];
+
+function getParser(parser?: HtmlDocumentParser): HtmlDocumentParser | null {
+	if (parser) return parser;
+	if (typeof DOMParser === 'undefined') return null;
+	return new DOMParser();
+}
+
+function resolveHttpUrl(value: string, baseUrl: URL): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+
+	try {
+		const url = new URL(trimmed, baseUrl);
+		return ['http:', 'https:'].includes(url.protocol) ? url.href : null;
+	} catch {
+		return null;
+	}
+}
+
+function isReplaceableImageSrc(value: string | null): boolean {
+	if (value === null) return true;
+	const trimmed = value.trim();
+	return trimmed === '' || trimmed.startsWith('data:image/');
+}
+
+function findLazyImageUrl(img: Element, baseUrl: URL): string | null {
+	for (const attribute of LAZY_IMAGE_ATTRIBUTES) {
+		const value = img.getAttribute(attribute);
+		if (!value) continue;
+
+		const resolved = resolveHttpUrl(value, baseUrl);
+		if (resolved) return resolved;
+	}
+
+	return null;
+}
+
+function normalizeSrcset(srcset: string, baseUrl: URL): string {
+	return srcset
+		.split(',')
+		.map(candidate => {
+			const trimmed = candidate.trim();
+			if (!trimmed) return trimmed;
+
+			const [urlPart, ...descriptorParts] = trimmed.split(/\s+/);
+			const resolvedUrl = resolveHttpUrl(urlPart, baseUrl);
+			if (!resolvedUrl) return trimmed;
+
+			const descriptor = descriptorParts.join(' ');
+			return descriptor ? `${resolvedUrl} ${descriptor}` : resolvedUrl;
+		})
+		.join(', ');
+}
+
+function serializeBody(doc: Document): string {
+	if (doc.body) return doc.body.innerHTML;
+	return doc.documentElement?.outerHTML || '';
+}
+
+export function normalizeImageUrls(
+	htmlContent: string,
+	baseUrl: string | URL,
+	parser?: HtmlDocumentParser
+): string {
+	const documentParser = getParser(parser);
+	if (!documentParser) return htmlContent;
+
+	let resolvedBaseUrl: URL;
+	try {
+		resolvedBaseUrl = new URL(baseUrl.toString());
+	} catch {
+		return htmlContent;
+	}
+
+	const doc = documentParser.parseFromString(`<!doctype html><html><body>${htmlContent}</body></html>`, 'text/html');
+	doc.querySelectorAll('img').forEach(img => {
+		const srcset = img.getAttribute('srcset');
+		if (srcset) {
+			img.setAttribute('srcset', normalizeSrcset(srcset, resolvedBaseUrl));
+		}
+
+		const currentSrc = img.getAttribute('src');
+		if (!isReplaceableImageSrc(currentSrc)) return;
+
+		const lazyUrl = findLazyImageUrl(img, resolvedBaseUrl);
+		if (lazyUrl) {
+			img.setAttribute('src', lazyUrl);
+		}
+	});
+
+	return serializeBody(doc);
+}

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -31,6 +31,7 @@ import { saveFile } from './file-utils';
 import { parseForClip } from './clip-utils';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './iframe-resize';
 import { setElementHTML, setSVGChildren, serializeChildren } from './dom-utils';
+import { normalizeImageUrls } from './image-url-normalization';
 
 // Mobile viewport settings
 const VIEWPORT = 'width=device-width, initial-scale=1, maximum-scale=1';
@@ -2777,7 +2778,7 @@ export class Reader {
 	static copyMarkdownOnReaderPage(doc: Document): void {
 		try {
 			const defuddled = parseForClip(doc);
-			const markdown = createMarkdownContent(defuddled.content, doc.URL);
+			const markdown = createMarkdownContent(normalizeImageUrls(defuddled.content, doc.URL), doc.URL);
 			navigator.clipboard.writeText(markdown).catch(() => {
 				const textArea = doc.createElement('textarea');
 				textArea.value = markdown;
@@ -2794,7 +2795,7 @@ export class Reader {
 	static async saveMarkdownOnReaderPage(doc: Document): Promise<void> {
 		try {
 			const defuddled = parseForClip(doc);
-			const markdown = createMarkdownContent(defuddled.content, doc.URL);
+			const markdown = createMarkdownContent(normalizeImageUrls(defuddled.content, doc.URL), doc.URL);
 			const title = defuddled.title || doc.title || 'Untitled';
 			const fileName = title.replace(/[/\\?%*:|"<>]/g, '-');
 			await saveFile({ content: markdown, fileName, mimeType: 'text/markdown' });


### PR DESCRIPTION
## Summary

- Normalize lazy-loaded image URLs before converting clipped HTML to Markdown
- Promote common lazy image attributes such as `data-src`, `data-original`, `data-lazy-src`, `data-actualsrc`, and `data-backup` when `src` is missing or a placeholder
- Preserve usable `src` values and normalize relative `srcset` candidates
- Apply the normalization across the main clip, Markdown export, reader export, and programmatic API paths

## Why

Some pages keep the real image URL in lazy-loading attributes while `src` is missing or points to a placeholder data URL. In those cases the generated Markdown can omit the usable image URL or keep the placeholder instead.

This keeps the existing behavior of linking to web image URLs rather than downloading attachments.

## Testing

- `git diff --check`
- `TZ=America/Los_Angeles npm test`
- `npm run build`

`npm run build` completes with existing Sass `@import` deprecation and bundle size warnings.