### PR TITLE
Add Apple Intelligence to Interpreter providers

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -1,5 +1,16 @@
 {
 	"version": "2026.12.08",
+	"apple-intelligence": {
+		"id": "apple-intelligence",
+		"name": "Apple Intelligence",
+		"providerType": "apple-intelligence",
+		"baseUrl": "",
+		"apiKeyRequired": false,
+		"popularModels": [
+			{ "id": "on-device", "name": "On-Device Model", "recommended": true },
+			{ "id": "private-cloud", "name": "Private Compute Cloud" }
+		]
+	},
 	"anthropic": {
 		"id": "anthropic",
 		"name": "Anthropic",

--- a/providers.json
+++ b/providers.json
@@ -8,7 +8,7 @@
 		"apiKeyRequired": false,
 		"popularModels": [
 			{ "id": "on-device", "name": "On-Device Model", "recommended": true },
-			{ "id": "private-cloud", "name": "Private Compute Cloud" }
+			{ "id": "private-cloud", "name": "Private Cloud Compute" }
 		]
 	},
 	"anthropic": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -725,6 +725,22 @@ browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime
 			}
 		}
 
+		if (typedRequest.action === 'appleIntelligencePrompt') {
+			const { systemPrompt, userMessage, model } = typedRequest as {
+				action: string;
+				systemPrompt: string;
+				userMessage: string;
+				model?: string;
+			};
+			(browser.runtime as any).sendNativeMessage('application.id', {
+				type: 'appleIntelligencePrompt',
+				systemPrompt,
+				userMessage,
+				model: model ?? 'on-device',
+			}).then(sendResponse).catch((err: Error) => sendResponse({ success: false, error: err.message }));
+			return true;
+		}
+
 		// For other actions that use sendResponse
 		if (typedRequest.action === "extractContent" ||
 			typedRequest.action === "ensureContentScriptLoaded" ||

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -1358,7 +1358,10 @@ async function handleClipObsidian(): Promise<void> {
 		}
 	} catch (error) {
 		console.error('Error in handleClipObsidian:', error);
-		showError('failedToSaveFile');
+		// Don't overwrite the interpreter's own error display with a generic save error
+		if (!interpretBtn?.classList.contains('error')) {
+			showError('failedToSaveFile');
+		}
 		throw error;
 	}
 }

--- a/src/managers/interpreter-settings.ts
+++ b/src/managers/interpreter-settings.ts
@@ -482,7 +482,7 @@ async function showProviderModal(provider: Provider, index?: number) {
 
 		const appleIntelligenceNote = document.createElement('p');
 		appleIntelligenceNote.className = 'setting-item-description';
-		appleIntelligenceNote.textContent = 'Requires Safari on Mac or iPhone with Apple Intelligence enabled in Settings.';
+		appleIntelligenceNote.textContent = 'Requires Safari on iOS or macOS 26+ on a supported device with Apple Intelligence enabled.';
 		appleIntelligenceNote.style.display = 'none';
 		baseUrlContainer.insertAdjacentElement('beforebegin', appleIntelligenceNote);
 

--- a/src/managers/interpreter-settings.ts
+++ b/src/managers/interpreter-settings.ts
@@ -1,5 +1,5 @@
 import { initializeToggles, initializeSettingToggle } from '../utils/ui-utils';
-import { ModelConfig, Provider } from '../types/types';
+import { ModelConfig, Provider, ProviderType } from '../types/types';
 import { generalSettings, loadSettings, saveSettings, getLocalStorage, setLocalStorage } from '../utils/storage-utils';
 import { initializeIcons } from '../icons/icons';
 import { showModal, hideModal } from '../utils/modal-utils';
@@ -12,6 +12,7 @@ export interface PresetProvider {
 	baseUrl: string;
 	apiKeyUrl?: string;
 	apiKeyRequired?: boolean;
+	providerType?: ProviderType;
 	modelsList?: string;
 	popularModels?: Array<{
 		id: string;
@@ -470,13 +471,20 @@ async function showProviderModal(provider: Provider, index?: number) {
 		const apiKeyInput = form.querySelector('[name="apiKey"]') as HTMLInputElement;
 		const presetSelect = form.querySelector('[name="preset"]') as HTMLSelectElement;
 		const nameContainer = nameInput.closest('.setting-item') as HTMLElement;
+		const baseUrlContainer = baseUrlInput.closest('.setting-item') as HTMLElement;
 		const apiKeyContainer = apiKeyInput.closest('.setting-item') as HTMLElement;
 		const apiKeyDescription = form.querySelector('.setting-item:has([name="apiKey"]) .setting-item-description') as HTMLElement;
 
-		if (!apiKeyContainer || !apiKeyDescription || !nameContainer || !presetSelect || !nameInput || !baseUrlInput || !apiKeyInput) {
+		if (!apiKeyContainer || !baseUrlContainer || !apiKeyDescription || !nameContainer || !presetSelect || !nameInput || !baseUrlInput || !apiKeyInput) {
 			console.error('Required provider modal elements not found');
 			return;
 		}
+
+		const appleIntelligenceNote = document.createElement('p');
+		appleIntelligenceNote.className = 'setting-item-description';
+		appleIntelligenceNote.textContent = 'Requires Safari on Mac or iPhone with Apple Intelligence enabled in Settings.';
+		appleIntelligenceNote.style.display = 'none';
+		baseUrlContainer.insertAdjacentElement('beforebegin', appleIntelligenceNote);
 
 		// Clear and populate preset select
 		presetSelect.textContent = '';
@@ -525,15 +533,24 @@ async function showProviderModal(provider: Provider, index?: number) {
 			const selectedPreset = selectedPresetId ? (cachedPresetProviders || {})[selectedPresetId] : null;
 
 			nameContainer.style.display = selectedPreset ? 'none' : 'block';
-			
+
 			if (selectedPreset) {
 				nameInput.value = selectedPreset.name;
-				
-				const editingOriginalPreset = index !== undefined && selectedPresetId === currentPresetId;
-				baseUrlInput.value = editingOriginalPreset ? provider.baseUrl : selectedPreset.baseUrl;
-				apiKeyInput.value = editingOriginalPreset ? provider.apiKey : '';
 
-				apiKeyContainer.style.display = selectedPreset.apiKeyRequired === false ? 'none' : 'block';
+				const isAppleIntelligence = selectedPreset.providerType === 'apple-intelligence';
+
+				appleIntelligenceNote.style.display = isAppleIntelligence ? 'block' : 'none';
+				baseUrlContainer.style.display = isAppleIntelligence ? 'none' : 'block';
+				apiKeyContainer.style.display = (isAppleIntelligence || selectedPreset.apiKeyRequired === false) ? 'none' : 'block';
+
+				if (isAppleIntelligence) {
+					baseUrlInput.value = '';
+					apiKeyInput.value = '';
+				} else {
+					const editingOriginalPreset = index !== undefined && selectedPresetId === currentPresetId;
+					baseUrlInput.value = editingOriginalPreset ? provider.baseUrl : selectedPreset.baseUrl;
+					apiKeyInput.value = editingOriginalPreset ? provider.apiKey : '';
+				}
 
 				if (selectedPreset.apiKeyRequired !== false && selectedPreset.apiKeyUrl) {
 					const message = getMessage('getApiKeyHere').replace('$1', selectedPreset.name);
@@ -557,6 +574,8 @@ async function showProviderModal(provider: Provider, index?: number) {
 					apiKeyInput.value = provider.apiKey;
 				}
 				
+				appleIntelligenceNote.style.display = 'none';
+				baseUrlContainer.style.display = 'block';
 				apiKeyContainer.style.display = 'block';
 				apiKeyDescription.textContent = getMessage('providerApiKeyDescription');
 			}
@@ -595,20 +614,26 @@ async function showProviderModal(provider: Provider, index?: number) {
 
 		debugLog('Providers', 'Saving provider:', updatedProvider);
 
-		if (!updatedProvider.name || !updatedProvider.baseUrl) {
+		const selectedPresetForSave = presetId && cachedPresetProviders ? cachedPresetProviders[presetId] : null;
+		const isAppleIntelligencePreset = selectedPresetForSave?.providerType === 'apple-intelligence';
+
+		if (!updatedProvider.name || (!updatedProvider.baseUrl && !isAppleIntelligencePreset)) {
 			alert(getMessage('providerRequiredFields'));
 			return;
 		}
 
-		if (presetId && cachedPresetProviders && cachedPresetProviders[presetId]) {
-			const providerPreset = cachedPresetProviders[presetId];
-			
+		if (selectedPresetForSave) {
+			const providerPreset = selectedPresetForSave;
+
 			updatedProvider.name = providerPreset.name;
-			
+
 			const providerPresetBaseUrl = providerPreset.baseUrl;
 			// Use the user-provided baseUrl if it's different from the preset baseUrl
 			updatedProvider.baseUrl = baseUrl !== providerPresetBaseUrl ? baseUrl : providerPresetBaseUrl;
 			updatedProvider.apiKeyRequired = providerPreset.apiKeyRequired !== false;
+			if (providerPreset.providerType) {
+				updatedProvider.providerType = providerPreset.providerType;
+			}
 		}
 
 		if (index !== undefined) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -36,6 +36,8 @@ export interface PropertyType {
 	defaultValue?: string;
 }
 
+export type ProviderType = 'http' | 'apple-intelligence';
+
 export interface Provider {
 	id: string;
 	name: string;
@@ -43,6 +45,7 @@ export interface Provider {
 	apiKey: string;
 	apiKeyRequired?: boolean;
 	presetId?: string;
+	providerType?: ProviderType;
 }
 
 export interface Rating {

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -37,12 +37,17 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 		const systemContent = 
 			`You are a helpful assistant. Please respond with one JSON object named \`prompts_responses\` — no explanatory text before or after. Use the keys provided, e.g. \`prompt_1\`, \`prompt_2\`, and fill in the values. Values should be Markdown strings unless otherwise specified. Make your responses concise. For example, your response should look like: {"prompts_responses":{"prompt_1":"tag1, tag2, tag3","prompt_2":"- bullet1\n- bullet 2\n- bullet3"}}`;
 		
-		const promptContent = {	
+		const promptContent = {
 			prompts: promptVariables.reduce((acc, { key, prompt }) => {
 				acc[key] = prompt;
 				return acc;
 			}, {} as { [key: string]: string })
 		};
+
+		if (provider.providerType === 'apple-intelligence') {
+			lastRequestTime = now;
+			return await sendToAppleIntelligence(systemContent, promptContext, promptContent, promptVariables, model.providerModelId);
+		}
 
 		let requestUrl: string;
 		let requestBody: any;
@@ -229,6 +234,67 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 		console.error(`Error sending to ${provider.name} LLM:`, error);
 		throw error;
 	}
+}
+
+async function sendToAppleIntelligence(
+	systemContent: string,
+	promptContext: string,
+	promptContent: { prompts: Record<string, string> },
+	promptVariables: PromptVariable[],
+	modelId: string
+): Promise<{ promptResponses: any[] }> {
+	if (typeof (browser.runtime as any).sendNativeMessage !== 'function') {
+		throw new Error(
+			'Apple Intelligence requires Safari on a Mac or iPhone. ' +
+			'Please switch to Safari or choose a different model.'
+		);
+	}
+
+	const result = await browser.runtime.sendMessage({
+		action: 'appleIntelligencePrompt',
+		systemPrompt: systemContent,
+		userMessage: `${promptContext}\n\n${JSON.stringify(promptContent)}`,
+		model: modelId,
+	}) as { success: boolean; content?: string; error?: string; reason?: string; quotaWarning?: boolean };
+
+	if (!result.success) {
+		const { reason, error } = result;
+		if (reason === 'appleIntelligenceNotEnabled') {
+			throw new Error('Apple Intelligence is not enabled on this device. Go to Settings → Apple Intelligence & Siri to enable it.');
+		}
+		if (reason === 'deviceNotEligible') {
+			throw new Error('This device does not support Apple Intelligence.');
+		}
+		if (reason === 'osVersionTooOld') {
+			throw new Error('Apple Intelligence requires macOS 26 or iOS 26 or later.');
+		}
+		if (reason === 'pccRequiresNewerOS') {
+			throw new Error('Private Cloud Compute requires macOS 27 or iOS 27 or later.');
+		}
+		if (reason === 'pccNotYetImplemented') {
+			throw new Error('Private Cloud Compute support is not yet available in this version.');
+		}
+		if (error === 'quotaExceeded') {
+			throw new Error('You have reached your Private Cloud Compute daily limit.');
+		}
+		if (error === 'contextWindowExceeded') {
+			throw new Error('The prompt context is too long for this model\'s context window. In interpreter settings, set the template\'s Context field to {{content}} to send only the clipped text instead of the full page, or choose a model with a larger context window.');
+		}
+		if (error === 'guardrailsViolation') {
+			throw new Error('Apple Intelligence declined to process this content.');
+		}
+		if (error === 'languageModelError') {
+			const detail = (result as any).detail;
+			throw new Error(`Apple Intelligence model error${detail ? `: ${detail}` : '.'}`);
+		}
+		throw new Error(`Apple Intelligence error: ${error ?? 'Unknown error'}`);
+	}
+
+	if (result.quotaWarning) {
+		debugLog('Interpreter', 'Apple Intelligence: Private Cloud Compute quota is approaching its daily limit.');
+	}
+
+	return parseLLMResponse(result.content!, promptVariables);
 }
 
 interface LLMResponse {

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -1,24 +1,34 @@
-import { generalSettings, saveSettings } from './storage-utils';
-import { PromptVariable, Template, ModelConfig } from '../types/types';
-import { compileTemplate } from './template-compiler';
-import { applyFilters } from './filters';
-import { formatDuration } from './string-utils';
-import { adjustNoteNameHeight } from './ui-utils';
-import { debugLog } from './debug';
-import { getMessage } from './i18n';
-import { updateTokenCount } from './token-counter';
+import { generalSettings, saveSettings } from "./storage-utils";
+import { PromptVariable, Template, ModelConfig } from "../types/types";
+import { compileTemplate } from "./template-compiler";
+import { applyFilters } from "./filters";
+import { formatDuration } from "./string-utils";
+import { adjustNoteNameHeight } from "./ui-utils";
+import { debugLog } from "./debug";
+import { getMessage } from "./i18n";
+import { updateTokenCount } from "./token-counter";
 
 const RATE_LIMIT_RESET_TIME = 60000; // 1 minute in milliseconds
 let lastRequestTime = 0;
 
 // Store event listeners for cleanup
-const eventListeners = new WeakMap<HTMLElement, { [key: string]: EventListener }>();
+const eventListeners = new WeakMap<
+	HTMLElement,
+	{ [key: string]: EventListener }
+>();
 
-export async function sendToLLM(promptContext: string, content: string, promptVariables: PromptVariable[], model: ModelConfig): Promise<{ promptResponses: any[] }> {
-	debugLog('Interpreter', 'Sending request to LLM...');
-	
+export async function sendToLLM(
+	promptContext: string,
+	content: string,
+	promptVariables: PromptVariable[],
+	model: ModelConfig,
+): Promise<{ promptResponses: any[] }> {
+	debugLog("Interpreter", "Sending request to LLM...");
+
 	// Find the provider for this model
-	const provider = generalSettings.providers.find(p => p.id === model.providerId);
+	const provider = generalSettings.providers.find(
+		(p) => p.id === model.providerId,
+	);
 	if (!provider) {
 		throw new Error(`Provider not found for model ${model.name}`);
 	}
@@ -30,114 +40,141 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 
 	const now = Date.now();
 	if (now - lastRequestTime < RATE_LIMIT_RESET_TIME) {
-		throw new Error(`Rate limit cooldown. Please wait ${Math.ceil((RATE_LIMIT_RESET_TIME - (now - lastRequestTime)) / 1000)} seconds before trying again.`);
+		throw new Error(
+			`Rate limit cooldown. Please wait ${Math.ceil((RATE_LIMIT_RESET_TIME - (now - lastRequestTime)) / 1000)} seconds before trying again.`,
+		);
 	}
 
 	try {
-		const systemContent = 
-			`You are a helpful assistant. Please respond with one JSON object named \`prompts_responses\` — no explanatory text before or after. Use the keys provided, e.g. \`prompt_1\`, \`prompt_2\`, and fill in the values. Values should be Markdown strings unless otherwise specified. Make your responses concise. For example, your response should look like: {"prompts_responses":{"prompt_1":"tag1, tag2, tag3","prompt_2":"- bullet1\n- bullet 2\n- bullet3"}}`;
-		
+		const systemContent = `You are a helpful assistant. Please respond with one JSON object named \`prompts_responses\` — no explanatory text before or after. Use the keys provided, e.g. \`prompt_1\`, \`prompt_2\`, and fill in the values. Values should be Markdown strings unless otherwise specified. Make your responses concise. For example, your response should look like: {"prompts_responses":{"prompt_1":"tag1, tag2, tag3","prompt_2":"- bullet1\n- bullet 2\n- bullet3"}}`;
+
 		const promptContent = {
-			prompts: promptVariables.reduce((acc, { key, prompt }) => {
-				acc[key] = prompt;
-				return acc;
-			}, {} as { [key: string]: string })
+			prompts: promptVariables.reduce(
+				(acc, { key, prompt }) => {
+					acc[key] = prompt;
+					return acc;
+				},
+				{} as { [key: string]: string },
+			),
 		};
 
-		if (provider.providerType === 'apple-intelligence') {
+		if (provider.providerType === "apple-intelligence") {
 			lastRequestTime = now;
-			return await sendToAppleIntelligence(systemContent, promptContext, promptContent, promptVariables, model.providerModelId);
+			return await sendToAppleIntelligence(
+				systemContent,
+				promptContext,
+				promptContent,
+				promptVariables,
+				model.providerModelId,
+			);
 		}
 
 		let requestUrl: string;
 		let requestBody: any;
 		let headers: HeadersInit = {
-			'Content-Type': 'application/json',
+			"Content-Type": "application/json",
 		};
 
-		if (provider.name.toLowerCase().includes('hugging')) {
+		if (provider.name.toLowerCase().includes("hugging")) {
 			// Replace {model-id} in baseUrl with the actual model ID
-			requestUrl = provider.baseUrl.replace('{model-id}', model.providerModelId);
+			requestUrl = provider.baseUrl.replace(
+				"{model-id}",
+				model.providerModelId,
+			);
 			requestBody = {
 				model: model.providerModelId,
 				messages: [
-					{ role: 'system', content: systemContent },
-					{ role: 'user', content: `${promptContext}` },
-					{ role: 'user', content: `${JSON.stringify(promptContent)}` }
+					{ role: "system", content: systemContent },
+					{ role: "user", content: `${promptContext}` },
+					{
+						role: "user",
+						content: `${JSON.stringify(promptContent)}`,
+					},
 				],
 				max_tokens: 1600,
-				stream: false
-			};					
+				stream: false,
+			};
 			headers = {
 				...headers,
-				'Authorization': `Bearer ${provider.apiKey}`
+				Authorization: `Bearer ${provider.apiKey}`,
 			};
-		} else if (provider.baseUrl.includes('openai.azure.com')) {
+		} else if (provider.baseUrl.includes("openai.azure.com")) {
 			requestUrl = provider.baseUrl;
 			requestBody = {
 				messages: [
-					{ role: 'system', content: systemContent },
-					{ role: 'user', content: `${promptContext}` },
-					{ role: 'user', content: `${JSON.stringify(promptContent)}` }
+					{ role: "system", content: systemContent },
+					{ role: "user", content: `${promptContext}` },
+					{
+						role: "user",
+						content: `${JSON.stringify(promptContent)}`,
+					},
 				],
 				max_tokens: 1600,
-				stream: false
+				stream: false,
 			};
 			headers = {
 				...headers,
-				'api-key': provider.apiKey
+				"api-key": provider.apiKey,
 			};
-		} else if (provider.name.toLowerCase().includes('anthropic')) {
+		} else if (provider.name.toLowerCase().includes("anthropic")) {
 			requestUrl = provider.baseUrl;
 			requestBody = {
 				model: model.providerModelId,
 				max_tokens: 1600,
 				messages: [
-					{ role: 'user', content: `${promptContext}` },
-					{ role: 'user', content: `${JSON.stringify(promptContent)}` }
+					{ role: "user", content: `${promptContext}` },
+					{
+						role: "user",
+						content: `${JSON.stringify(promptContent)}`,
+					},
 				],
 				temperature: 0.5,
-				system: systemContent
+				system: systemContent,
 			};
 			headers = {
 				...headers,
-				'x-api-key': provider.apiKey,
-				'anthropic-version': '2023-06-01',
-				'anthropic-dangerous-direct-browser-access': 'true'
+				"x-api-key": provider.apiKey,
+				"anthropic-version": "2023-06-01",
+				"anthropic-dangerous-direct-browser-access": "true",
 			};
-		} else if (provider.name.toLowerCase().includes('perplexity')) {
+		} else if (provider.name.toLowerCase().includes("perplexity")) {
 			requestUrl = provider.baseUrl;
 			requestBody = {
 				model: model.providerModelId,
 				max_tokens: 1600,
 				messages: [
-					{ role: 'system', content: systemContent },
-					{ role: 'user', content: `
+					{ role: "system", content: systemContent },
+					{
+						role: "user",
+						content: `
 						"${promptContext}"
-						"${JSON.stringify(promptContent)}"`
-					}
+						"${JSON.stringify(promptContent)}"`,
+					},
 				],
-				temperature: 0.3
+				temperature: 0.3,
 			};
 			headers = {
 				...headers,
-				'HTTP-Referer': 'https://obsidian.md/',
-				'X-Title': 'Obsidian Web Clipper',
-				'Authorization': `Bearer ${provider.apiKey}`
+				"HTTP-Referer": "https://obsidian.md/",
+				"X-Title": "Obsidian Web Clipper",
+				Authorization: `Bearer ${provider.apiKey}`,
 			};
-		} else if (provider.name.toLowerCase().includes('ollama')) {
+		} else if (provider.name.toLowerCase().includes("ollama")) {
 			requestUrl = provider.baseUrl;
 			requestBody = {
 				model: model.providerModelId,
 				messages: [
-					{ role: 'system', content: systemContent },
-					{ role: 'user', content: `${promptContext}` },
-					{ role: 'user', content: `${JSON.stringify(promptContent)}` }
+					{ role: "system", content: systemContent },
+					{ role: "user", content: `${promptContext}` },
+					{
+						role: "user",
+						content: `${JSON.stringify(promptContent)}`,
+					},
 				],
-				format: 'json',
+				format: "json",
 				num_ctx: 120000,
 				temperature: 0.5,
-				stream: false
+				stream: false,
 			};
 		} else {
 			// Default request format
@@ -145,59 +182,71 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 			requestBody = {
 				model: model.providerModelId,
 				messages: [
-					{ role: 'system', content: systemContent },
-					{ role: 'user', content: `${promptContext}` },
-					{ role: 'user', content: `${JSON.stringify(promptContent)}` }
-				]
+					{ role: "system", content: systemContent },
+					{ role: "user", content: `${promptContext}` },
+					{
+						role: "user",
+						content: `${JSON.stringify(promptContent)}`,
+					},
+				],
 			};
 			headers = {
 				...headers,
-				'HTTP-Referer': 'https://obsidian.md/',
-				'X-Title': 'Obsidian Web Clipper',
-				'Authorization': `Bearer ${provider.apiKey}`
+				"HTTP-Referer": "https://obsidian.md/",
+				"X-Title": "Obsidian Web Clipper",
+				Authorization: `Bearer ${provider.apiKey}`,
 			};
 		}
 
-		debugLog('Interpreter', `Sending request to ${provider.name} API:`, requestBody);
+		debugLog(
+			"Interpreter",
+			`Sending request to ${provider.name} API:`,
+			requestBody,
+		);
 
 		const response = await fetch(requestUrl, {
-			method: 'POST',
+			method: "POST",
 			headers: headers,
-			body: JSON.stringify(requestBody)
+			body: JSON.stringify(requestBody),
 		});
 
 		if (!response.ok) {
 			const errorText = await response.text();
 			console.error(`${provider.name} error response:`, errorText);
-			
+
 			// Add specific message for Ollama 403 errors
-			if (provider.name.toLowerCase().includes('ollama') && response.status === 403) {
+			if (
+				provider.name.toLowerCase().includes("ollama") &&
+				response.status === 403
+			) {
 				throw new Error(
 					`Ollama cannot process requests originating from a browser extension without setting OLLAMA_ORIGINS. ` +
-					`See instructions at https://help.obsidian.md/web-clipper/interpreter`
+						`See instructions at https://help.obsidian.md/web-clipper/interpreter`,
 				);
 			}
-			
-			throw new Error(`${provider.name} error: ${response.statusText} ${errorText}`);
+
+			throw new Error(
+				`${provider.name} error: ${response.statusText} ${errorText}`,
+			);
 		}
 
 		const responseText = await response.text();
-		debugLog('Interpreter', `Raw ${provider.name} response:`, responseText);
+		debugLog("Interpreter", `Raw ${provider.name} response:`, responseText);
 
 		let data;
 		try {
 			data = JSON.parse(responseText);
 		} catch (error) {
-			console.error('Error parsing JSON response:', error);
+			console.error("Error parsing JSON response:", error);
 			throw new Error(`Failed to parse response from ${provider.name}`);
 		}
 
-		debugLog('Interpreter', `Parsed ${provider.name} response:`, data);
+		debugLog("Interpreter", `Parsed ${provider.name} response:`, data);
 
 		lastRequestTime = now;
 
 		let llmResponseContent: string;
-		if (provider.name.toLowerCase().includes('anthropic')) {
+		if (provider.name.toLowerCase().includes("anthropic")) {
 			// Handle Anthropic's nested content structure
 			const textContent = data.content[0]?.text;
 			if (textContent) {
@@ -212,7 +261,7 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 			} else {
 				llmResponseContent = JSON.stringify(data);
 			}
-		} else if (provider.name.toLowerCase().includes('ollama')) {
+		} else if (provider.name.toLowerCase().includes("ollama")) {
 			const messageContent = data.message?.content;
 			if (messageContent) {
 				try {
@@ -225,9 +274,10 @@ export async function sendToLLM(promptContext: string, content: string, promptVa
 				llmResponseContent = JSON.stringify(data);
 			}
 		} else {
-			llmResponseContent = data.choices[0]?.message?.content || JSON.stringify(data);
+			llmResponseContent =
+				data.choices[0]?.message?.content || JSON.stringify(data);
 		}
-		debugLog('Interpreter', 'Processed LLM response:', llmResponseContent);
+		debugLog("Interpreter", "Processed LLM response:", llmResponseContent);
 
 		return parseLLMResponse(llmResponseContent, promptVariables);
 	} catch (error) {
@@ -241,63 +291,94 @@ async function sendToAppleIntelligence(
 	promptContext: string,
 	promptContent: { prompts: Record<string, string> },
 	promptVariables: PromptVariable[],
-	modelId: string
+	modelId: string,
 ): Promise<{ promptResponses: any[] }> {
-	if (typeof (browser.runtime as any).sendNativeMessage !== 'function') {
+	if (typeof (browser.runtime as any).sendNativeMessage !== "function") {
 		throw new Error(
-			'Apple Intelligence requires Safari on a Mac or iPhone. ' +
-			'Please switch to Safari or choose a different model.'
+			"Apple Intelligence requires Safari on a Mac or iPhone. " +
+				"Please switch to Safari or choose a different model.",
 		);
 	}
 
-	const result = await browser.runtime.sendMessage({
-		action: 'appleIntelligencePrompt',
+	const result = (await browser.runtime.sendMessage({
+		action: "appleIntelligencePrompt",
 		systemPrompt: systemContent,
 		userMessage: `${promptContext}\n\n${JSON.stringify(promptContent)}`,
 		model: modelId,
-	}) as { success: boolean; content?: string; error?: string; reason?: string; quotaWarning?: boolean };
+	})) as {
+		success: boolean;
+		content?: string;
+		error?: string;
+		reason?: string;
+		quotaWarning?: boolean;
+	};
 
 	if (!result.success) {
 		const { reason, error } = result;
-		if (reason === 'appleIntelligenceNotEnabled') {
-			throw new Error('Apple Intelligence is not enabled on this device. Go to Settings → Apple Intelligence & Siri to enable it.');
+		if (reason === "appleIntelligenceNotEnabled") {
+			throw new Error(
+				"Apple Intelligence is not enabled on this device. Go to Settings → Apple Intelligence & Siri to enable it.",
+			);
 		}
-		if (reason === 'deviceNotEligible') {
-			throw new Error('This device does not support Apple Intelligence.');
+		if (reason === "deviceNotEligible") {
+			throw new Error("This device does not support Apple Intelligence.");
 		}
-		if (reason === 'osVersionTooOld') {
-			throw new Error('Apple Intelligence requires macOS 26 or iOS 26 or later.');
+		if (reason === "osVersionTooOld") {
+			throw new Error(
+				"Apple Intelligence requires macOS 26 or iOS 26 or later.",
+			);
 		}
-		if (reason === 'pccRequiresNewerOS') {
-			throw new Error('Private Cloud Compute requires macOS 27 or iOS 27 or later.');
+		if (reason === "pccRequiresNewerOS") {
+			throw new Error(
+				"Private Cloud Compute requires macOS 27 or iOS 27 or later.",
+			);
 		}
-		if (reason === 'pccNotYetImplemented') {
-			throw new Error('Private Cloud Compute support is not yet available in this version.');
+		if (reason === "pccNotYetImplemented") {
+			throw new Error(
+				"Private Cloud Compute support is not yet available in this version.",
+			);
 		}
-		if (error === 'quotaExceeded') {
-			throw new Error('You have reached your Private Cloud Compute daily limit.');
+		if (error === "quotaExceeded") {
+			throw new Error(
+				"You have reached your Private Cloud Compute daily limit.",
+			);
 		}
-		if (error === 'contextWindowExceeded') {
-			throw new Error('The prompt context is too long for this model\'s context window. In interpreter settings, set the template\'s Context field to {{content}} to send only the clipped text instead of the full page, or choose a model with a larger context window.');
+		if (error === "contextWindowExceeded") {
+			throw new Error(
+				"The prompt context is too long for this model's context window. In interpreter settings, set the template's Context field to {{content}} to send only the clipped text instead of the full page, or choose a model with a larger context window.",
+			);
 		}
-		if (error === 'guardrailsViolation') {
-			throw new Error('Apple Intelligence declined to process this content.');
+		if (error === "guardrailsViolation") {
+			throw new Error(
+				"Apple Intelligence declined to process this content.",
+			);
 		}
-		if (error === 'refusal') {
-			throw new Error('Apple Intelligence declined to answer this prompt.');
+		if (error === "refusal") {
+			throw new Error(
+				"Apple Intelligence declined to answer this prompt.",
+			);
 		}
-		if (error === 'rateLimited') {
-			throw new Error('Apple Intelligence is rate limited. Please wait a moment and try again.');
+		if (error === "rateLimited") {
+			throw new Error(
+				"Apple Intelligence is rate limited. Please wait a moment and try again.",
+			);
 		}
-		if (error === 'languageModelError') {
+		if (error === "languageModelError") {
 			const detail = (result as any).detail;
-			throw new Error(`Apple Intelligence model error${detail ? `: ${detail}` : '.'}`);
+			throw new Error(
+				`Apple Intelligence model error${detail ? `: ${detail}` : "."}`,
+			);
 		}
-		throw new Error(`Apple Intelligence error: ${error ?? 'Unknown error'}`);
+		throw new Error(
+			`Apple Intelligence error: ${error ?? "Unknown error"}`,
+		);
 	}
 
 	if (result.quotaWarning) {
-		debugLog('Interpreter', 'Apple Intelligence: Private Cloud Compute quota is approaching its daily limit.');
+		debugLog(
+			"Interpreter",
+			"Apple Intelligence: Private Compute Cloud quota is approaching its daily limit.",
+		);
 	}
 
 	return parseLLMResponse(result.content!, promptVariables);
@@ -307,88 +388,101 @@ interface LLMResponse {
 	prompts_responses: { [key: string]: string };
 }
 
-function parseLLMResponse(responseContent: string, promptVariables: PromptVariable[]): { promptResponses: any[] } {
+function parseLLMResponse(
+	responseContent: string,
+	promptVariables: PromptVariable[],
+): { promptResponses: any[] } {
 	try {
 		let parsedResponse: LLMResponse;
-		
+
 		// If responseContent is already an object, convert to string
-		if (typeof responseContent === 'object') {
+		if (typeof responseContent === "object") {
 			responseContent = JSON.stringify(responseContent);
 		}
 
 		// Helper function to sanitize JSON string
 		const sanitizeJsonString = (str: string) => {
 			// First, normalize all newlines to \n
-			let result = str.replace(/\r\n/g, '\n');
-			
+			let result = str.replace(/\r\n/g, "\n");
+
 			// Escape newlines properly
-			result = result.replace(/\n/g, '\\n');
-			
+			result = result.replace(/\n/g, "\\n");
+
 			// Escape quotes that are part of the content
 			result = result.replace(/(?<!\\)"/g, '\\"');
-			
+
 			// Then unescape the quotes that are JSON structural elements
-			result = result.replace(/(?<=[{[,:]\s*)\\"/g, '"')
+			result = result
+				.replace(/(?<=[{[,:]\s*)\\"/g, '"')
 				.replace(/\\"(?=\s*[}\],:}])/g, '"');
-			
-			return result
-				// Replace curly quotes
-				.replace(/[""]/g, '\\"')
-				// Remove any bad control characters
-				.replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, '')
-				// Remove any whitespace between quotes and colons
-				.replace(/"\s*:/g, '":')
-				.replace(/:\s*"/g, ':"')
-				// Fix any triple or more backslashes
-				.replace(/\\{3,}/g, '\\\\');
+
+			return (
+				result
+					// Replace curly quotes
+					.replace(/[""]/g, '\\"')
+					// Remove any bad control characters
+					.replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "")
+					// Remove any whitespace between quotes and colons
+					.replace(/"\s*:/g, '":')
+					.replace(/:\s*"/g, ':"')
+					// Fix any triple or more backslashes
+					.replace(/\\{3,}/g, "\\\\")
+			);
 		};
 
 		// First try to parse the content directly
 		try {
 			const sanitizedContent = sanitizeJsonString(responseContent);
-			debugLog('Interpreter', 'Sanitized content:', sanitizedContent);
+			debugLog("Interpreter", "Sanitized content:", sanitizedContent);
 			parsedResponse = JSON.parse(sanitizedContent);
 		} catch (e) {
 			// If direct parsing fails, try to extract and parse the JSON content
 			const jsonMatch = responseContent.match(/\{[\s\S]*\}/);
 			if (!jsonMatch) {
-				throw new Error('No JSON object found in response');
+				throw new Error("No JSON object found in response");
 			}
 
 			// Try parsing with minimal sanitization first
 			try {
 				const minimalSanitized = jsonMatch[0]
 					.replace(/[""]/g, '"')
-					.replace(/\r\n/g, '\\n')
-					.replace(/\n/g, '\\n');
+					.replace(/\r\n/g, "\\n")
+					.replace(/\n/g, "\\n");
 				parsedResponse = JSON.parse(minimalSanitized);
 			} catch (minimalError) {
 				// If minimal sanitization fails, try full sanitization
 				const sanitizedMatch = sanitizeJsonString(jsonMatch[0]);
-				debugLog('Interpreter', 'Fully sanitized match:', sanitizedMatch);
-				
+				debugLog(
+					"Interpreter",
+					"Fully sanitized match:",
+					sanitizedMatch,
+				);
+
 				try {
 					parsedResponse = JSON.parse(sanitizedMatch);
 				} catch (fullError) {
 					// Last resort: try to manually rebuild the JSON structure
 					const prompts_responses: { [key: string]: string } = {};
-					
+
 					// Extract each prompt response separately
 					promptVariables.forEach((variable, index) => {
 						const promptKey = `prompt_${index + 1}`;
-						const promptRegex = new RegExp(`"${promptKey}"\\s*:\\s*"([^]*?)(?:"\\s*,|"\\s*})`, 'g');
+						const promptRegex = new RegExp(
+							`"${promptKey}"\\s*:\\s*"([^]*?)(?:"\\s*,|"\\s*})`,
+							"g",
+						);
 						const match = promptRegex.exec(jsonMatch[0]);
 						if (match) {
 							let content = match[1]
 								.replace(/"/g, '\\"')
-								.replace(/\r\n/g, '\\n')
-								.replace(/\n/g, '\\n');
+								.replace(/\r\n/g, "\\n")
+								.replace(/\n/g, "\\n");
 							prompts_responses[promptKey] = content;
 						}
 					});
 
 					const rebuiltJson = JSON.stringify({ prompts_responses });
-					debugLog('Interpreter', 'Rebuilt JSON:', rebuiltJson);
+					debugLog("Interpreter", "Rebuilt JSON:", rebuiltJson);
 					parsedResponse = JSON.parse(rebuiltJson);
 				}
 			}
@@ -396,39 +490,50 @@ function parseLLMResponse(responseContent: string, promptVariables: PromptVariab
 
 		// Validate the response structure
 		if (!parsedResponse?.prompts_responses) {
-			debugLog('Interpreter', 'No prompts_responses found in parsed response', parsedResponse);
+			debugLog(
+				"Interpreter",
+				"No prompts_responses found in parsed response",
+				parsedResponse,
+			);
 			return { promptResponses: [] };
 		}
 
 		// Convert escaped newlines to actual newlines in the responses
-		Object.keys(parsedResponse.prompts_responses).forEach(key => {
-			if (typeof parsedResponse.prompts_responses[key] === 'string') {
-				parsedResponse.prompts_responses[key] = parsedResponse.prompts_responses[key]
-					.replace(/\\n/g, '\n')
-					.replace(/\r/g, '');
+		Object.keys(parsedResponse.prompts_responses).forEach((key) => {
+			if (typeof parsedResponse.prompts_responses[key] === "string") {
+				parsedResponse.prompts_responses[key] =
+					parsedResponse.prompts_responses[key]
+						.replace(/\\n/g, "\n")
+						.replace(/\r/g, "");
 			}
 		});
 
 		// Map the responses to their prompts
-		const promptResponses = promptVariables.map(variable => ({
+		const promptResponses = promptVariables.map((variable) => ({
 			key: variable.key,
 			prompt: variable.prompt,
-			user_response: parsedResponse.prompts_responses[variable.key] || ''
+			user_response: parsedResponse.prompts_responses[variable.key] || "",
 		}));
 
-		debugLog('Interpreter', 'Successfully mapped prompt responses:', promptResponses);
+		debugLog(
+			"Interpreter",
+			"Successfully mapped prompt responses:",
+			promptResponses,
+		);
 		return { promptResponses };
 	} catch (parseError) {
-		console.error('Failed to parse LLM response:', parseError);
-		debugLog('Interpreter', 'Parse error details:', {
+		console.error("Failed to parse LLM response:", parseError);
+		debugLog("Interpreter", "Parse error details:", {
 			error: parseError,
-			responseContent: responseContent
+			responseContent: responseContent,
 		});
 		return { promptResponses: [] };
 	}
 }
 
-export function collectPromptVariables(template: Template | null): PromptVariable[] {
+export function collectPromptVariables(
+	template: Template | null,
+): PromptVariable[] {
 	const promptMap = new Map<string, PromptVariable>();
 	const promptRegex = /{{(?:prompt:)?"([\s\S]*?)"(\|.*?)?}}/g;
 	let match;
@@ -441,8 +546,10 @@ export function collectPromptVariables(template: Template | null): PromptVariabl
 	}
 
 	if (template?.noteContentFormat) {
-		while ((match = promptRegex.exec(template.noteContentFormat)) !== null) {
-			addPrompt(match[1], match[2] || '');
+		while (
+			(match = promptRegex.exec(template.noteContentFormat)) !== null
+		) {
+			addPrompt(match[1], match[2] || "");
 		}
 	}
 
@@ -450,17 +557,20 @@ export function collectPromptVariables(template: Template | null): PromptVariabl
 		for (const property of template.properties) {
 			let propertyValue = property.value;
 			while ((match = promptRegex.exec(propertyValue)) !== null) {
-				addPrompt(match[1], match[2] || '');
+				addPrompt(match[1], match[2] || "");
 			}
 		}
 	}
 
-	const allInputs = document.querySelectorAll('input, textarea');
+	const allInputs = document.querySelectorAll("input, textarea");
 	allInputs.forEach((input) => {
-		if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+		if (
+			input instanceof HTMLInputElement ||
+			input instanceof HTMLTextAreaElement
+		) {
 			let inputValue = input.value;
 			while ((match = promptRegex.exec(inputValue)) !== null) {
-				addPrompt(match[1], match[2] || '');
+				addPrompt(match[1], match[2] || "");
 			}
 		}
 	});
@@ -468,11 +578,20 @@ export function collectPromptVariables(template: Template | null): PromptVariabl
 	return Array.from(promptMap.values());
 }
 
-export async function initializeInterpreter(template: Template, variables: { [key: string]: string }, tabId: number, currentUrl: string) {
-	const interpreterContainer = document.getElementById('interpreter');
-	const interpretBtn = document.getElementById('interpret-btn');
-	const promptContextTextarea = document.getElementById('prompt-context') as HTMLTextAreaElement;
-	const modelSelect = document.getElementById('model-select') as HTMLSelectElement;
+export async function initializeInterpreter(
+	template: Template,
+	variables: { [key: string]: string },
+	tabId: number,
+	currentUrl: string,
+) {
+	const interpreterContainer = document.getElementById("interpreter");
+	const interpretBtn = document.getElementById("interpret-btn");
+	const promptContextTextarea = document.getElementById(
+		"prompt-context",
+	) as HTMLTextAreaElement;
+	const modelSelect = document.getElementById(
+		"model-select",
+	) as HTMLSelectElement;
 
 	function removeOldListeners(element: HTMLElement, eventType: string) {
 		const listeners = eventListeners.get(element);
@@ -481,7 +600,11 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 		}
 	}
 
-	function storeListener(element: HTMLElement, eventType: string, listener: EventListener) {
+	function storeListener(
+		element: HTMLElement,
+		eventType: string,
+		listener: EventListener,
+	) {
 		let listeners = eventListeners.get(element);
 		if (!listeners) {
 			listeners = {};
@@ -496,33 +619,38 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 
 	// Hide interpreter if it's disabled or there are no prompt variables
 	if (!generalSettings.interpreterEnabled || promptVariables.length === 0) {
-		if (interpreterContainer) interpreterContainer.style.display = 'none';
-		if (interpretBtn) interpretBtn.style.display = 'none';
+		if (interpreterContainer) interpreterContainer.style.display = "none";
+		if (interpretBtn) interpretBtn.style.display = "none";
 		return;
 	}
 
-	if (interpreterContainer) interpreterContainer.style.display = 'flex';
-	if (interpretBtn) interpretBtn.style.display = 'inline-block';
-	
+	if (interpreterContainer) interpreterContainer.style.display = "flex";
+	if (interpretBtn) interpretBtn.style.display = "inline-block";
+
 	if (promptContextTextarea) {
-		const tokenCounter = document.getElementById('token-counter');
-		
+		const tokenCounter = document.getElementById("token-counter");
+
 		const inputListener = () => {
 			template.context = promptContextTextarea.value;
 			if (tokenCounter) {
 				updateTokenCount(promptContextTextarea.value, tokenCounter);
 			}
 		};
-		
-		storeListener(promptContextTextarea, 'input', inputListener);
+
+		storeListener(promptContextTextarea, "input", inputListener);
 
 		let promptToDisplay =
-			template.context
-			|| generalSettings.defaultPromptContext
-			|| '{{fullHtml|remove_html:("#navbar,.footer,#footer,header,footer,style,script")|strip_tags:("script,h1,h2,h3,h4,h5,h6,meta,a,ol,ul,li,p,em,strong,i,b,s,strike,u,sup,sub,img,video,audio,math,table,cite,td,th,tr,caption")|strip_attr:("alt,src,href,id,content,property,name,datetime,title")}}';
-		promptToDisplay = await compileTemplate(tabId, promptToDisplay, variables, currentUrl);
+			template.context ||
+			generalSettings.defaultPromptContext ||
+			'{{fullHtml|remove_html:("#navbar,.footer,#footer,header,footer,style,script")|strip_tags:("script,h1,h2,h3,h4,h5,h6,meta,a,ol,ul,li,p,em,strong,i,b,s,strike,u,sup,sub,img,video,audio,math,table,cite,td,th,tr,caption")|strip_attr:("alt,src,href,id,content,property,name,datetime,title")}}';
+		promptToDisplay = await compileTemplate(
+			tabId,
+			promptToDisplay,
+			variables,
+			currentUrl,
+		);
 		promptContextTextarea.value = promptToDisplay;
-		
+
 		// Initial token count
 		if (tokenCounter) {
 			updateTokenCount(promptContextTextarea.value, tokenCounter);
@@ -534,13 +662,23 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 		if (interpretBtn && !generalSettings.interpreterAutoRun) {
 			const clickListener = async () => {
 				const selectedModelId = modelSelect.value;
-				const modelConfig = generalSettings.models.find(m => m.id === selectedModelId);
+				const modelConfig = generalSettings.models.find(
+					(m) => m.id === selectedModelId,
+				);
 				if (!modelConfig) {
-					throw new Error(`Model configuration not found for ${selectedModelId}`);
+					throw new Error(
+						`Model configuration not found for ${selectedModelId}`,
+					);
 				}
-				await handleInterpreterUI(template, variables, tabId, currentUrl, modelConfig);
+				await handleInterpreterUI(
+					template,
+					variables,
+					tabId,
+					currentUrl,
+					modelConfig,
+				);
 			};
-			storeListener(interpretBtn, 'click', clickListener);
+			storeListener(interpretBtn, "click", clickListener);
 		}
 
 		if (modelSelect) {
@@ -548,26 +686,34 @@ export async function initializeInterpreter(template: Template, variables: { [ke
 				generalSettings.interpreterModel = modelSelect.value;
 				await saveSettings();
 			};
-			storeListener(modelSelect, 'change', changeListener);
+			storeListener(modelSelect, "change", changeListener);
 
-			modelSelect.style.display = 'inline-block';
+			modelSelect.style.display = "inline-block";
 
 			// Only repopulate if the skeleton hasn't already done it
 			if (modelSelect.options.length === 0) {
-				const enabledModels = generalSettings.models.filter(model => model.enabled);
-				modelSelect.textContent = '';
-				enabledModels.forEach(model => {
-					const option = document.createElement('option');
+				const enabledModels = generalSettings.models.filter(
+					(model) => model.enabled,
+				);
+				modelSelect.textContent = "";
+				enabledModels.forEach((model) => {
+					const option = document.createElement("option");
 					option.value = model.id;
 					option.textContent = model.name;
 					modelSelect.appendChild(option);
 				});
-				modelSelect.value = generalSettings.interpreterModel || (enabledModels[0]?.id ?? '');
+				modelSelect.value =
+					generalSettings.interpreterModel ||
+					(enabledModels[0]?.id ?? "");
 			}
 
 			// Validate that the selected model is still enabled
-			const enabledModels = generalSettings.models.filter(model => model.enabled);
-			const lastSelectedModel = enabledModels.find(model => model.id === generalSettings.interpreterModel);
+			const enabledModels = generalSettings.models.filter(
+				(model) => model.enabled,
+			);
+			const lastSelectedModel = enabledModels.find(
+				(model) => model.id === generalSettings.interpreterModel,
+			);
 
 			if (!lastSelectedModel && enabledModels.length > 0) {
 				generalSettings.interpreterModel = enabledModels[0].id;
@@ -583,26 +729,36 @@ export async function handleInterpreterUI(
 	variables: { [key: string]: string },
 	tabId: number,
 	currentUrl: string,
-	modelConfig: ModelConfig
+	modelConfig: ModelConfig,
 ): Promise<void> {
-	const interpreterContainer = document.getElementById('interpreter');
-	const interpretBtn = document.getElementById('interpret-btn') as HTMLButtonElement;
-	const interpreterErrorMessage = document.getElementById('interpreter-error') as HTMLDivElement;
-	const responseTimer = document.getElementById('interpreter-timer') as HTMLSpanElement;
-	const clipButton = document.getElementById('clip-btn') as HTMLButtonElement;
-	const moreButton = document.getElementById('more-btn') as HTMLButtonElement;
-	const promptContextTextarea = document.getElementById('prompt-context') as HTMLTextAreaElement;
+	const interpreterContainer = document.getElementById("interpreter");
+	const interpretBtn = document.getElementById(
+		"interpret-btn",
+	) as HTMLButtonElement;
+	const interpreterErrorMessage = document.getElementById(
+		"interpreter-error",
+	) as HTMLDivElement;
+	const responseTimer = document.getElementById(
+		"interpreter-timer",
+	) as HTMLSpanElement;
+	const clipButton = document.getElementById("clip-btn") as HTMLButtonElement;
+	const moreButton = document.getElementById("more-btn") as HTMLButtonElement;
+	const promptContextTextarea = document.getElementById(
+		"prompt-context",
+	) as HTMLTextAreaElement;
 
 	try {
 		// Hide any previous error message
-		interpreterErrorMessage.style.display = 'none';
-		interpreterErrorMessage.textContent = '';
+		interpreterErrorMessage.style.display = "none";
+		interpreterErrorMessage.textContent = "";
 
 		// Remove any previous done or error classes
-		interpreterContainer?.classList.remove('done', 'error');
+		interpreterContainer?.classList.remove("done", "error");
 
 		// Find the provider for this model
-		const provider = generalSettings.providers.find(p => p.id === modelConfig.providerId);
+		const provider = generalSettings.providers.find(
+			(p) => p.id === modelConfig.providerId,
+		);
 		if (!provider) {
 			throw new Error(`Provider not found for model ${modelConfig.name}`);
 		}
@@ -615,27 +771,29 @@ export async function handleInterpreterUI(
 		const promptVariables = collectPromptVariables(template);
 
 		if (promptVariables.length === 0) {
-			throw new Error('No prompt variables found. Please add at least one prompt variable to your template.');
+			throw new Error(
+				"No prompt variables found. Please add at least one prompt variable to your template.",
+			);
 		}
 
 		const contextToUse = promptContextTextarea.value;
-		const contentToProcess = variables.content || '';
+		const contentToProcess = variables.content || "";
 
 		// Start the timer
 		const startTime = performance.now();
 		let timerInterval: number;
 
 		// Change button text and add class
-		interpretBtn.textContent = getMessage('thinking');
-		interpretBtn.classList.add('processing');
+		interpretBtn.textContent = getMessage("thinking");
+		interpretBtn.classList.add("processing");
 
 		// Disable the clip button
 		clipButton.disabled = true;
 		moreButton.disabled = true;
 
 		// Show and update the timer
-		responseTimer.style.display = 'inline';
-		responseTimer.textContent = '0ms';
+		responseTimer.style.display = "inline";
+		responseTimer.textContent = "0ms";
 
 		// Update the timer text with elapsed time
 		timerInterval = window.setInterval(() => {
@@ -643,8 +801,13 @@ export async function handleInterpreterUI(
 			responseTimer.textContent = formatDuration(elapsedTime);
 		}, 10);
 
-		const { promptResponses } = await sendToLLM(contextToUse, contentToProcess, promptVariables, modelConfig);
-		debugLog('Interpreter', 'LLM response:', { promptResponses });
+		const { promptResponses } = await sendToLLM(
+			contextToUse,
+			contentToProcess,
+			promptVariables,
+			modelConfig,
+		);
+		debugLog("Interpreter", "LLM response:", { promptResponses });
 
 		// Stop the timer and update UI
 		clearInterval(timerInterval);
@@ -653,14 +816,14 @@ export async function handleInterpreterUI(
 		responseTimer.textContent = formatDuration(totalTime);
 
 		// Update button state
-		interpretBtn.textContent = getMessage('done').toLowerCase();
-		interpretBtn.classList.remove('processing');
-		interpretBtn.classList.add('done');
+		interpretBtn.textContent = getMessage("done").toLowerCase();
+		interpretBtn.classList.remove("processing");
+		interpretBtn.classList.add("done");
 		interpretBtn.disabled = true;
 
 		// Add done class to container
-		interpreterContainer?.classList.add('done');
-		
+		interpreterContainer?.classList.add("done");
+
 		// Update fields with responses
 		replacePromptVariables(promptVariables, promptResponses);
 
@@ -669,29 +832,33 @@ export async function handleInterpreterUI(
 		moreButton.disabled = false;
 
 		// Adjust height for noteNameField after content is replaced
-		const noteNameField = document.getElementById('note-name-field') as HTMLTextAreaElement | null;
+		const noteNameField = document.getElementById(
+			"note-name-field",
+		) as HTMLTextAreaElement | null;
 		if (noteNameField instanceof HTMLTextAreaElement) {
 			adjustNoteNameHeight(noteNameField);
 		}
-
 	} catch (error) {
-		console.error('Error processing LLM:', error);
-		
+		console.error("Error processing LLM:", error);
+
 		// Revert button text and remove class in case of error
-		interpretBtn.textContent = getMessage('error');
-		interpretBtn.classList.remove('processing');
-		interpretBtn.classList.add('error');
+		interpretBtn.textContent = getMessage("error");
+		interpretBtn.classList.remove("processing");
+		interpretBtn.classList.add("error");
 		interpretBtn.disabled = true;
 
 		// Add error class to interpreter container
-		interpreterContainer?.classList.add('error');
+		interpreterContainer?.classList.add("error");
 
 		// Hide the timer
-		responseTimer.style.display = 'none';
+		responseTimer.style.display = "none";
 
 		// Display the error message
-		interpreterErrorMessage.textContent = error instanceof Error ? error.message : 'An unknown error occurred while processing the interpreter request.';
-		interpreterErrorMessage.style.display = 'block';
+		interpreterErrorMessage.textContent =
+			error instanceof Error
+				? error.message
+				: "An unknown error occurred while processing the interpreter request.";
+		interpreterErrorMessage.style.display = "block";
 
 		// Re-enable the clip button
 		clipButton.disabled = false;
@@ -700,45 +867,66 @@ export async function handleInterpreterUI(
 		if (error instanceof Error) {
 			throw new Error(`${error.message}`);
 		} else {
-			throw new Error('An unknown error occurred while processing the interpreter request.');
+			throw new Error(
+				"An unknown error occurred while processing the interpreter request.",
+			);
 		}
 	}
 }
 
 // Similar to replaceVariables, but happens after the LLM response is received
-export function replacePromptVariables(promptVariables: PromptVariable[], promptResponses: any[]) {
-	const allInputs = document.querySelectorAll('input, textarea');
+export function replacePromptVariables(
+	promptVariables: PromptVariable[],
+	promptResponses: any[],
+) {
+	const allInputs = document.querySelectorAll("input, textarea");
 	allInputs.forEach((input) => {
-		if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
-			input.value = input.value.replace(/{{(?:prompt:)?"([\s\S]*?)"(\|[\s\S]*?)?}}/g, (match, promptText, filters) => {
-				const variable = promptVariables.find(v => v.prompt === promptText);
-				if (!variable) return match;
+		if (
+			input instanceof HTMLInputElement ||
+			input instanceof HTMLTextAreaElement
+		) {
+			input.value = input.value.replace(
+				/{{(?:prompt:)?"([\s\S]*?)"(\|[\s\S]*?)?}}/g,
+				(match, promptText, filters) => {
+					const variable = promptVariables.find(
+						(v) => v.prompt === promptText,
+					);
+					if (!variable) return match;
 
-				const response = promptResponses.find(r => r.key === variable.key);
-				if (response && response.user_response !== undefined) {
-					let value = response.user_response;
-					
-					// Handle array or object responses
-					if (typeof value === 'object') {
-						try {
-							value = JSON.stringify(value, null, 2);
-						} catch (error) {
-							console.error('Error stringifying object:', error);
-							value = String(value);
+					const response = promptResponses.find(
+						(r) => r.key === variable.key,
+					);
+					if (response && response.user_response !== undefined) {
+						let value = response.user_response;
+
+						// Handle array or object responses
+						if (typeof value === "object") {
+							try {
+								value = JSON.stringify(value, null, 2);
+							} catch (error) {
+								console.error(
+									"Error stringifying object:",
+									error,
+								);
+								value = String(value);
+							}
 						}
-					}
 
-					if (filters) {
-						value = applyFilters(value, filters.slice(1));
+						if (filters) {
+							value = applyFilters(value, filters.slice(1));
+						}
+
+						return value;
 					}
-					
-					return value;
-				}
-				return match; // Return original if no match found
-			});
+					return match; // Return original if no match found
+				},
+			);
 
 			// Adjust height for noteNameField after updating its value
-			if (input.id === 'note-name-field' && input instanceof HTMLTextAreaElement) {
+			if (
+				input.id === "note-name-field" &&
+				input instanceof HTMLTextAreaElement
+			) {
 				adjustNoteNameHeight(input);
 			}
 		}

--- a/src/utils/interpreter.ts
+++ b/src/utils/interpreter.ts
@@ -283,6 +283,12 @@ async function sendToAppleIntelligence(
 		if (error === 'guardrailsViolation') {
 			throw new Error('Apple Intelligence declined to process this content.');
 		}
+		if (error === 'refusal') {
+			throw new Error('Apple Intelligence declined to answer this prompt.');
+		}
+		if (error === 'rateLimited') {
+			throw new Error('Apple Intelligence is rate limited. Please wait a moment and try again.');
+		}
 		if (error === 'languageModelError') {
 			const detail = (result as any).detail;
 			throw new Error(`Apple Intelligence model error${detail ? `: ${detail}` : '.'}`);

--- a/xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj/xcshareddata/xcschemes/Obsidian Web Clipper (iOS).xcscheme
+++ b/xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj/xcshareddata/xcschemes/Obsidian Web Clipper (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj/xcshareddata/xcschemes/Obsidian Web Clipper (macOS).xcscheme
+++ b/xcode/Obsidian Web Clipper/Obsidian Web Clipper.xcodeproj/xcshareddata/xcschemes/Obsidian Web Clipper (macOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/xcode/Obsidian Web Clipper/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/xcode/Obsidian Web Clipper/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import SafariServices
+import FoundationModels
 import os.log
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
@@ -38,6 +39,14 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         switch type {
         case "fetchRequest":
             handleFetchRequest(context: context, message: messageDict)
+        case "appleIntelligencePrompt":
+            if #available(iOS 26.0, macOS 26.0, *) {
+                handleAppleIntelligencePrompt(context: context, message: messageDict)
+            } else {
+                sendResponse(context: context, data: [
+                    "success": false, "error": "unavailable", "reason": "osVersionTooOld"
+                ])
+            }
         default:
             // Echo back for any other message type (original behavior)
             sendResponse(context: context, data: ["echo": message as Any])
@@ -88,6 +97,88 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         semaphore.wait()
 
         sendResponse(context: context, data: responseData)
+    }
+
+    @available(iOS 26.0, macOS 26.0, *)
+    private func handleAppleIntelligencePrompt(context: NSExtensionContext, message: [String: Any]) {
+        guard let systemPrompt = message["systemPrompt"] as? String,
+              let userMessage = message["userMessage"] as? String else {
+            sendResponse(context: context, data: ["success": false, "error": "Invalid parameters"])
+            return
+        }
+
+        let modelId = message["model"] as? String ?? "on-device"
+
+        if modelId == "private-cloud" {
+            if #available(iOS 27.0, macOS 27.0, *) {
+                handleWithPCC(context: context, systemPrompt: systemPrompt, userMessage: userMessage)
+            } else {
+                sendResponse(context: context, data: [
+                    "success": false, "error": "unavailable", "reason": "pccRequiresNewerOS"
+                ])
+            }
+            return
+        }
+
+        if case .unavailable(let reason) = SystemLanguageModel.default.availability {
+            let reasonString: String
+            switch reason {
+            case .deviceNotEligible:           reasonString = "deviceNotEligible"
+            case .appleIntelligenceNotEnabled: reasonString = "appleIntelligenceNotEnabled"
+            default:                           reasonString = "unknown"
+            }
+            sendResponse(context: context, data: [
+                "success": false, "error": "unavailable", "reason": reasonString
+            ])
+            return
+        }
+
+        // Bridge async FoundationModels call to synchronous extension context,
+        // matching the pattern used in handleFetchRequest.
+        let semaphore = DispatchSemaphore(value: 0)
+        var responseData: [String: Any] = ["success": false, "error": "Timeout"]
+
+        Task {
+            do {
+                let session = LanguageModelSession(instructions: systemPrompt)
+                let response = try await session.respond(to: userMessage)
+                responseData = ["success": true, "content": response.content]
+            } catch {
+                // Map known FoundationModels error patterns to stable codes the JS side can handle.
+                // TODO: LanguageModelError is only available in macOS 27 / iOS 27+.
+                // Once minimum deployment target is raised, replace with typed case matching.
+                let desc = error.localizedDescription.lowercased()
+                let code: String
+                if desc.contains("context") || desc.contains("too long") || desc.contains("token") {
+                    code = "contextWindowExceeded"
+                } else if desc.contains("guardrail") || desc.contains("policy") {
+                    code = "guardrailsViolation"
+                } else {
+                    code = "languageModelError"
+                }
+                responseData = ["success": false, "error": code, "detail": error.localizedDescription]
+            }
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        sendResponse(context: context, data: responseData)
+    }
+
+    @available(iOS 27.0, macOS 27.0, *)
+    private func handleWithPCC(context: NSExtensionContext, systemPrompt: String, userMessage: String) {
+        // TODO: PrivateCloudComputeLanguageModel is not available in the macOS 26 SDK.
+        // Replace this stub with the full implementation once the macOS 27 SDK ships:
+        //
+        //   let model = PrivateCloudComputeLanguageModel()
+        //   if model.quotaUsage.isLimitReached { ... }
+        //   let session = LanguageModelSession(model: model, instructions: systemPrompt)
+        //   let response = try await session.respond(to: userMessage)
+        //   // include quotaWarning flag if model.quotaUsage.status isApproachingLimit
+        //
+        sendResponse(context: context, data: [
+            "success": false, "error": "unavailable", "reason": "pccNotYetImplemented"
+        ])
     }
 
     private func sendResponse(context: NSExtensionContext, data: [String: Any]) {

--- a/xcode/Obsidian Web Clipper/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/xcode/Obsidian Web Clipper/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -144,19 +144,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
                 let response = try await session.respond(to: userMessage)
                 responseData = ["success": true, "content": response.content]
             } catch {
-                // Map known FoundationModels error patterns to stable codes the JS side can handle.
-                // TODO: LanguageModelError is only available in macOS 27 / iOS 27+.
-                // Once minimum deployment target is raised, replace with typed case matching.
-                let desc = error.localizedDescription.lowercased()
-                let code: String
-                if desc.contains("context") || desc.contains("too long") || desc.contains("token") {
-                    code = "contextWindowExceeded"
-                } else if desc.contains("guardrail") || desc.contains("policy") {
-                    code = "guardrailsViolation"
-                } else {
-                    code = "languageModelError"
-                }
-                responseData = ["success": false, "error": code, "detail": error.localizedDescription]
+                responseData = mapError(error)
             }
             semaphore.signal()
         }
@@ -167,18 +155,64 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
     @available(iOS 27.0, macOS 27.0, *)
     private func handleWithPCC(context: NSExtensionContext, systemPrompt: String, userMessage: String) {
-        // TODO: PrivateCloudComputeLanguageModel is not available in the macOS 26 SDK.
-        // Replace this stub with the full implementation once the macOS 27 SDK ships:
-        //
-        //   let model = PrivateCloudComputeLanguageModel()
-        //   if model.quotaUsage.isLimitReached { ... }
-        //   let session = LanguageModelSession(model: model, instructions: systemPrompt)
-        //   let response = try await session.respond(to: userMessage)
-        //   // include quotaWarning flag if model.quotaUsage.status isApproachingLimit
-        //
-        sendResponse(context: context, data: [
-            "success": false, "error": "unavailable", "reason": "pccNotYetImplemented"
-        ])
+        let model = PrivateCloudComputeLanguageModel()
+
+        if model.quotaUsage.isLimitReached {
+            sendResponse(context: context, data: ["success": false, "error": "quotaExceeded"])
+            return
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var responseData: [String: Any] = ["success": false, "error": "Timeout"]
+
+        Task {
+            do {
+                let session = LanguageModelSession(model: model, instructions: systemPrompt)
+                let response = try await session.respond(to: userMessage)
+
+                var data: [String: Any] = ["success": true, "content": response.content]
+                if case .belowLimit(let info) = model.quotaUsage.status, info.isApproachingLimit {
+                    data["quotaWarning"] = true
+                }
+                responseData = data
+            } catch {
+                responseData = mapError(error)
+            }
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        sendResponse(context: context, data: responseData)
+    }
+
+    // Maps FoundationModels errors to stable string codes for the JS side.
+    // Uses typed LanguageModelError on macOS/iOS 27+; falls back to description
+    // matching on macOS/iOS 26 where the type is unavailable.
+    @available(iOS 26.0, macOS 26.0, *)
+    private func mapError(_ error: Error) -> [String: Any] {
+        if #available(iOS 27.0, macOS 27.0, *),
+           let lmError = error as? LanguageModelError {
+            let code: String
+            switch lmError {
+            case .contextSizeExceeded:  code = "contextWindowExceeded"
+            case .guardrailViolation:   code = "guardrailsViolation"
+            case .refusal:              code = "refusal"
+            case .rateLimited:          code = "rateLimited"
+            default:                    code = "languageModelError"
+            }
+            return ["success": false, "error": code, "detail": lmError.localizedDescription]
+        }
+        // Fallback for macOS 26 where LanguageModelError is unavailable
+        let desc = error.localizedDescription.lowercased()
+        let code: String
+        if desc.contains("context") || desc.contains("too long") || desc.contains("token") {
+            code = "contextWindowExceeded"
+        } else if desc.contains("guardrail") || desc.contains("policy") {
+            code = "guardrailsViolation"
+        } else {
+            code = "languageModelError"
+        }
+        return ["success": false, "error": code, "detail": error.localizedDescription]
     }
 
     private func sendResponse(context: NSExtensionContext, data: [String: Any]) {

--- a/xcode/Obsidian Web Clipper/macOS (App)/Info.plist
+++ b/xcode/Obsidian Web Clipper/macOS (App)/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
+<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>SFSafariWebExtensionConverterVersion</key>
 	<string>15.4</string>


### PR DESCRIPTION
This adds support for Apple Intelligence Foundation Models as an interpreter provider on supported devices, using Safari's native messaging bridge to call the FoundationModels framework from Swift (as the Apple Intelligence models are not directly available in JavaScript).

Because they leverage the Swift bridge, this support is only for the Safari extension and only works on supported devices running Apple Intelligence (iOS/macOS 26+).

<details>
<summary>Here's what it looks like:</summary>

<img width="1822" height="1457" alt="Screenshot of the 'Add Provider' dialog, showing Apple Intelligence" src="https://github.com/user-attachments/assets/075e1609-b253-47f3-a6d1-ecf8972c7c58" />

<img width="1822" height="1457" alt="Screenshot of the 'Add model' dialog, showing radio buttons for different Apple Intelligence models" src="https://github.com/user-attachments/assets/fe588cf4-1194-47a1-9530-6e04d2b16db5" />

<img width="1822" height="1457" alt="Screenshot of the Interpreter settings page, showing Apple Intelligence provider and models selected. The default interpreter context has been overridden." src="https://github.com/user-attachments/assets/3d74a920-f0f8-4dcd-8225-c02654bc930e" />

<img width="1822" height="1457" alt="Screenshot of a template using prompt variables." src="https://github.com/user-attachments/assets/ef847a81-7d78-4ad6-b1cc-05c49fa5b361" />

<img width="1822" height="1457" alt="Screenshot of the main web clipper interface on a Wikipedia article, showing the selected template, selected Apple Intelligence model and selected text on the underlying page." src="https://github.com/user-attachments/assets/64ccadaa-c55c-4128-b217-ad81ac3ac3b7" />

<img width="1822" height="1457" alt="Screenshot of the main web clipper interface on a Wikipedia article mid-inference." src="https://github.com/user-attachments/assets/58e5e661-585e-40fa-ad40-bc8935e45ff5" />

<img width="1822" height="1457" alt="Screenshot 2026-06-26 at 10 10 20" src="https://github.com/user-attachments/assets/1c6d2ebd-df1b-40c0-8e51-b8a4c1ac03d6" />

<img width="1126" height="829" alt="Screenshot of Obsidian, showing summarised article content." src="https://github.com/user-attachments/assets/d069be59-d16f-4a5f-8ab5-2360dcd38e55" />

</details>

As I submit this draft PR, only the on-device model is implemented. There seems to be a [new interface](https://developer.apple.com/documentation/FoundationModels/PrivateCloudComputeLanguageModel) added in iOS/macOS 27 for the Private Cloud Compute model — I had thought it was available in iOS/macOS 26, as it can be selected in Shortcuts when running inference requests through there, but I can't find it in Apple's documentation. I was hoping to get some feedback while I install macOS 27 and iOS 27 betas to properly implement and test the PCC option.

# Testing

The current extension fetches `providers.json` from `origin/main` on GitHub at runtime rather than using a bundled version. To test this PR, you'll need to change that URL at `src/managers/interpreter-settings.ts#29` (I haven't included that change in the PR itself):

```ts
const PROVIDERS_URL = 'https://raw.githubusercontent.com/jimjam-slam/obsidian-clipper/refs/heads/test-appleintelligence-provider/providers.json'
```

[That version](https://github.com/jimjam-slam/obsidian-clipper/blob/test-appleintelligence-provider/providers.json) adds an `apple-intelligence` entry. It also has a `providerType: "apple-intelligence"` that I've used to make slight UI modifications (hiding URL options when adding the provider, noting the OS and browser requirements, but this field is absent from the existing models. You could just key this on the provider name directly if you wanted.

You'll also want to set up a template with prompt variables, of course. I just used the following note content:

```
# Summary

{{"Write a brief summary of this article, no more than three sentences."}}
```

> [!TIP]
> Note that the on-device model that has been implemented is _very_ limited, especially in terms of context (at least on iOS/macOS 26). Since the default interpreter context is `{{fullHtml}}`, most web pages are too big for it. I recommend overriding it to `{{content}}` so that you can select text to send when testing. (I would probably make this the default, but I'm not sure if there are other side effects to this change, and I don't know whether it's desirable to have different defaults for different models.)
> 
> **EDIT:** looks on on-device max context is [4096 tokens on iOS/macOS 26.4](https://developer.apple.com/documentation/Updates/FoundationModels#February-2026) and potentially even smaller on 26.0–26.3. [The list of model updates](https://developer.apple.com/documentation/Updates/FoundationModels) suggests the on-device model is better in 27.0 but doesn't necessarily have a larger context window as I'd hoped.

# Feedback

I'm hoping to get some steering on a few things before this is ready to go.

- [ ] The Private Compute Cloud option that Apple is marketing for iOS/Mac OS 27 will be rate limited. It's easy enough to alert users when that limit is exceeded (and it's also possible to alert them when it's nearing, but I might need some basic guidance on UI deviations here since it would presumably be proactive). However, Apple also recommends linking users who've exceeded their quotas to an iCloud subscription flow. I can add this in if you like, but I can also skip it in favour of a basic message if you find it inappropriate.
- [ ] Should the non-Safari extensions need to filter out Apple Intelligence as a provider? They can't access Apple Intelligence, as it uses the Swift bridging code rather than a direct JavaScript API. If settings are shared across devices or browsers, I'd probably keep it in, as I wouldn't want to clobber settings a user has set up across multiple browsers or devices. if they're not, I'd probably filter it out.
- [ ] Apple is shipping [properly typed errors](https://developer.apple.com/documentation/foundationmodels/languagemodelerror) for the language models in iOS/macOS 27. For 26, I've gone with some basic pattern matching on the error strings returned. Happy to tweak if needed.
- [ ] Not sure if you would like this to be more proactive about the on-device context window. I believe we can [fetch the max context size](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/contextsize); there could potentially be UI here to alert the user if the content is likely to exceed that before they click interpret.
  - **EDIT:** yes, `SystemLanguageModel` and `privateCloudComputeLanguageModel` both have `.contextSize` for getting max context (4K on-device or 32K in PCC), and there's also `SystemLanguageModel.tokenCount(for:)` for estimating token count for a given prompt.
- [ ] I assume that the existing APIs will continue to work for the on-device model in iOS/macOS 27, even though that model will be substantially upgraded for selected devices. I own one of those devices (a Mac), so I'll do some before/after testing to confirm this.
- [ ] You can check for model support for a specific locale, which might be good to more proactively flag lack of support for some locale users. This would require additional UI.
- [ ] The Private Cloud Compute model has a configurable reasoning level. Can add UI in the settings if this is desired.

**EDIT:** oops, forgot to disclose that I worked with Claude on this PR!