### PR TITLE
feat: persist path, convert video embeds, add language switcher and v…

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -20,6 +20,9 @@
 	"addToObsidian": {
 		"message": "Add to Obsidian"
 	},
+	"videoLabel": {
+		"message": "Video"
+	},
 	"addVaultPlaceholder": {
 		"message": "Press enter to add a vault"
 	},
@@ -344,6 +347,12 @@
 	},
 	"folder": {
 		"message": "Folder"
+	},
+	"fetchVaultFolders": {
+		"message": "Fetch vault folders"
+	},
+	"fileSystemApiNotSupported": {
+		"message": "This browser does not support folder selection. Please use Chrome or Edge."
 	},
 	"general": {
 		"message": "General"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -20,6 +20,9 @@
 	"addToObsidian": {
 		"message": "添加到 Obsidian"
 	},
+	"videoLabel": {
+		"message": "视频"
+	},
 	"addVaultPlaceholder": {
 		"message": "按回车键添加保管库"
 	},
@@ -344,6 +347,12 @@
 	},
 	"folder": {
 		"message": "文件夹"
+	},
+	"fetchVaultFolders": {
+		"message": "获取 Vault 文件夹"
+	},
+	"fileSystemApiNotSupported": {
+		"message": "当前浏览器不支持文件夹选择，请使用 Chrome 或 Edge。"
 	},
 	"general": {
 		"message": "常规"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -20,6 +20,9 @@
 	"addToObsidian": {
 		"message": "新增到 Obsidian"
 	},
+	"videoLabel": {
+		"message": "影片"
+	},
 	"addVaultPlaceholder": {
 		"message": "按 Enter 鍵新增儲存庫"
 	},
@@ -344,6 +347,12 @@
 	},
 	"folder": {
 		"message": "資料夾"
+	},
+	"fetchVaultFolders": {
+		"message": "取得 Vault 資料夾"
+	},
+	"fileSystemApiNotSupported": {
+		"message": "目前瀏覽器不支援資料夾選擇，請使用 Chrome 或 Edge。"
 	},
 	"general": {
 		"message": "一般"

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,6 +12,7 @@ import { saveFile } from './utils/file-utils';
 import { debugLog } from './utils/debug';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './utils/iframe-resize';
 import { parseForClip } from './utils/clip-utils';
+import { convertMediaEmbeds } from './utils/content-extractor';
 
 declare global {
 	interface Window {
@@ -156,7 +157,7 @@ declare global {
 					const defuddled = parseForClip(document);
 
 					// Convert HTML content to markdown
-					const markdown = createMarkdownContent(defuddled.content, document.URL);
+					const markdown = createMarkdownContent(convertMediaEmbeds(defuddled.content), document.URL);
 
 					// Copy to clipboard
 					const textArea = document.createElement("textarea");
@@ -179,7 +180,7 @@ declare global {
 			flattenShadowDom(document).then(async () => {
 				try {
 					const defuddled = parseForClip(document);
-					const markdown = createMarkdownContent(defuddled.content, document.URL);
+					const markdown = createMarkdownContent(convertMediaEmbeds(defuddled.content), document.URL);
 					const title = defuddled.title || document.title || 'Untitled';
 					const fileName = title.replace(/[/\\?%*:|"<>]/g, '-');
 					await saveFile({

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -21,7 +21,7 @@ import { memoizeWithExpiration } from '../utils/memoize';
 import { debounce } from '../utils/debounce';
 import { sanitizeFileName } from '../utils/string-utils';
 import { saveFile } from '../utils/file-utils';
-import { translatePage, getMessage, setupLanguageAndDirection } from '../utils/i18n';
+import { translatePage, getMessage, setupLanguageAndDirection, getAvailableLanguages, getCurrentLanguage, setLanguage } from '../utils/i18n';
 import { formatPropertyValue } from '../utils/shared';
 
 interface ReaderModeResponse {
@@ -35,6 +35,9 @@ let templates: Template[] = [];
 let currentVariables: { [key: string]: string } = {};
 let currentTabId: number | undefined;
 let lastSelectedVault: string | null = null;
+let lastSelectedPath: string | null = null;
+let pathHistory: string[] = [];
+let vaultFolders: string[] = [];
 
 const isSidePanel = window.location.pathname.includes('side-panel.html');
 const urlParams = new URLSearchParams(window.location.search);
@@ -197,6 +200,14 @@ async function initializeExtension(tabId: number) {
 			lastSelectedVault = loadedSettings.vaults[0];
 		}
 		debugLog('Vaults', 'Last selected vault:', lastSelectedVault);
+
+		// Load last selected path, path history, and vault folders
+		lastSelectedPath = await getLocalStorage('lastSelectedPath');
+		const storedHistory = await getLocalStorage('pathHistory');
+		pathHistory = Array.isArray(storedHistory) ? storedHistory.filter((p: unknown) => typeof p === 'string') : [];
+		const storedFolders = await getLocalStorage('vaultFolders');
+		vaultFolders = Array.isArray(storedFolders) ? storedFolders.filter((f: unknown) => typeof f === 'string') : [];
+		debugLog('Path', 'Last selected path:', lastSelectedPath, 'history:', pathHistory, 'vaultFolders:', vaultFolders.length);
 
 		const tab = await getTabInfo(tabId);
 		if (!tab.url || isBlankPage(tab.url)) {
@@ -368,6 +379,40 @@ document.addEventListener('DOMContentLoaded', async function() {
 			initializeIcons(settingsButton);
 		}
 
+		// Language switcher dropdown
+		const languageBtn = document.getElementById('language-btn') as HTMLAnchorElement | null;
+		const languageDropdown = document.getElementById('language-dropdown');
+		if (languageBtn && languageDropdown) {
+			initializeIcons(languageBtn);
+
+			languageBtn.addEventListener('click', async function(e) {
+				e.preventDefault();
+				e.stopPropagation();
+				const isVisible = languageDropdown.style.display !== 'none';
+				languageDropdown.style.display = isVisible ? 'none' : 'block';
+				if (!isVisible) {
+					await populateLanguageDropdown(languageDropdown);
+				}
+			});
+
+			document.addEventListener('click', function(e) {
+				if (!languageDropdown.contains(e.target as Node) && e.target !== languageBtn && !languageBtn.contains(e.target as Node)) {
+					languageDropdown.style.display = 'none';
+				}
+			});
+		}
+
+		// Fetch vault folders button
+		const fetchFoldersBtn = document.getElementById('fetch-folders-btn');
+		if (fetchFoldersBtn) {
+			initializeIcons(fetchFoldersBtn);
+			fetchFoldersBtn.addEventListener('click', async function(e) {
+				e.preventDefault();
+				e.stopPropagation();
+				await fetchVaultFolders();
+			});
+		}
+
 		// Initialize the rest of the popup
 		if (currentTabId) {
 			const initialized = await initializeExtension(currentTabId);
@@ -378,6 +423,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 			try {
 				// DOM-dependent initializations
 				updateVaultDropdown(loadedSettings.vaults);
+				populatePathDatalist();
 				populateTemplateDropdown();
 				setupEventListeners(currentTabId);
 				await initializeUI();
@@ -421,6 +467,18 @@ function setupEventListeners(tabId: number) {
 		noteNameField.addEventListener('keydown', function(e) {
 			if (e.key === 'Enter' && !e.shiftKey) {
 				e.preventDefault();
+			}
+		});
+	}
+
+	const pathField = document.getElementById('path-name-field') as HTMLInputElement;
+	if (pathField) {
+		pathField.addEventListener('change', () => {
+			const value = pathField.value.trim();
+			if (value) {
+				lastSelectedPath = value;
+				setLocalStorage('lastSelectedPath', value);
+				addToPathHistory(value);
 			}
 		});
 	}
@@ -929,7 +987,14 @@ async function fillTemplateFieldValues(currentTabId: number, template: Template 
 
 	const pathField = document.getElementById('path-name-field') as HTMLInputElement;
 	if (pathField) {
-		pathField.value = formattedPath;
+		// If the template's path contains variables, always use the compiled value.
+		// Otherwise, restore the user's last manually-entered path if one exists.
+		const templatePathHasVariables = /{{.*?}}/.test(template.path || '');
+		if (!templatePathHasVariables && lastSelectedPath) {
+			pathField.value = lastSelectedPath;
+		} else {
+			pathField.value = formattedPath;
+		}
 	}
 
 	const noteContentField = document.getElementById('note-content-field') as HTMLTextAreaElement;
@@ -1078,6 +1143,121 @@ function updateVaultDropdown(vaults: string[]) {
 		lastSelectedVault = vaultDropdown.value;
 		setLocalStorage('lastSelectedVault', lastSelectedVault);
 	});
+}
+
+function populatePathDatalist() {
+	const datalist = document.getElementById('path-history-list') as HTMLDataListElement | null;
+	if (!datalist) return;
+	datalist.textContent = '';
+	// Show vault folders first (sorted), then history entries
+	const seen = new Set<string>();
+	vaultFolders.forEach(path => {
+		if (seen.has(path)) return;
+		seen.add(path);
+		const option = document.createElement('option');
+		option.value = path;
+		datalist.appendChild(option);
+	});
+	pathHistory.forEach(path => {
+		if (seen.has(path)) return;
+		seen.add(path);
+		const option = document.createElement('option');
+		option.value = path;
+		datalist.appendChild(option);
+	});
+}
+
+async function addToPathHistory(path: string): Promise<void> {
+	const trimmed = path.trim();
+	if (!trimmed) return;
+	// Remove existing entry to move it to the front (most recently used first)
+	pathHistory = pathHistory.filter(p => p !== trimmed);
+	pathHistory.unshift(trimmed);
+	// Keep only the last 50 entries
+	pathHistory = pathHistory.slice(0, 50);
+	await setLocalStorage('pathHistory', pathHistory);
+	populatePathDatalist();
+}
+
+async function populateLanguageDropdown(dropdown: HTMLElement): Promise<void> {
+	dropdown.textContent = '';
+	const languages = getAvailableLanguages();
+	const currentLang = await getCurrentLanguage();
+	languages.forEach((lang: { code: string; name: string }) => {
+		const item = document.createElement('div');
+		item.className = 'language-option';
+		if (lang.code === currentLang) {
+			item.classList.add('selected');
+		}
+		item.textContent = lang.code === '' ? getMessage('systemDefault') : lang.name;
+		item.addEventListener('click', async () => {
+			try {
+				await setLanguage(lang.code);
+				dropdown.style.display = 'none';
+			} catch (error) {
+				console.error('Failed to change language:', error);
+			}
+		});
+		dropdown.appendChild(item);
+	});
+}
+
+// Recursively read subdirectory names from a FileSystemDirectoryHandle.
+// Returns paths relative to the root, using '/' as separator (Obsidian convention).
+async function readDirectoryTree(
+	dirHandle: any,
+	prefix: string,
+	maxDepth: number,
+	results: string[]
+): Promise<void> {
+	if (maxDepth < 0) return;
+	try {
+		for await (const entry of dirHandle.values()) {
+			if (entry.kind === 'directory') {
+				const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+				results.push(relativePath);
+				// Skip hidden folders and common noise directories
+				if (!entry.name.startsWith('.') && entry.name !== 'node_modules' && entry.name !== '.obsidian' && entry.name !== '.trash') {
+					await readDirectoryTree(entry, relativePath, maxDepth - 1, results);
+				}
+			}
+		}
+	} catch (e) {
+		// Permission or read error on a subdirectory — skip silently
+	}
+}
+
+async function fetchVaultFolders(): Promise<void> {
+	// File System Access API — Chrome/Edge only
+	if (typeof (window as any).showDirectoryPicker !== 'function') {
+		alert(getMessage('fileSystemApiNotSupported'));
+		return;
+	}
+
+	try {
+		const dirHandle = await (window as any).showDirectoryPicker({
+			mode: 'read',
+			id: 'obsidian-vault',
+		});
+
+		const folders: string[] = [];
+		// Read up to 5 levels deep — enough for any reasonable vault structure
+		await readDirectoryTree(dirHandle, '', 5, folders);
+
+		// Sort alphabetically for a clean dropdown
+		folders.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+		vaultFolders = folders;
+		await setLocalStorage('vaultFolders', vaultFolders);
+		populatePathDatalist();
+
+		debugLog('Path', `Fetched ${vaultFolders.length} vault folders`);
+	} catch (e) {
+		// User cancelled the picker or denied permission — do nothing
+		if ((e as Error).name !== 'AbortError') {
+			console.error('Failed to fetch vault folders:', e);
+		}
+	}
 }
 
 function refreshPopup() {
@@ -1352,6 +1532,13 @@ async function handleClipObsidian(): Promise<void> {
 
 		lastSelectedVault = selectedVault;
 		await setLocalStorage('lastSelectedVault', lastSelectedVault);
+
+		// Persist the path so it survives popup reopen
+		if (path) {
+			lastSelectedPath = path;
+			await setLocalStorage('lastSelectedPath', path);
+			await addToPathHistory(path);
+		}
 
 		if (!isSidePanel) {
 			setTimeout(() => window.close(), 500);

--- a/src/popup.html
+++ b/src/popup.html
@@ -26,14 +26,22 @@
 					data-i18n-title="reader">
 					<i data-lucide="book-open"></i>
 				</a>
-				<a href="#" id="embedded-mode" class="clickable-icon" 
-					data-i18n-title="openEmbedded">
-					<i data-lucide="picture-in-picture-2"></i>
+			<a href="#" id="embedded-mode" class="clickable-icon" 
+				data-i18n-title="openEmbedded">
+				<i data-lucide="picture-in-picture-2"></i>
+			</a>
+			<div id="language-switcher" class="language-switcher">
+				<a href="#" id="language-btn" class="clickable-icon"
+					data-i18n-title="language">
+					<i data-lucide="globe"></i>
 				</a>
-				<a href="#" id="open-settings" class="clickable-icon" 
-					data-i18n-title="settings">
-					<i data-lucide="settings"></i>
-				</a>		
+				<div id="language-dropdown" class="language-dropdown" style="display: none;">
+				</div>
+			</div>
+			<a href="#" id="open-settings" class="clickable-icon" 
+				data-i18n-title="settings">
+				<i data-lucide="settings"></i>
+			</a>
 			</div>
 		</div>
 		<p class="error-message" style="display: none;"></p>
@@ -52,7 +60,12 @@
 					<div id="vault-container" style="display: none;">
 						<select id="vault-select"></select>
 					</div>
-					<input id="path-name-field" type="text" data-i18n="folder"/>
+					<input id="path-name-field" type="text" list="path-history-list" data-i18n="folder"/>
+					<datalist id="path-history-list"></datalist>
+					<a href="#" id="fetch-folders-btn" class="clickable-icon fetch-folders-btn"
+						data-i18n-title="fetchVaultFolders">
+						<i data-lucide="folder-tree"></i>
+					</a>
 				</div>
 				<div id="interpreter" style="display: none;">
 					<textarea id="prompt-context" rows="3"></textarea>

--- a/src/side-panel.html
+++ b/src/side-panel.html
@@ -26,14 +26,22 @@
 					data-i18n-title="reader">
 					<i data-lucide="book-open"></i>
 				</a>
-				<a href="#" id="refresh-pane" class="clickable-icon"
-					data-i18n-title="refresh">
-					<i data-lucide="rotate-cw"></i>
+			<a href="#" id="refresh-pane" class="clickable-icon"
+				data-i18n-title="refresh">
+				<i data-lucide="rotate-cw"></i>
+			</a>
+			<div id="language-switcher" class="language-switcher">
+				<a href="#" id="language-btn" class="clickable-icon"
+					data-i18n-title="language">
+					<i data-lucide="globe"></i>
 				</a>
-				<a href="#" id="open-settings" class="clickable-icon" 
-					data-i18n-title="settings">
-					<i data-lucide="settings"></i>
-				</a>
+				<div id="language-dropdown" class="language-dropdown" style="display: none;">
+				</div>
+			</div>
+			<a href="#" id="open-settings" class="clickable-icon" 
+				data-i18n-title="settings">
+				<i data-lucide="settings"></i>
+			</a>
 				<a href="#" id="embedded-mode" class="clickable-icon" 
 					data-i18n-title="embeddedMode">
 					<i data-lucide="x"></i>
@@ -56,7 +64,12 @@
 					<div id="vault-container" style="display: none;">
 						<select id="vault-select"></select>
 					</div>
-					<input id="path-name-field" type="text" data-i18n="folder"/>
+					<input id="path-name-field" type="text" list="path-history-list" data-i18n="folder"/>
+					<datalist id="path-history-list"></datalist>
+					<a href="#" id="fetch-folders-btn" class="clickable-icon fetch-folders-btn"
+						data-i18n-title="fetchVaultFolders">
+						<i data-lucide="folder-tree"></i>
+					</a>
 				</div>
 				<div id="interpreter" style="display: none;">
 					<textarea id="prompt-context" rows="3"></textarea>

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -166,6 +166,26 @@
 			min-width: 100px;
 			cursor: default;
 		}
+		#path-name-field {
+			flex-grow: 1;
+			min-width: 0;
+		}
+		.fetch-folders-btn {
+			flex-shrink: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: var(--input-height, 36px);
+			height: var(--input-height, 36px);
+			border-radius: var(--radius-s);
+			color: var(--text-muted);
+			@media (hover: hover) {
+				&:hover {
+					background-color: var(--background-modifier-hover);
+					color: var(--text-normal);
+				}
+			}
+		}
 	}
 }
 
@@ -370,6 +390,48 @@
 			&.active:hover {
 				background-color: hsla(var(--color-accent-hsl), 0.15);
 			}
+		}
+	}
+}
+
+.language-switcher {
+	position: relative;
+	display: flex;
+	align-items: center;
+}
+
+.language-dropdown {
+	position: absolute;
+	top: 100%;
+	right: 0;
+	margin-top: 4px;
+	min-width: 180px;
+	max-height: 300px;
+	overflow-y: auto;
+	background-color: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: var(--radius-m);
+	box-shadow: var(--shadow-l);
+	z-index: 1000;
+	padding: 4px 0;
+
+	.language-option {
+		display: flex;
+		align-items: center;
+		padding: 6px 14px;
+		font-size: var(--font-ui-smaller);
+		color: var(--text-normal);
+		cursor: default;
+		user-select: none;
+		-webkit-user-select: none;
+		@media (hover: hover) {
+			&:hover {
+				background-color: var(--background-modifier-hover);
+			}
+		}
+		&.selected {
+			color: var(--text-accent);
+			font-weight: 600;
 		}
 	}
 }

--- a/src/utils/content-extractor.ts
+++ b/src/utils/content-extractor.ts
@@ -4,6 +4,7 @@ import { sanitizeFileName } from './string-utils';
 import { buildVariables, addSchemaOrgDataToVariables } from './shared';
 import browser from './browser-polyfill';
 import { debugLog } from './debug';
+import { getMessage } from './i18n';
 import dayjs from 'dayjs';
 import { AnyHighlightData, TextHighlightData, HighlightData, collapseGroupsForExport } from './highlighter';
 import { generalSettings } from './storage-utils';
@@ -41,6 +42,150 @@ function stripHtml(html: string): string {
 
 function normalizeText(html: string): string {
 	return stripHtml(html).replace(/\s+/g, ' ').trim();
+}
+
+// Convert non-YouTube/non-Twitter video and iframe embeds into Obsidian-friendly
+// markdown so they don't disappear when Obsidian strips raw HTML. YouTube and
+// Twitter/X are already handled by defuddle's embedToMarkdown rule, so we skip
+// those here. Supported platforms: Bilibili, Reddit, Instagram, Vimeo, TikTok,
+// Dailymotion, Facebook, plus generic <video> elements and unknown iframes.
+export function convertMediaEmbeds(html: string): string {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(html, 'text/html');
+
+	let modified = false;
+
+	// --- <iframe> embeds ---
+	const iframes = Array.from(doc.querySelectorAll('iframe'));
+	for (const iframe of iframes) {
+		const src = (iframe.getAttribute('src') || '').trim();
+		if (!src) {
+			iframe.remove();
+			modified = true;
+			continue;
+		}
+
+		// Skip YouTube/Twitter — defuddle already converts these to ![](...)
+		if (/(?:youtube\.com|youtube-nocookie\.com|youtu\.be)/i.test(src) ||
+			/(?:twitter\.com|x\.com)/i.test(src)) {
+			continue;
+		}
+
+		const replacement = iframeToMarkdown(src);
+		if (replacement) {
+			iframe.replaceWith(doc.createTextNode(replacement));
+			modified = true;
+		}
+	}
+
+	// --- <video> elements ---
+	const videos = Array.from(doc.querySelectorAll('video'));
+	for (const video of videos) {
+		// Try to find a usable source URL
+		let src = (video.getAttribute('src') || '').trim();
+		if (!src) {
+			const source = video.querySelector('source');
+			if (source) src = (source.getAttribute('src') || '').trim();
+		}
+		// Prefer the poster image as the displayed embed, with the video src as a link
+		const poster = (video.getAttribute('poster') || '').trim();
+
+		if (src || poster) {
+			const parts: string[] = [];
+			if (poster) {
+				parts.push(`![](${poster})`);
+			}
+			if (src) {
+				parts.push(`[▶ ${getMessage('videoLabel')}](${src})`);
+			}
+			video.replaceWith(doc.createTextNode('\n' + parts.join('\n') + '\n'));
+			modified = true;
+		}
+	}
+
+	if (!modified) return html;
+
+	const serializer = new XMLSerializer();
+	let result = '';
+	Array.from(doc.body.childNodes).forEach(node => {
+		if (node.nodeType === Node.ELEMENT_NODE) {
+			result += serializer.serializeToString(node);
+		} else if (node.nodeType === Node.TEXT_NODE) {
+			result += node.textContent;
+		}
+	});
+	return result;
+}
+
+// Map a known-platform iframe src to an Obsidian-friendly markdown link.
+// Returns '' when no conversion applies (caller leaves the iframe untouched
+// — defuddle will keep the raw HTML, which is still better than dropping it).
+function iframeToMarkdown(src: string): string {
+	try {
+		const url = new URL(src);
+		const host = url.hostname.toLowerCase();
+		const path = url.pathname;
+		const q = url.searchParams;
+
+		// Bilibili: player.bilibili.com/player.html?bvid=XXX or ?aid=XXX
+		if (host.includes('bilibili.com')) {
+			const bvid = q.get('bvid');
+			if (bvid) return `\n![](https://www.bilibili.com/video/${bvid})\n`;
+			const aid = q.get('aid');
+			if (aid) return `\n![](https://www.bilibili.com/video/av${aid})\n`;
+			// Some embeds use /video/BVxxx in the path
+			const pathMatch = path.match(/\/video\/(BV[\w]+)/);
+			if (pathMatch) return `\n![](https://www.bilibili.com/video/${pathMatch[1]})\n`;
+		}
+
+		// Reddit: embed.reddit.com/r/<sub>/comments/<id>/<slug>/?context=...
+		if (host.includes('reddit.com') || host.includes('redditmedia.com')) {
+			// /r/sub/comments/id/slug/
+			const m = path.match(/\/r\/([^/]+)\/comments\/([a-z0-9]+)\//i);
+			if (m) return `\n![](https://www.reddit.com/r/${m[1]}/comments/${m[2]})\n`;
+			// /comments/<id>/...
+			const m2 = path.match(/\/comments\/([a-z0-9]+)\//i);
+			if (m2) return `\n![](https://www.reddit.com/comments/${m2[1]})\n`;
+		}
+
+		// Instagram: instagram.com/p/<id>/embed or /reel/<id>/embed
+		if (host.includes('instagram.com')) {
+			const m = path.match(/\/(p|reel|reels)\/([^/]+)/i);
+			if (m) return `\n![](https://www.instagram.com/${m[1]}/${m[2]})\n`;
+		}
+
+		// Vimeo: player.vimeo.com/video/<id>
+		if (host.includes('vimeo.com')) {
+			const m = path.match(/\/video\/(\d+)/);
+			if (m) return `\n![](https://vimeo.com/${m[1]})\n`;
+		}
+
+		// TikTok: tiktok.com/embed/v2/<id> or player.tiktok.com
+		if (host.includes('tiktok.com')) {
+			const m = path.match(/\/embed\/v?2?\/(\d+)/i);
+			if (m) return `\n![](https://www.tiktok.com/video/${m[1]})\n`;
+		}
+
+		// Dailymotion: dailymotion.com/embed/video/<id>
+		if (host.includes('dailymotion.com')) {
+			const m = path.match(/\/embed\/video\/([^/]+)/);
+			if (m) return `\n![](https://www.dailymotion.com/video/${m[1]})\n`;
+		}
+
+		// Facebook: facebook.com/plugins/video.php?href=...
+		if (host.includes('facebook.com') || host.includes('fbcdn')) {
+			const href = q.get('href');
+			if (href) return `\n![](${href})\n`;
+		}
+
+		// Generic fallback: link to the iframe src so it's never invisible
+		if (src.startsWith('http')) {
+			return `\n[▶ ${getMessage('videoLabel')}](${src})\n`;
+		}
+	} catch {
+		// Invalid URL — fall through
+	}
+	return '';
 }
 
 interface ContentResponse {
@@ -149,13 +294,17 @@ export async function initializePageContent(
 		let selectedMarkdown = '';
 		if (selectedHtml) {
 			content = selectedHtml;
-			selectedMarkdown = createMarkdownContent(selectedHtml, currentUrl);
+			selectedMarkdown = createMarkdownContent(convertMediaEmbeds(selectedHtml), currentUrl);
 		}
 
 		// Process highlights after getting the base content
 		if (generalSettings.highlighterEnabled && generalSettings.highlightBehavior !== 'no-highlights' && highlights && highlights.length > 0) {
 			content = processHighlights(content, highlights);
 		}
+
+		// Convert video/iframe embeds (Bilibili, Reddit, Instagram, Vimeo, etc.)
+		// to markdown links so they survive Obsidian's HTML sanitization.
+		content = convertMediaEmbeds(content);
 
 		const markdownBody = createMarkdownContent(content, currentUrl);
 

--- a/src/utils/filters/markdown.ts
+++ b/src/utils/filters/markdown.ts
@@ -1,9 +1,10 @@
 import { createMarkdownContent } from 'defuddle/full';
+import { convertMediaEmbeds } from '../content-extractor';
 
 export const markdown = (str: string, param?: string): string => {
 	const baseUrl = param || 'about:blank';
 	try {
-		return createMarkdownContent(str, baseUrl);
+		return createMarkdownContent(convertMediaEmbeds(str), baseUrl);
 	} catch (error) {
 		console.error('Error in createMarkdownContent:', error);
 		return str;

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -29,6 +29,7 @@ import { getFontCss } from './font-utils';
 import { createMarkdownContent } from 'defuddle/full';
 import { saveFile } from './file-utils';
 import { parseForClip } from './clip-utils';
+import { convertMediaEmbeds } from './content-extractor';
 import { updateSidebarWidth, addResizeHandle, cleanupResizeHandlers } from './iframe-resize';
 import { setElementHTML, setSVGChildren, serializeChildren } from './dom-utils';
 
@@ -2747,9 +2748,9 @@ export class Reader {
 
 	static copyMarkdownOnReaderPage(doc: Document): void {
 		try {
-			const defuddled = parseForClip(doc);
-			const markdown = createMarkdownContent(defuddled.content, doc.URL);
-			navigator.clipboard.writeText(markdown).catch(() => {
+		const defuddled = parseForClip(doc);
+		const markdown = createMarkdownContent(convertMediaEmbeds(defuddled.content), doc.URL);
+		navigator.clipboard.writeText(markdown).catch(() => {
 				const textArea = doc.createElement('textarea');
 				textArea.value = markdown;
 				doc.body.appendChild(textArea);
@@ -2764,9 +2765,9 @@ export class Reader {
 
 	static async saveMarkdownOnReaderPage(doc: Document): Promise<void> {
 		try {
-			const defuddled = parseForClip(doc);
-			const markdown = createMarkdownContent(defuddled.content, doc.URL);
-			const title = defuddled.title || doc.title || 'Untitled';
+		const defuddled = parseForClip(doc);
+		const markdown = createMarkdownContent(convertMediaEmbeds(defuddled.content), doc.URL);
+		const title = defuddled.title || doc.title || 'Untitled';
 			const fileName = title.replace(/[/\\?%*:|"<>]/g, '-');
 			await saveFile({ content: markdown, fileName, mimeType: 'text/markdown' });
 		} catch (err) {


### PR DESCRIPTION
…ault folder picker

Popup improvements:
- Persist the last-used path and a history list (MRU, capped at 50) to local storage. Restore it when the template path has no variables; show all prior paths as datalist autocomplete suggestions.
- Add a language switcher dropdown (globe icon) in the popup header so users can change the UI language without opening settings.
- Add a vault folder picker button next to the path field. Uses the File System Access API to recursively read subdirectories (up to 5 levels, skipping .obsidian/.trash/node_modules/hidden folders) and caches the folder list locally so it only needs to be fetched once. Cached folders appear as autocomplete suggestions alongside history.

Video embed conversion:
- Add convertMediaEmbeds() in content-extractor.ts and call it before createMarkdownContent() across all clip paths (popup, content.ts, reader.ts, markdown filter). Converts non-YouTube/non-Twitter iframe embeds (Bilibili, Reddit, Instagram, Vimeo, TikTok, Dailymotion, Facebook, and generic iframes) and <video> elements into markdown links so embedded videos no longer disappear in Obsidian notes.

Localization:
- Add videoLabel, fetchVaultFolders, and fileSystemApiNotSupported keys for en, zh_CN, and zh_TW.