### PR TITLE
Add batch URL clipping

### DIFF
--- a/docs/Clip web pages.md
+++ b/docs/Clip web pages.md
@@ -21,6 +21,22 @@ By default Web Clipper attempts to intelligently extract only the main article c
 - If a selection is present, it uses the selection. You can use `Ctrl/Cmd+A` to select the entire page.
 - If any [[Highlight web pages|highlights]] are present, it uses the highlights.
 
+## Batch clip URLs
+
+To clip multiple pages, open Web Clipper and click **Batch clip URLs** in the header. Paste one URL per line and click **Start batch clip**.
+
+Batch clipping opens pages in background tabs, waits for each page to load, scrolls the page to give lazy-loaded content a chance to appear, then clips each page using your default Web Clipper template. Web Clipper processes a limited number of tabs at a time and saves notes one at a time, so Obsidian receives each page in order.
+
+Successfully clipped tabs are closed automatically. Tabs that cannot be clipped stay open so you can handle cookie notices, sign-in prompts, captchas, or site-specific errors, then retry those URLs from the batch page.
+
+Batch clipping can optionally notify you when a run finishes. Choose **Do nothing**, **System notification**, **Sound**, or **Notification and sound** from the **When finished** menu.
+
+Batch saves request silent Obsidian handoff when possible, so Obsidian saves the note without opening it. Depending on your operating system and Obsidian protocol handling, Obsidian may still be brought to the foreground while processing an `obsidian://` save URL.
+
+Batch saves use the same clipboard handoff as normal clipping, with a short `obsidian://` URL telling Obsidian to read the clipped content from the clipboard. If clipboard handoff is unavailable, Web Clipper falls back to direct URI content when it is small enough to send safely. Failed batch entries include debug details such as the save stage, final URL, template behavior, vault, note path, content size, handoff URL length, and timings.
+
+Templates with Interpreter prompt variables are not supported in batch mode. Use a template without prompts for batch clipping, or clip those pages manually.
+
 ## Download images
 
 Images are not automatically downloaded when you use Web Clipper. Instead, images link to their web-based URL. This saves space in your vault but it means the images will not be accessible offline, or if the URL stops working.
@@ -51,6 +67,7 @@ Header functionality includes:
 - **Template** dropdown to switch between your saved [[Obsidian Web Clipper/Templates|templates]] added in Web Clipper settings.
 - **More (...)** button to display page variables you can use in templates.
 - **Highlighter** button to turn on [[Highlight web pages|highlighting]].
+- **Batch clip URLs** button to clip a list of URLs.
 - **Cog** button to open Web Clipper settings.
 
 Footer functionality includes:
@@ -59,4 +76,3 @@ Footer functionality includes:
 - **Vault** dropdown to switch between saved vaults added in Web Clipper settings.
 - **Folder** field to define which folder to save to.
 - **Interpreter** to run [[Interpret web pages|natural language prompts]] on the page.
-

--- a/docs/Troubleshoot Web Clipper.md
+++ b/docs/Troubleshoot Web Clipper.md
@@ -25,6 +25,23 @@ If you don't see any content in Obsidian when you click **Add to Obsidian**:
 - Check that your vault name in Web Clipper settings exactly matches your *vault name* in Obsidian *not the vault path*.
 - Check that the folder name is correctly formatted.
 
+### Batch clipping leaves tabs open
+
+When you [[Clip web pages#Batch clip URLs|batch clip URLs]], Web Clipper closes tabs only after the page is clipped and handed off to Obsidian. If a tab stays open, check the batch log for the error message.
+
+Common causes include:
+
+- The page requires sign-in, cookie consent, captcha verification, or another manual action.
+- The website blocks content scripts or changes the page before Web Clipper can extract content.
+- The clipped note is too large to send safely during batch mode.
+- The page is not an `http` or `https` URL.
+
+After handling the page, use **Retry failed URLs** on the batch page.
+
+### Batch clipping permissions
+
+Batch clipping requires permission to create, inspect, update, and close the tabs it opens. Completion notifications use an optional browser notification permission and are requested only if you choose a notification-based completion alert. Web Clipper does not collect usage data; batch URLs are processed locally in your browser and sent to Obsidian using the same clipping pipeline as single-page clipping.
+
 ## Linux
 
 #### Obsidian does not open

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -59,6 +59,141 @@
 	"autoRunInterpreterDescription": {
 		"message": "Run prompt variables immediately if the template contains any. This will consume API credits with your model provider. Turn off if you only want to run interpreter manually."
 	},
+	"batchAlertBoth": {
+		"message": "Notification and sound"
+	},
+	"batchAlertNone": {
+		"message": "Do nothing"
+	},
+	"batchAlertNotification": {
+		"message": "System notification"
+	},
+	"batchAlertSound": {
+		"message": "Sound"
+	},
+	"batchClipComplete": {
+		"message": "Batch clip complete"
+	},
+	"batchClipUrls": {
+		"message": "Batch clip URLs"
+	},
+	"batchClipUrlsDescription": {
+		"message": "Paste one URL per line. Pages are opened in background batches of $1, clipped with your default Web Clipper template, and closed after a successful Obsidian handoff."
+	},
+	"batchCompletionMessage": {
+		"message": "$1/$2 saved. $3 need attention."
+	},
+	"batchDebugDetails": {
+		"message": "Debug details:"
+	},
+	"batchDone": {
+		"message": "Done. Saved $1/$2 URLs."
+	},
+	"batchElapsed": {
+		"message": "Elapsed $1"
+	},
+	"batchErrorCannotClipPage": {
+		"message": "Page cannot be clipped. Current tab URL: $1"
+	},
+	"batchErrorIntervention": {
+		"message": "Possible cookie banner, login wall, or interstitial. Handle it in the open tab, then retry."
+	},
+	"batchErrorInterpreterTemplate": {
+		"message": "Batch clipping does not support templates with Interpreter prompt variables yet. Use a template without prompts or clip this page manually."
+	},
+	"batchErrorNoTabId": {
+		"message": "Browser did not return a tab ID."
+	},
+	"batchErrorNoTemplates": {
+		"message": "No templates available."
+	},
+	"batchErrorNoteTooLarge": {
+		"message": "Clipped note is too large to save safely in batch mode ($1 URL characters)."
+	},
+	"batchErrorPageDidNotSettle": {
+		"message": "Page did not settle before clipping."
+	},
+	"batchErrorPageLoadTimeout": {
+		"message": "Timed out waiting for page load."
+	},
+	"batchErrorPrepareTimeout": {
+		"message": "Timed out while preparing the page."
+	},
+	"batchErrorSettleTimeout": {
+		"message": "Timed out while settling lazy-loaded content."
+	},
+	"batchErrorUnableExtract": {
+		"message": "Unable to extract page content."
+	},
+	"batchErrorUnableInitialize": {
+		"message": "Unable to initialize page content."
+	},
+	"batchFailedFinal": {
+		"message": "$1/$2 saved. $3 tabs stayed open for cookie banners, logins, interstitials, or errors. Handle them, then retry."
+	},
+	"batchFailedFinalOne": {
+		"message": "$1/$2 saved. 1 tab stayed open for cookie banners, logins, interstitials, or errors. Handle it, then retry."
+	},
+	"batchFinishedIn": {
+		"message": "Finished in $1."
+	},
+	"batchIgnoredInvalid": {
+		"message": "Ignored $1 invalid entries."
+	},
+	"batchIgnoredInvalidOne": {
+		"message": "Ignored 1 invalid entry."
+	},
+	"batchLazyLoadSkipped": {
+		"message": "Lazy-load settling skipped; clipping anyway ($1)"
+	},
+	"batchNeedAttention": {
+		"message": "Needs attention: $1 ($2)"
+	},
+	"batchNotificationPermissionDenied": {
+		"message": "System notifications were not enabled for this run."
+	},
+	"batchNotificationPermissionUnavailable": {
+		"message": "System notifications are not available for this run."
+	},
+	"batchNoValidUrls": {
+		"message": "No valid URLs found. Rejected $1."
+	},
+	"batchOpening": {
+		"message": "Opening $1"
+	},
+	"batchPasteAtLeastOneUrl": {
+		"message": "Paste at least one URL."
+	},
+	"batchProgressSummary": {
+		"message": "$1/$2 done. $3 saved, $4 need attention."
+	},
+	"batchRetryFailedUrls": {
+		"message": "Retry failed URLs"
+	},
+	"batchSaved": {
+		"message": "Saved $1"
+	},
+	"batchSaving": {
+		"message": "Saving $1"
+	},
+	"batchStart": {
+		"message": "Start batch clip"
+	},
+	"batchUrlPlaceholder": {
+		"message": "https://example.com/article-1\nhttps://example.com/article-2"
+	},
+	"batchUrls": {
+		"message": "URLs"
+	},
+	"batchUnknownUrl": {
+		"message": "unknown"
+	},
+	"batchWaiting": {
+		"message": "Waiting for URLs."
+	},
+	"batchWhenFinished": {
+		"message": "When finished"
+	},
 	"behavior": {
 		"message": "Behavior"
 	},

--- a/src/background.ts
+++ b/src/background.ts
@@ -333,7 +333,7 @@ browser.runtime.onMessage.addListener((request: unknown) => {
 
 browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime.MessageSender, sendResponse: (response?: any) => void): true | undefined => {
 	if (typeof request === 'object' && request !== null) {
-		const typedRequest = request as { action: string; isActive?: boolean; hasHighlights?: boolean; tabId?: number; text?: string; section?: string; readerUrl?: string };
+		const typedRequest = request as { action: string; isActive?: boolean; hasHighlights?: boolean; tabId?: number; targetTabId?: number; text?: string; url?: string; section?: string; readerUrl?: string };
 		
 		if (typedRequest.action === 'copy-to-clipboard' && typedRequest.text) {
 			// Use content script to copy to clipboard
@@ -582,6 +582,44 @@ browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime
 			return true;
 		}
 
+		if (typedRequest.action === "openBatchClipper") {
+			try {
+				browser.tabs.create({
+					url: browser.runtime.getURL('batch.html')
+				}).then(() => {
+					sendResponse({ success: true });
+				}).catch((error) => {
+					console.error('Error opening batch clipper:', error);
+					sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) });
+				});
+			} catch (error) {
+				console.error('Error opening batch clipper:', error);
+				sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) });
+			}
+			return true;
+		}
+
+		if (typedRequest.action === "showBatchNotification") {
+			const title = (typedRequest as any).title || 'Batch clip complete';
+			const message = (typedRequest as any).message || '';
+			const notifications = (browser as any).notifications;
+			if (notifications?.create) {
+				notifications.create({
+					type: 'basic',
+					iconUrl: browser.runtime.getURL('icons/icon128.png'),
+					title,
+					message
+				}).then(() => {
+					sendResponse({ success: true });
+				}).catch((error: unknown) => {
+					sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) });
+				});
+			} else {
+				sendResponse({ success: false, error: 'Notifications are not available in this browser.' });
+			}
+			return true;
+		}
+
 		if (typedRequest.action === "openHighlights") {
 			const domain = (typedRequest as any).domain;
 			const query = domain ? `?domain=${encodeURIComponent(domain)}` : '';
@@ -690,6 +728,20 @@ browser.runtime.onMessage.addListener((request: unknown, sender: browser.Runtime
 		if (typedRequest.action === "openObsidianUrl") {
 			const url = (typedRequest as any).url;
 			if (url) {
+				const targetTabId = typedRequest.targetTabId;
+				if (targetTabId) {
+					browser.tabs.update(targetTabId, { url }).then(() => {
+						sendResponse({ success: true });
+					}).catch((error) => {
+						console.error('Error opening Obsidian URL in target tab:', error);
+						sendResponse({
+							success: false,
+							error: error instanceof Error ? error.message : String(error)
+						});
+					});
+					return true;
+				}
+
 				browser.tabs.query({active: true, currentWindow: true}).then((tabs) => {
 					const currentTab = tabs[0];
 					if (currentTab && currentTab.id) {

--- a/src/batch.html
+++ b/src/batch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html id="popup">
+	<head>
+		<title>Batch clip URLs</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+		<link rel="stylesheet" href="style.css">
+		<script src="browser-polyfill.min.js"></script>
+	</head>
+	<body id="popup-container">
+		<script type="module" src="popup.js"></script>
+	</body>
+</html>

--- a/src/content.ts
+++ b/src/content.ts
@@ -392,6 +392,13 @@ declare global {
 		} else if (request.action === "getReaderModeState") {
 			sendResponse({ isActive: document.documentElement.classList.contains('obsidian-reader-active') });
 			return true;
+		} else if (request.action === "settlePageForBatchClip") {
+			settlePageForBatchClip(request.maxMs).then((result) => {
+				sendResponse({ success: true, ...result });
+			}).catch((error) => {
+				sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) });
+			});
+			return true;
 		}
 		return true;
 	});
@@ -403,6 +410,54 @@ declare global {
 	function updateHasHighlights() {
 		const hasHighlights = highlighter.getHighlights().length > 0;
 		browser.runtime.sendMessage({ action: "updateHasHighlights", hasHighlights });
+	}
+
+	async function settlePageForBatchClip(maxMs: number = 30000): Promise<{ scrolls: number; height: number; textLength: number }> {
+		const startedAt = Date.now();
+		const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+		let scrolls = 0;
+		let lastHeight = Math.max(
+			document.documentElement.scrollHeight,
+			document.body?.scrollHeight || 0
+		);
+		let stableHeightCount = 0;
+
+		await sleep(750);
+
+		while (Date.now() - startedAt < maxMs) {
+			const viewport = window.innerHeight || document.documentElement.clientHeight || 800;
+			const currentY = window.scrollY || window.pageYOffset;
+			const nextY = Math.min(currentY + Math.max(500, Math.floor(viewport * 0.8)), lastHeight);
+			window.scrollTo({ top: nextY, behavior: 'auto' });
+			scrolls++;
+			await sleep(650);
+
+			const newHeight = Math.max(
+				document.documentElement.scrollHeight,
+				document.body?.scrollHeight || 0
+			);
+			const atBottom = Math.ceil(window.scrollY + viewport) >= newHeight - 8;
+
+			if (newHeight === lastHeight) {
+				stableHeightCount++;
+			} else {
+				stableHeightCount = 0;
+				lastHeight = newHeight;
+			}
+
+			if (atBottom && stableHeightCount >= 2) {
+				break;
+			}
+		}
+
+		window.scrollTo({ top: 0, behavior: 'auto' });
+		await sleep(500);
+
+		return {
+			scrolls,
+			height: Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight || 0),
+			textLength: document.body?.innerText?.trim().length || 0
+		};
 	}
 
 	let highlighterCSSPromise: Promise<void> | null = null;

--- a/src/core/popup.ts
+++ b/src/core/popup.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { Template, Property, PromptVariable } from '../types/types';
 import { incrementStat, addHistoryEntry, getClipHistory } from '../utils/storage-utils';
-import { generateFrontmatter, saveToObsidian } from '../utils/obsidian-note-creator';
+import { generateFrontmatter, saveToObsidian, SaveToObsidianDiagnostics } from '../utils/obsidian-note-creator';
 import { extractPageContent, initializePageContent } from '../utils/content-extractor';
 import { compileTemplate } from '../utils/template-compiler';
 import { initializeIcons, getPropertyTypeIcon } from '../icons/icons';
@@ -23,6 +23,7 @@ import { sanitizeFileName } from '../utils/string-utils';
 import { saveFile } from '../utils/file-utils';
 import { translatePage, getMessage, setupLanguageAndDirection } from '../utils/i18n';
 import { formatPropertyValue } from '../utils/shared';
+import { formatBatchDuration, parseBatchUrls } from '../utils/batch-utils';
 
 interface ReaderModeResponse {
 	success: boolean;
@@ -39,6 +40,89 @@ let lastSelectedVault: string | null = null;
 const isSidePanel = window.location.pathname.includes('side-panel.html');
 const urlParams = new URLSearchParams(window.location.search);
 const isIframe = urlParams.get('context') === 'iframe';
+const isBatchMode = urlParams.get('batch') === '1' || window.location.pathname.includes('batch.html');
+
+const BATCH_CONCURRENCY = 5;
+const BATCH_PAGE_TIMEOUT_MS = 60000;
+const BATCH_SETTLE_TIMEOUT_MS = 15000;
+const BATCH_SAVE_SETTLE_MS = 1500;
+const BATCH_CLIPBOARD_SAVE_SETTLE_MS = 3000;
+const BATCH_MAX_URI_LENGTH = 60000;
+
+interface PreparedObsidianClip {
+	fileContent: string;
+	noteName: string;
+	path: string;
+	vault: string;
+	behavior: Template['behavior'];
+	title?: string;
+	url: string;
+	contentLength: number;
+	templateName: string;
+}
+
+interface BatchClipResult {
+	url: string;
+	success: boolean;
+	tabId?: number;
+	title?: string;
+	error?: string;
+	debugDetails?: BatchDebugDetails;
+}
+
+interface BatchTimings {
+	startedAt: number;
+	loadedAt?: number;
+	settledAt?: number;
+	preparedAt?: number;
+	saveStartedAt?: number;
+	failedAt?: number;
+	savedAt?: number;
+}
+
+interface BatchDebugDetails {
+	stage: string;
+	inputUrl: string;
+	finalUrl?: string;
+	tabId?: number;
+	title?: string;
+	templateName?: string;
+	behavior?: Template['behavior'];
+	vault?: string;
+	path?: string;
+	noteName?: string;
+	contentLength?: number;
+	uriLength?: number;
+	usesClipboard?: boolean;
+	usesUriContent?: boolean;
+	silent?: boolean;
+	fallbackReason?: string;
+	errorName?: string;
+	errorStack?: string;
+	timings: BatchTimings;
+}
+
+interface PreparedBatchClipItem {
+	url: string;
+	position: number;
+	total: number;
+	tabId: number;
+	preparedClip: PreparedObsidianClip;
+	timings: BatchTimings;
+}
+
+type BatchPreparationResult =
+	| { success: true; item: PreparedBatchClipItem }
+	| { success: false; result: BatchClipResult };
+
+type BatchCompletionAlert = 'none' | 'notification' | 'sound' | 'both';
+
+class BatchSettleTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'BatchSettleTimeoutError';
+	}
+}
 
 // Memoize compileTemplate with a short expiration and URL-sensitive key
 const memoizedCompileTemplate = memoizeWithExpiration(
@@ -288,6 +372,11 @@ document.addEventListener('DOMContentLoaded', async function() {
 		document.documentElement.classList.add('is-embedded');
 	}
 
+	if (isBatchMode) {
+		await initializeBatchClipperPage();
+		return;
+	}
+
 	const isSidePanel = document.documentElement.classList.contains('is-side-panel');
 
 	try {
@@ -441,6 +530,21 @@ function setupEventListeners(tabId: number) {
 				}
 			});
 		}
+
+	const batchClipperButton = document.getElementById('batch-clipper');
+	if (batchClipperButton) {
+		batchClipperButton.addEventListener('click', async function(e) {
+			e.preventDefault();
+			try {
+				await browser.runtime.sendMessage({ action: "openBatchClipper" });
+				if (!isSidePanel && !isIframe) {
+					setTimeout(() => window.close(), 50);
+				}
+			} catch (error) {
+				console.error('Error opening batch clipper:', error);
+			}
+		});
+	}
 
 	const moreButton = document.getElementById('more-btn');
 	const moreDropdown = document.getElementById('more-dropdown');
@@ -603,6 +707,733 @@ async function initializeUI() {
 			browser.runtime.sendMessage({ action: "sidePanelClosed" });
 		});
 	}
+}
+
+async function initializeBatchClipperPage() {
+	await translatePage();
+	await setupLanguageAndDirection();
+	await addBrowserClassToHtml();
+
+	document.title = getMessage('batchClipUrls');
+	document.documentElement.classList.add('is-batch-mode');
+	document.body.classList.add('batch-mode');
+	document.body.innerHTML = `
+		<div class="batch-clipper-page">
+			<header class="batch-header">
+				<div>
+					<h1>${escapeHtml(getMessage('batchClipUrls'))}</h1>
+					<p>${escapeHtml(getMessage('batchClipUrlsDescription', BATCH_CONCURRENCY.toString()))}</p>
+				</div>
+				<button id="batch-settings-btn" class="clickable-icon" title="${escapeHtml(getMessage('settings'))}"><i data-lucide="settings"></i></button>
+			</header>
+			<main class="batch-main">
+				<section class="batch-inputs">
+					<label for="batch-url-list">${escapeHtml(getMessage('batchUrls'))}</label>
+					<textarea id="batch-url-list" spellcheck="false" placeholder="${escapeHtml(getMessage('batchUrlPlaceholder'))}"></textarea>
+					<div class="batch-options">
+						<label for="batch-alert-mode">${escapeHtml(getMessage('batchWhenFinished'))}</label>
+						<select id="batch-alert-mode">
+							<option value="none">${escapeHtml(getMessage('batchAlertNone'))}</option>
+							<option value="notification">${escapeHtml(getMessage('batchAlertNotification'))}</option>
+							<option value="sound">${escapeHtml(getMessage('batchAlertSound'))}</option>
+							<option value="both">${escapeHtml(getMessage('batchAlertBoth'))}</option>
+						</select>
+					</div>
+					<div class="batch-controls">
+						<button id="batch-start-btn" class="mod-cta">${escapeHtml(getMessage('batchStart'))}</button>
+						<button id="batch-retry-btn" style="display: none;">${escapeHtml(getMessage('batchRetryFailedUrls'))}</button>
+					</div>
+				</section>
+				<section class="batch-progress" aria-live="polite">
+					<div class="batch-progress-bar"><div id="batch-progress-fill"></div></div>
+					<div id="batch-timer">${escapeHtml(getMessage('batchElapsed', '00:00'))}</div>
+					<div id="batch-summary">${escapeHtml(getMessage('batchWaiting'))}</div>
+					<ol id="batch-log"></ol>
+				</section>
+			</main>
+		</div>
+	`;
+
+	initializeIcons(document.body);
+	templates = await loadTemplates();
+	initializeTriggers(templates);
+	lastSelectedVault = await getLocalStorage('lastSelectedVault');
+	if (!lastSelectedVault && loadedSettings.vaults.length > 0) {
+		lastSelectedVault = loadedSettings.vaults[0];
+	}
+
+	let failedUrls: string[] = [];
+	let isRunning = false;
+
+	const textarea = document.getElementById('batch-url-list') as HTMLTextAreaElement;
+	const startButton = document.getElementById('batch-start-btn') as HTMLButtonElement;
+	const retryButton = document.getElementById('batch-retry-btn') as HTMLButtonElement;
+	const settingsButton = document.getElementById('batch-settings-btn') as HTMLButtonElement;
+	const alertModeSelect = document.getElementById('batch-alert-mode') as HTMLSelectElement;
+	const summary = document.getElementById('batch-summary') as HTMLElement;
+	const timer = document.getElementById('batch-timer') as HTMLElement;
+	const log = document.getElementById('batch-log') as HTMLOListElement;
+	const progressFill = document.getElementById('batch-progress-fill') as HTMLElement;
+
+	const savedAlertMode = await getLocalStorage('batchCompletionAlert') as BatchCompletionAlert | undefined;
+	alertModeSelect.value = savedAlertMode || 'none';
+	alertModeSelect.addEventListener('change', () => {
+		setLocalStorage('batchCompletionAlert', alertModeSelect.value);
+	});
+
+	settingsButton.addEventListener('click', () => {
+		browser.runtime.sendMessage({ action: "openOptionsPage" });
+	});
+
+	const startRun = async (rawUrls: string) => {
+		if (isRunning) return;
+		const { urls, rejected } = parseBatchUrls(rawUrls);
+		if (urls.length === 0) {
+			summary.textContent = rejected.length > 0
+				? getMessage('batchNoValidUrls', rejected.length.toString())
+				: getMessage('batchPasteAtLeastOneUrl');
+			return;
+		}
+
+		isRunning = true;
+		failedUrls = [];
+		log.textContent = '';
+		progressFill.style.width = '0%';
+		startButton.disabled = true;
+		retryButton.style.display = 'none';
+		textarea.disabled = true;
+
+		if (rejected.length > 0) {
+			appendBatchLog(log, getBatchInvalidUrlMessage(rejected.length));
+		}
+
+		let completed = 0;
+		let succeeded = 0;
+		let failed = 0;
+		const total = urls.length;
+		const completionAlertMode = await ensureBatchCompletionAlertPermission(
+			alertModeSelect.value as BatchCompletionAlert,
+			(message) => appendBatchLog(log, message)
+		);
+		const startedAt = Date.now();
+		let timerInterval: number | undefined;
+		const updateSummary = () => {
+			progressFill.style.width = `${Math.round((completed / total) * 100)}%`;
+			summary.textContent = getMessage('batchProgressSummary', [
+				completed.toString(),
+				total.toString(),
+				succeeded.toString(),
+				failed.toString()
+			]);
+			timer.textContent = getBatchTimerText(startedAt);
+		};
+		updateSummary();
+		timerInterval = window.setInterval(updateSummary, 1000);
+
+		await runBatchClip(urls, (message) => appendBatchLog(log, message), (result) => {
+			completed++;
+			if (result.success) {
+				succeeded++;
+			} else {
+				failed++;
+				failedUrls.push(result.url);
+			}
+			updateSummary();
+		});
+		if (timerInterval !== undefined) {
+			window.clearInterval(timerInterval);
+		}
+
+		isRunning = false;
+		startButton.disabled = false;
+		textarea.disabled = false;
+
+		if (failedUrls.length > 0) {
+			retryButton.style.display = 'inline-flex';
+			summary.textContent = getBatchFailureSummary(succeeded, total, failedUrls.length);
+		} else {
+			summary.textContent = getMessage('batchDone', [succeeded.toString(), total.toString()]);
+		}
+		timer.textContent = getMessage('batchFinishedIn', formatBatchDuration(Date.now() - startedAt));
+		await notifyBatchComplete(completionAlertMode, succeeded, failed, total);
+	};
+
+	startButton.addEventListener('click', () => startRun(textarea.value));
+	retryButton.addEventListener('click', () => {
+		textarea.value = failedUrls.join('\n');
+		startRun(textarea.value);
+	});
+}
+
+function appendBatchLog(log: HTMLOListElement, message: string) {
+	const item = document.createElement('li');
+	item.textContent = message;
+	log.prepend(item);
+	while (log.children.length > 200) {
+		log.lastElementChild?.remove();
+	}
+}
+
+function getBatchInvalidUrlMessage(count: number): string {
+	return count === 1
+		? getMessage('batchIgnoredInvalidOne')
+		: getMessage('batchIgnoredInvalid', count.toString());
+}
+
+function getBatchFailureSummary(succeeded: number, total: number, failed: number): string {
+	const substitutions = [succeeded.toString(), total.toString(), failed.toString()];
+	return failed === 1
+		? getMessage('batchFailedFinalOne', substitutions)
+		: getMessage('batchFailedFinal', substitutions);
+}
+
+function getBatchTimerText(startedAt: number): string {
+	const elapsedMs = Date.now() - startedAt;
+	return getMessage('batchElapsed', formatBatchDuration(elapsedMs));
+}
+
+async function ensureBatchCompletionAlertPermission(
+	mode: BatchCompletionAlert,
+	onLog: (message: string) => void
+): Promise<BatchCompletionAlert> {
+	if (mode !== 'notification' && mode !== 'both') {
+		return mode;
+	}
+
+	const permissions = (browser as typeof browser & {
+		permissions?: {
+			contains?: (permissions: { permissions: string[] }) => Promise<boolean>;
+			request?: (permissions: { permissions: string[] }) => Promise<boolean>;
+		};
+	}).permissions;
+
+	if (!permissions?.contains || !permissions.request) {
+		onLog(getMessage('batchNotificationPermissionUnavailable'));
+		return mode === 'both' ? 'sound' : 'none';
+	}
+
+	try {
+		const permission = { permissions: ['notifications'] };
+		const hasPermission = await permissions.contains(permission);
+		if (hasPermission) {
+			return mode;
+		}
+		const granted = await permissions.request(permission);
+		if (granted) {
+			return mode;
+		}
+		onLog(getMessage('batchNotificationPermissionDenied'));
+		return mode === 'both' ? 'sound' : 'none';
+	} catch (error) {
+		console.warn('Batch notification permission request failed:', error);
+		onLog(getMessage('batchNotificationPermissionUnavailable'));
+		return mode === 'both' ? 'sound' : 'none';
+	}
+}
+
+async function notifyBatchComplete(mode: BatchCompletionAlert, succeeded: number, failed: number, total: number): Promise<void> {
+	if (mode === 'sound' || mode === 'both') {
+		await playBatchCompleteSound();
+	}
+	if (mode === 'notification' || mode === 'both') {
+		await browser.runtime.sendMessage({
+			action: 'showBatchNotification',
+			title: getMessage('batchClipComplete'),
+			message: getMessage('batchCompletionMessage', [succeeded.toString(), total.toString(), failed.toString()])
+		}).catch((error) => {
+			console.warn('Batch notification failed:', error);
+		});
+	}
+}
+
+async function playBatchCompleteSound(): Promise<void> {
+	try {
+		const AudioContextClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+		if (!AudioContextClass) return;
+		const audioContext = new AudioContextClass();
+		const oscillator = audioContext.createOscillator();
+		const gain = audioContext.createGain();
+		oscillator.type = 'sine';
+		oscillator.frequency.value = 880;
+		gain.gain.setValueAtTime(0.001, audioContext.currentTime);
+		gain.gain.exponentialRampToValueAtTime(0.08, audioContext.currentTime + 0.02);
+		gain.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.35);
+		oscillator.connect(gain);
+		gain.connect(audioContext.destination);
+		oscillator.start();
+		oscillator.stop(audioContext.currentTime + 0.38);
+		setTimeout(() => audioContext.close(), 500);
+	} catch (error) {
+		console.warn('Batch completion sound failed:', error);
+	}
+}
+
+async function runBatchClip(urls: string[], onLog: (message: string) => void, onResult: (result: BatchClipResult) => void): Promise<BatchClipResult[]> {
+	const results: BatchClipResult[] = new Array(urls.length);
+
+	for (let windowStart = 0; windowStart < urls.length; windowStart += BATCH_CONCURRENCY) {
+		const windowUrls = urls.slice(windowStart, windowStart + BATCH_CONCURRENCY);
+		const preparedItems = windowUrls.map((url, offset) => {
+			const currentIndex = windowStart + offset;
+			return prepareBatchUrl(url, currentIndex + 1, urls.length, onLog);
+		});
+
+		for (let offset = 0; offset < preparedItems.length; offset++) {
+			const currentIndex = windowStart + offset;
+			const preparedResult = await preparedItems[offset];
+			const result = preparedResult.success
+				? await savePreparedBatchClip(preparedResult.item, onLog)
+				: preparedResult.result;
+			results[currentIndex] = result;
+			onResult(result);
+		}
+	}
+
+	return results;
+}
+
+async function prepareBatchUrl(
+	url: string,
+	position: number,
+	total: number,
+	onLog: (message: string) => void
+): Promise<BatchPreparationResult> {
+	let tabId: number | undefined;
+	let stage = 'open';
+	const timings: BatchTimings = { startedAt: Date.now() };
+
+	try {
+		onLog(formatBatchLogLine(position, total, getMessage('batchOpening', url)));
+		const tab = await browser.tabs.create({ url, active: false });
+		tabId = tab.id;
+		if (!tabId) {
+			throw new Error(getMessage('batchErrorNoTabId'));
+		}
+
+		stage = 'load';
+		await waitForBatchTabComplete(tabId, BATCH_PAGE_TIMEOUT_MS);
+		timings.loadedAt = Date.now();
+		throwIfBatchTimedOut(timings.startedAt);
+
+		stage = 'lazy-load settling';
+		await settleBatchTabForClip(tabId, timings.startedAt, onLog, position, total);
+		timings.settledAt = Date.now();
+
+		stage = 'clip preparation';
+		const preparedClip = await prepareBatchClip(tabId);
+		timings.preparedAt = Date.now();
+		throwIfBatchTimedOut(timings.startedAt);
+
+		return {
+			success: true,
+			item: {
+				url,
+				position,
+				total,
+				tabId,
+				preparedClip,
+				timings
+			}
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const debugDetails = await buildBatchDebugDetails({
+			stage,
+			inputUrl: url,
+			tabId,
+			error,
+			timings: {
+				...timings,
+				failedAt: Date.now()
+			}
+		});
+		onLog(formatBatchFailureLog(position, total, url, message, debugDetails));
+		return { success: false, result: { url, success: false, tabId, error: message, debugDetails } };
+	}
+}
+
+async function savePreparedBatchClip(item: PreparedBatchClipItem, onLog: (message: string) => void): Promise<BatchClipResult> {
+	const { url, position, total, tabId, preparedClip, timings } = item;
+	let saveDiagnostics: SaveToObsidianDiagnostics | undefined;
+	try {
+		timings.saveStartedAt = Date.now();
+		onLog(formatBatchLogLine(position, total, getMessage('batchSaving', preparedClip.title || preparedClip.url)));
+		await saveToObsidian(
+			preparedClip.fileContent,
+			preparedClip.noteName,
+			preparedClip.path,
+			preparedClip.vault,
+			preparedClip.behavior,
+			{
+				targetTabId: tabId,
+				silent: true,
+				maxUriLength: BATCH_MAX_URI_LENGTH,
+				onUrlReady: (diagnostics) => {
+					saveDiagnostics = diagnostics;
+				}
+			}
+		);
+		await incrementStat('addToObsidian', preparedClip.vault, preparedClip.path, preparedClip.url, preparedClip.title);
+		await delay(saveDiagnostics?.usesClipboard ? BATCH_CLIPBOARD_SAVE_SETTLE_MS : BATCH_SAVE_SETTLE_MS);
+		await browser.tabs.remove(tabId).catch(() => {});
+		timings.savedAt = Date.now();
+		onLog(formatBatchLogLine(position, total, getMessage('batchSaved', preparedClip.title || url)));
+		return { url, success: true, title: preparedClip.title };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const debugDetails = await buildBatchDebugDetails({
+			stage: 'save handoff',
+			inputUrl: url,
+			tabId,
+			preparedClip,
+			saveDiagnostics,
+			error,
+			timings: {
+				...timings,
+				failedAt: Date.now()
+			}
+		});
+		onLog(formatBatchFailureLog(position, total, url, message, debugDetails));
+		return { url, success: false, tabId, error: message, debugDetails };
+	}
+}
+
+async function buildBatchDebugDetails({
+	stage,
+	inputUrl,
+	tabId,
+	preparedClip,
+	saveDiagnostics,
+	error,
+	timings
+}: {
+	stage: string;
+	inputUrl: string;
+	tabId?: number;
+	preparedClip?: PreparedObsidianClip;
+	saveDiagnostics?: SaveToObsidianDiagnostics;
+	error: unknown;
+	timings: BatchTimings;
+}): Promise<BatchDebugDetails> {
+	const currentTab = tabId ? await browser.tabs.get(tabId).catch(() => undefined) : undefined;
+	const finalUrl = preparedClip?.url || (currentTab ? getBatchTabUrl(currentTab) : undefined);
+	const errorObject = error instanceof Error ? error : undefined;
+	return {
+		stage,
+		inputUrl,
+		finalUrl,
+		tabId,
+		title: preparedClip?.title || currentTab?.title,
+		templateName: preparedClip?.templateName,
+		behavior: preparedClip?.behavior,
+		vault: preparedClip?.vault,
+		path: preparedClip?.path,
+		noteName: preparedClip?.noteName,
+		contentLength: preparedClip?.contentLength,
+		uriLength: saveDiagnostics?.urlLength,
+		usesClipboard: saveDiagnostics?.usesClipboard,
+		usesUriContent: saveDiagnostics?.usesUriContent,
+		silent: saveDiagnostics?.silent,
+		fallbackReason: saveDiagnostics?.fallbackReason,
+		errorName: errorObject?.name,
+		errorStack: errorObject?.stack,
+		timings
+	};
+}
+
+function formatBatchFailureLog(
+	position: number,
+	total: number,
+	url: string,
+	message: string,
+	debugDetails: BatchDebugDetails
+): string {
+	return [
+		formatBatchLogLine(position, total, getMessage('batchNeedAttention', [url, message])),
+		getMessage('batchDebugDetails'),
+		...formatBatchDebugDetails(debugDetails)
+	].join('\n');
+}
+
+function formatBatchDebugDetails(details: BatchDebugDetails): string[] {
+	const rows = [
+		['Stage', details.stage],
+		['Input URL', details.inputUrl],
+		['Final URL', details.finalUrl],
+		['Title', details.title],
+		['Tab ID', details.tabId],
+		['Template', details.templateName],
+		['Behavior', details.behavior],
+		['Vault', details.vault],
+		['Path', details.path],
+		['Note name', details.noteName],
+		['Content characters', details.contentLength],
+		['Obsidian URI characters', details.uriLength],
+		['Clipboard handoff', typeof details.usesClipboard === 'boolean' ? String(details.usesClipboard) : undefined],
+		['URI content handoff', typeof details.usesUriContent === 'boolean' ? String(details.usesUriContent) : undefined],
+		['Silent handoff requested', typeof details.silent === 'boolean' ? String(details.silent) : undefined],
+		['Fallback reason', details.fallbackReason],
+		['Timings', formatBatchTimings(details.timings)],
+		['Error name', details.errorName],
+		['Error stack', details.errorStack]
+	];
+
+	return rows
+		.filter(([, value]) => value !== undefined && value !== null && value !== '')
+		.map(([label, value]) => `- ${label}: ${String(value)}`);
+}
+
+function formatBatchTimings(timings: BatchTimings): string {
+	const rows = [
+		['load', timings.loadedAt],
+		['settle', timings.settledAt],
+		['prepare', timings.preparedAt],
+		['save start', timings.saveStartedAt],
+		['failed', timings.failedAt],
+		['saved', timings.savedAt]
+	];
+	return rows
+		.filter(([, timestamp]) => typeof timestamp === 'number')
+		.map(([label, timestamp]) => `${label} +${formatBatchDuration((timestamp as number) - timings.startedAt)}`)
+		.join(', ');
+}
+
+function formatBatchLogLine(position: number, total: number, message: string): string {
+	return `[${position}/${total}] ${message}`;
+}
+
+async function settleBatchTabForClip(
+	tabId: number,
+	startedAt: number,
+	onLog: (message: string) => void,
+	position: number,
+	total: number
+): Promise<void> {
+	const settleTimeoutMs = Math.max(1000, Math.min(BATCH_SETTLE_TIMEOUT_MS, remainingBatchTime(startedAt) - 5000));
+	const runSettle = async () => browser.runtime.sendMessage({
+		action: "sendMessageToTab",
+		tabId,
+		message: {
+			action: "settlePageForBatchClip",
+			maxMs: settleTimeoutMs
+		}
+	}) as Promise<{ success?: boolean; error?: string } | undefined>;
+	const runSettleWithTimeout = () => withTimeout(
+		runSettle(),
+		settleTimeoutMs + 1000,
+		() => new BatchSettleTimeoutError(getMessage('batchErrorSettleTimeout'))
+	);
+
+	try {
+		const settleResponse = await runSettleWithTimeout();
+		if (settleResponse?.success !== false) {
+			return;
+		}
+		throw new Error(settleResponse.error || getMessage('batchErrorPageDidNotSettle'));
+	} catch (firstError) {
+		if (firstError instanceof BatchSettleTimeoutError) {
+			onLog(formatBatchLogLine(position, total, getMessage('batchLazyLoadSkipped', firstError.message)));
+			return;
+		}
+		try {
+			await browser.runtime.sendMessage({ action: "forceInjectContentScript", tabId });
+			await delay(500);
+			const retryResponse = await runSettleWithTimeout();
+			if (retryResponse?.success !== false) {
+				return;
+			}
+			throw new Error(retryResponse.error || getMessage('batchErrorPageDidNotSettle'));
+		} catch (retryError) {
+			const message = retryError instanceof Error
+				? retryError.message
+				: firstError instanceof Error
+					? firstError.message
+					: String(retryError || firstError);
+			onLog(formatBatchLogLine(position, total, getMessage('batchLazyLoadSkipped', message)));
+		}
+	}
+}
+
+async function waitForBatchTabComplete(tabId: number, timeoutMs: number): Promise<void> {
+	const isReady = (tab: browser.Tabs.Tab) => {
+		const url = tab.url;
+		return tab.status === 'complete' && !!url && isValidUrl(url) && !isBlankPage(url);
+	};
+
+	const initialTab = await browser.tabs.get(tabId);
+	if (isReady(initialTab)) return;
+
+	await new Promise<void>((resolve, reject) => {
+		const timeout = window.setTimeout(() => {
+			browser.tabs.onUpdated.removeListener(listener);
+			window.clearInterval(pollInterval);
+			reject(new Error(getMessage('batchErrorPageLoadTimeout')));
+		}, timeoutMs);
+
+		const finishIfReady = async () => {
+			try {
+				const tab = await browser.tabs.get(tabId);
+				if (isReady(tab)) {
+					window.clearTimeout(timeout);
+					window.clearInterval(pollInterval);
+					browser.tabs.onUpdated.removeListener(listener);
+					resolve();
+				}
+			} catch (error) {
+				window.clearTimeout(timeout);
+				window.clearInterval(pollInterval);
+				browser.tabs.onUpdated.removeListener(listener);
+				reject(error);
+			}
+		};
+
+		const pollInterval = window.setInterval(finishIfReady, 250);
+
+		const listener = (updatedTabId: number) => {
+			if (updatedTabId === tabId) {
+				finishIfReady();
+			}
+		};
+
+		browser.tabs.onUpdated.addListener(listener);
+		finishIfReady();
+	});
+}
+
+function getBatchTabUrl(tab: browser.Tabs.Tab): string | undefined {
+	const pendingUrl = (tab as browser.Tabs.Tab & { pendingUrl?: string }).pendingUrl;
+	return tab.url || pendingUrl;
+}
+
+async function getBatchTabInfo(tabId: number): Promise<{ id: number; url: string }> {
+	const tab = await browser.tabs.get(tabId);
+	const url = getBatchTabUrl(tab);
+	if (tab.id && url) {
+		return { id: tab.id, url };
+	}
+	return getTabInfo(tabId);
+}
+
+async function prepareBatchClip(tabId: number): Promise<PreparedObsidianClip> {
+	if (templates.length === 0) {
+		throw new Error(getMessage('batchErrorNoTemplates'));
+	}
+
+	const tab = await getBatchTabInfo(tabId);
+	if (!tab.url || isBlankPage(tab.url) || !isValidUrl(tab.url) || isRestrictedUrl(tab.url)) {
+		throw new Error(getMessage('batchErrorCannotClipPage', tab.url || getMessage('batchUnknownUrl')));
+	}
+
+	const extractedData = await extractPageContent(tabId);
+	if (!extractedData) {
+		throw new Error(getMessage('batchErrorUnableExtract'));
+	}
+	assertNotLikelyBlockedByIntervention(extractedData);
+
+	const matchedTemplate = await findMatchingTemplate(tab.url, async () => extractedData.schemaOrgData);
+	const template = matchedTemplate || templates[0];
+	if (generalSettings.interpreterEnabled && collectPromptVariables(template).length > 0) {
+		throw new Error(getMessage('batchErrorInterpreterTemplate'));
+	}
+
+	const initializedContent = await initializePageContent(
+		extractedData.content,
+		extractedData.selectedHtml,
+		extractedData.extractedContent,
+		tab.url,
+		extractedData.schemaOrgData,
+		extractedData.fullHtml,
+		extractedData.highlights || [],
+		extractedData.title,
+		extractedData.author,
+		extractedData.description,
+		extractedData.favicon,
+		extractedData.image,
+		extractedData.published,
+		extractedData.site,
+		extractedData.wordCount,
+		extractedData.language || '',
+		extractedData.metaTags
+	);
+	if (!initializedContent) {
+		throw new Error(getMessage('batchErrorUnableInitialize'));
+	}
+
+	const variables = initializedContent.currentVariables;
+	const properties: Property[] = await Promise.all(template.properties.map(async property => {
+		const propertyType = generalSettings.propertyTypes.find(p => p.name === property.name)?.type || 'text';
+		const compiledValue = await compileTemplate(tabId, unescapeValue(property.value), variables, tab.url);
+		return {
+			...property,
+			value: formatPropertyValue(compiledValue, propertyType, property.value)
+		};
+	}));
+	const [noteName, path, noteContent] = await Promise.all([
+		compileTemplate(tabId, template.noteNameFormat, variables, tab.url),
+		compileTemplate(tabId, template.path, variables, tab.url),
+		template.noteContentFormat ? compileTemplate(tabId, template.noteContentFormat, variables, tab.url) : Promise.resolve('')
+	]);
+
+	const frontmatter = await generateFrontmatter(properties);
+	const selectedVault = template.vault || lastSelectedVault || loadedSettings.vaults[0] || '';
+	const isDailyNote = template.behavior === 'append-daily' || template.behavior === 'prepend-daily';
+
+	return {
+		fileContent: frontmatter + noteContent,
+		noteName: isDailyNote ? '' : noteName.trim(),
+		path: isDailyNote ? '' : path,
+		vault: selectedVault,
+		behavior: template.behavior,
+		title: extractedData.title,
+		url: tab.url,
+		contentLength: (frontmatter + noteContent).length,
+		templateName: template.name
+	};
+}
+
+function assertNotLikelyBlockedByIntervention(extractedData: Awaited<ReturnType<typeof extractPageContent>>) {
+	if (!extractedData) return;
+	const text = [
+		extractedData.title,
+		extractedData.description,
+		extractedData.content
+	].join(' ').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+	const blockerPattern = /\b(cookie|cookies|consent|privacy settings|accept all|reject all|subscribe to continue|sign in|log in|captcha|verify you are human|access denied|enable javascript)\b/i;
+	if ((extractedData.wordCount || 0) < 120 && blockerPattern.test(text)) {
+		throw new Error(getMessage('batchErrorIntervention'));
+	}
+}
+
+function remainingBatchTime(startedAt: number): number {
+	return Math.max(1000, BATCH_PAGE_TIMEOUT_MS - (Date.now() - startedAt));
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, createError: () => Error): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timeout = window.setTimeout(() => {
+			reject(createError());
+		}, timeoutMs);
+		promise.then(
+			value => {
+				window.clearTimeout(timeout);
+				resolve(value);
+			},
+			error => {
+				window.clearTimeout(timeout);
+				reject(error);
+			}
+		);
+	});
+}
+
+function throwIfBatchTimedOut(startedAt: number) {
+	if (Date.now() - startedAt > BATCH_PAGE_TIMEOUT_MS) {
+		throw new Error(getMessage('batchErrorPrepareTimeout'));
+	}
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function showError(messageKey: string): void {

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -7,6 +7,7 @@
 	"description": "Save and highlight web pages in a private and durable format that you can access offline. The official extension for Obsidian.",
 	"permissions": [
 		"activeTab",
+		"tabs",
 		"clipboardWrite",
 		"commands",
 		"contextMenus",
@@ -14,6 +15,9 @@
 		"storage",
 		"scripting",
 		"declarativeNetRequest"
+	],
+	"optional_permissions": [
+		"notifications"
 	],
 	"host_permissions": [
 		"<all_urls>",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -7,12 +7,16 @@
 	"description": "Save and highlight web pages in a private and durable format that you can access offline. The official extension for Obsidian.",
 	"permissions": [
 		"activeTab",
+		"tabs",
 		"clipboardWrite",
 		"contextMenus",
 		"storage",
 		"scripting",
 		"webRequest",
 		"webRequestBlocking"
+	],
+	"optional_permissions": [
+		"notifications"
 	],
 	"host_permissions": [
 		"<all_urls>",
@@ -90,10 +94,7 @@
 			}
 		},
 		"gecko_android": {
-			"strict_min_version": "113.0",
-			"data_collection_permissions": {
-				"required": ["none"]
-			}
+			"strict_min_version": "113.0"
 		}
 	}
 }

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -6,11 +6,15 @@
 	"description": "Save content from the web to Obsidian, in a private and durable format you can always access offline.",
 	"permissions": [
 		"activeTab",
+		"tabs",
 		"clipboardWrite",
 		"contextMenus",
 		"nativeMessaging",
 		"storage",
 		"scripting"
+	],
+	"optional_permissions": [
+		"notifications"
 	],
 	"host_permissions": [
 		"<all_urls>",

--- a/src/popup.html
+++ b/src/popup.html
@@ -30,6 +30,10 @@
 					data-i18n-title="openEmbedded">
 					<i data-lucide="picture-in-picture-2"></i>
 				</a>
+				<a href="#" id="batch-clipper" class="clickable-icon" 
+					data-i18n-title="batchClipUrls">
+					<i data-lucide="clipboard-list"></i>
+				</a>
 				<a href="#" id="open-settings" class="clickable-icon" 
 					data-i18n-title="settings">
 					<i data-lucide="settings"></i>

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -259,6 +259,187 @@
 	}
 }
 
+.batch-mode {
+	background: var(--background-primary);
+	color: var(--text-normal);
+	min-width: 720px;
+	min-height: 100vh;
+	overflow: auto;
+}
+
+#popup.is-batch-mode {
+	height: auto;
+	max-height: none;
+	overflow: auto;
+
+	#popup-container {
+		display: block;
+		width: 100%;
+		height: auto;
+		max-height: none;
+		overflow: auto;
+	}
+}
+
+.batch-clipper-page {
+	box-sizing: border-box;
+	width: min(960px, 100vw);
+	min-height: 100vh;
+	margin: 0 auto;
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.batch-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	border-bottom: 1px solid var(--divider-color);
+	padding-bottom: 16px;
+
+	h1 {
+		margin: 0 0 6px;
+		font-size: var(--font-ui-large);
+		font-weight: 700;
+	}
+
+	p {
+		margin: 0;
+		max-width: 720px;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+		line-height: 1.45;
+	}
+}
+
+.batch-main {
+	display: grid;
+	grid-template-columns: minmax(320px, 1fr) minmax(280px, 0.8fr);
+	gap: 20px;
+	align-items: stretch;
+}
+
+.batch-inputs,
+.batch-progress {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	min-width: 0;
+}
+
+.batch-inputs label {
+	font-size: var(--font-ui-small);
+	font-weight: 600;
+	color: var(--text-muted);
+}
+
+.batch-options {
+	display: grid;
+	grid-template-columns: minmax(100px, max-content) minmax(180px, 260px);
+	gap: 10px;
+	align-items: center;
+
+	label {
+		font-size: var(--font-ui-small);
+		font-weight: 600;
+		color: var(--text-muted);
+	}
+}
+
+#batch-url-list {
+	min-height: 420px;
+	width: 100%;
+	resize: vertical;
+	font-family: var(--font-monospace);
+	font-size: var(--font-ui-small);
+	line-height: 1.45;
+}
+
+.batch-controls {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.batch-progress-bar {
+	height: 8px;
+	width: 100%;
+	overflow: hidden;
+	border-radius: var(--radius-s);
+	background: var(--background-modifier-border);
+}
+
+#batch-progress-fill {
+	height: 100%;
+	width: 0;
+	background: var(--interactive-accent);
+	transition: width 0.15s ease;
+}
+
+#batch-summary {
+	min-height: 22px;
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+}
+
+#batch-timer {
+	min-height: 22px;
+	color: var(--text-normal);
+	font-size: var(--font-ui-small);
+	font-variant-numeric: tabular-nums;
+}
+
+#batch-log {
+	flex: 1;
+	min-height: 380px;
+	max-height: calc(100vh - 220px);
+	overflow: auto;
+	margin: 0;
+	padding-inline-start: 22px;
+	border: 1px solid var(--divider-color);
+	border-radius: var(--radius-s);
+	background: var(--background-secondary);
+	font-size: var(--font-ui-smaller);
+	line-height: 1.45;
+
+	li {
+		padding: 7px 10px 7px 0;
+		border-bottom: 1px solid var(--divider-color);
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+}
+
+@media (max-width: 760px) {
+	.batch-mode {
+		min-width: 0;
+	}
+
+	.batch-clipper-page {
+		padding: 16px;
+	}
+
+	.batch-main {
+		grid-template-columns: 1fr;
+	}
+
+	#batch-url-list {
+		min-height: 260px;
+	}
+
+	.batch-options {
+		grid-template-columns: 1fr;
+	}
+
+	#batch-log {
+		min-height: 240px;
+		max-height: none;
+	}
+}
+
 .is-tablet,
 .is-mobile {
 	.action-buttons {

--- a/src/utils/batch-utils.test.ts
+++ b/src/utils/batch-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { formatBatchDuration, parseBatchUrls } from './batch-utils';
+
+describe('parseBatchUrls', () => {
+	it('accepts one URL per line and normalizes missing protocols', () => {
+		const result = parseBatchUrls('example.com\nhttps://obsidian.md/path');
+
+		expect(result.urls).toEqual([
+			'https://example.com/',
+			'https://obsidian.md/path'
+		]);
+		expect(result.rejected).toEqual([]);
+	});
+
+	it('deduplicates URLs and rejects unsupported protocols', () => {
+		const result = parseBatchUrls('https://example.com\nhttps://example.com/\nftp://example.com/file');
+
+		expect(result.urls).toEqual(['https://example.com/']);
+		expect(result.rejected).toEqual(['ftp://example.com/file']);
+	});
+
+	it('does not split URLs on spaces within a line', () => {
+		const result = parseBatchUrls('https://example.com/article one');
+
+		expect(result.urls).toEqual([]);
+		expect(result.rejected).toEqual(['https://example.com/article one']);
+	});
+});
+
+describe('formatBatchDuration', () => {
+	it('formats milliseconds as mm:ss', () => {
+		expect(formatBatchDuration(0)).toBe('00:00');
+		expect(formatBatchDuration(65_400)).toBe('01:05');
+		expect(formatBatchDuration(-1000)).toBe('00:00');
+	});
+});

--- a/src/utils/batch-utils.ts
+++ b/src/utils/batch-utils.ts
@@ -1,0 +1,45 @@
+export interface ParsedBatchUrls {
+	urls: string[];
+	rejected: string[];
+}
+
+export function parseBatchUrls(raw: string): ParsedBatchUrls {
+	const urls: string[] = [];
+	const rejected: string[] = [];
+	const seen = new Set<string>();
+	const parts = raw
+		.split(/\r?\n/)
+		.map(part => part.trim())
+		.filter(Boolean);
+
+	for (const part of parts) {
+		if (/\s/.test(part)) {
+			rejected.push(part);
+			continue;
+		}
+		const candidate = /^[a-z][a-z\d+\-.]*:\/\//i.test(part) ? part : `https://${part}`;
+		try {
+			const parsed = new URL(candidate);
+			if (!['http:', 'https:'].includes(parsed.protocol)) {
+				rejected.push(part);
+				continue;
+			}
+			const normalized = parsed.href;
+			if (!seen.has(normalized)) {
+				seen.add(normalized);
+				urls.push(normalized);
+			}
+		} catch {
+			rejected.push(part);
+		}
+	}
+
+	return { urls, rejected };
+}
+
+export function formatBatchDuration(ms: number): string {
+	const totalSeconds = Math.max(0, Math.round(ms / 1000));
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}

--- a/src/utils/obsidian-note-creator.ts
+++ b/src/utils/obsidian-note-creator.ts
@@ -14,31 +14,89 @@ export async function generateFrontmatter(properties: Property[]): Promise<strin
 	return generateFrontmatterCore(properties, typeMap);
 }
 
-function openObsidianUrl(url: string): void {
-	browser.runtime.sendMessage({
-		action: "openObsidianUrl",
-		url: url
-	}).catch((error) => {
-		console.error('Error opening Obsidian URL via background script:', error);
-		window.open(url, '_blank');
-	});
+interface OpenObsidianUrlOptions {
+	targetTabId?: number;
+	silent?: boolean;
 }
 
-async function tryClipboardWrite(fileContent: string, obsidianUrl: string): Promise<void> {
+export interface SaveToObsidianDiagnostics {
+	urlLength: number;
+	usesClipboard: boolean;
+	usesUriContent: boolean;
+	silent: boolean;
+	targetTabId?: number;
+	fallbackReason?: string;
+}
+
+interface SaveToObsidianOptions extends OpenObsidianUrlOptions {
+	forceUriContent?: boolean;
+	maxUriLength?: number;
+	onUrlReady?: (diagnostics: SaveToObsidianDiagnostics) => void;
+}
+
+async function openObsidianUrl(url: string, options?: OpenObsidianUrlOptions): Promise<void> {
+	try {
+		const response = await browser.runtime.sendMessage({
+			action: "openObsidianUrl",
+			url: url,
+			targetTabId: options?.targetTabId
+		}) as { success?: boolean; error?: string } | undefined;
+
+		if (response?.success === false) {
+			throw new Error(response.error || 'Failed to open Obsidian URL');
+		}
+	} catch (error) {
+		console.error('Error opening Obsidian URL via background script:', error);
+		if (options?.targetTabId) {
+			throw error;
+		}
+		window.open(url, '_blank');
+	}
+}
+
+function isSilentObsidianHandoff(options?: SaveToObsidianOptions): boolean {
+	return generalSettings.silentOpen || !!options?.silent;
+}
+
+async function tryClipboardWrite(
+	fileContent: string,
+	obsidianUrl: string,
+	options?: SaveToObsidianOptions,
+	fallbackReason?: string
+): Promise<void> {
 	const success = await copyToClipboard(fileContent);
 	
 	if (success) {
 		// &clipboard tells Obsidian to read data from clipboard instead of the content param.
 		// content is a fallback shown only if Obsidian can't access the clipboard (e.g. on Linux).
 		obsidianUrl += `&clipboard&content=${encodeURIComponent(getMessage('clipboardError', 'https://help.obsidian.md/web-clipper/troubleshoot'))}`;
-		openObsidianUrl(obsidianUrl);
+		options?.onUrlReady?.({
+			urlLength: obsidianUrl.length,
+			usesClipboard: true,
+			usesUriContent: false,
+			silent: isSilentObsidianHandoff(options),
+			targetTabId: options?.targetTabId,
+			fallbackReason
+		});
+		await openObsidianUrl(obsidianUrl, options);
 		console.log('Obsidian URL:', obsidianUrl);
 	} else {
 		console.error('All clipboard methods failed, falling back to URI method');
 		// Final fallback: use URI method with actual content (same as legacy mode)
 		// Note: We don't add &clipboard here since we're bypassing the clipboard entirely
 		obsidianUrl += `&content=${encodeURIComponent(fileContent)}`;
-		openObsidianUrl(obsidianUrl);
+		options?.onUrlReady?.({
+			urlLength: obsidianUrl.length,
+			usesClipboard: false,
+			usesUriContent: true,
+			silent: isSilentObsidianHandoff(options),
+			targetTabId: options?.targetTabId,
+			fallbackReason: fallbackReason || 'clipboard-unavailable'
+		});
+		if (options?.maxUriLength && obsidianUrl.length > options.maxUriLength) {
+			throw new Error(getMessage('batchErrorNoteTooLarge', obsidianUrl.length.toString()));
+		}
+		await openObsidianUrl(obsidianUrl, options);
 		console.log('Obsidian URL (URI fallback):', obsidianUrl);
 	}
 }
@@ -49,6 +107,7 @@ export async function saveToObsidian(
 	path: string,
 	vault: string,
 	behavior: Template['behavior'],
+	options?: SaveToObsidianOptions,
 ): Promise<void> {
 	let obsidianUrl: string;
 
@@ -77,18 +136,28 @@ export async function saveToObsidian(
 	const vaultParam = vault ? `&vault=${encodeURIComponent(vault)}` : '';
 	obsidianUrl += vaultParam;
 
-	// Add silent parameter if silentOpen is enabled
-	if (generalSettings.silentOpen) {
+	// Add silent parameter if silentOpen is enabled or a caller explicitly asks for it.
+	if (isSilentObsidianHandoff(options)) {
 		obsidianUrl += '&silent=true';
 	}
 
-	if (generalSettings.legacyMode) {
+	if (generalSettings.legacyMode || options?.forceUriContent) {
 		// Use the URI method
-		obsidianUrl += `&content=${encodeURIComponent(fileContent)}`;
-		console.log('Obsidian URL:', obsidianUrl);
-		openObsidianUrl(obsidianUrl);
+		const uriContentUrl = `${obsidianUrl}&content=${encodeURIComponent(fileContent)}`;
+		options?.onUrlReady?.({
+			urlLength: uriContentUrl.length,
+			usesClipboard: false,
+			usesUriContent: true,
+			silent: isSilentObsidianHandoff(options),
+			targetTabId: options?.targetTabId
+		});
+		if (options?.maxUriLength && uriContentUrl.length > options.maxUriLength) {
+			throw new Error(getMessage('batchErrorNoteTooLarge', uriContentUrl.length.toString()));
+		}
+		console.log('Obsidian URL:', uriContentUrl);
+		await openObsidianUrl(uriContentUrl, options);
 	} else {
 		// Try to copy to clipboard with fallback mechanisms
-		await tryClipboardWrite(fileContent, obsidianUrl);
+		await tryClipboardWrite(fileContent, obsidianUrl, options);
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -144,6 +144,7 @@ module.exports = (env, argv) => {
 						to: "manifest.json" 
 					},
 					{ from: "src/popup.html", to: "popup.html" },
+					{ from: "src/batch.html", to: "batch.html" },
 					{ from: "src/side-panel.html", to: "side-panel.html" },
 					{ from: "src/settings.html", to: "settings.html" },
 					{ from: "src/highlights.html", to: "highlights.html" },


### PR DESCRIPTION
## Summary

Adds a batch URL clipping workflow to Web Clipper:

- opens a dedicated Batch clip URLs page from the popup toolbar
- accepts one URL per line, normalizes/deduplicates HTTP(S) URLs, and reports rejected entries
- processes URLs in fixed windows of 5 so large batches do not open unbounded tabs
- waits for page load, best-effort scrolls pages for lazy-loaded content, then clips using the normal template pipeline
- saves prepared clips in input order using the same clipboard-first Obsidian handoff as manual clipping
- closes successfully saved tabs and leaves failed tabs open for manual attention/retry
- shows elapsed time, progress counts, completion alerts, and UI-only debug details for failures

## Notes

- Batch mode requests `tabs` permission to create, inspect, update, and close tabs it opens.
- Completion notifications use optional `notifications` permission and are requested only when notification alerts are selected.
- Batch clipping does not support Interpreter prompt-variable templates yet; those fail with a clear log message so unresolved prompt placeholders are not saved silently.
- `obsidian://` handoff can confirm browser/protocol dispatch, but not that Obsidian has finished writing the note. Batch saves are serialized and delayed to avoid clipboard races as much as possible within the existing zero-setup save path.
- Firefox manifest cleanup removes the invalid `gecko_android.data_collection_permissions` entry while keeping the valid Firefox data collection declaration under `gecko`.

## Validation

- `git diff --check`
- `npx vitest run src/utils/batch-utils.test.ts`
- `TZ=America/Los_Angeles npm test` (57 files, 582 tests)
- `npm run build:firefox`
- `npm run build` (Chrome, Firefox, Safari; existing webpack bundle-size warnings only)

Also manually tested in Firefox with an 11-URL batch including Reddit pages and a large page that clips successfully via the normal clipboard handoff.
