### PR TITLE
Fix reading view direction for right-to-left articles

### DIFF
--- a/src/core/reader-view.ts
+++ b/src/core/reader-view.ts
@@ -47,6 +47,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 		const parsedDoc = parser.parseFromString(html, 'text/html');
 		Object.defineProperty(parsedDoc, 'URL', { value: url, configurable: true });
 
+		// Capture the source document's declared direction (some RTL pages set dir
+		// without a lang) to carry onto the reader page alongside the language. (#864)
+		const sourceDir = parsedDoc.documentElement.getAttribute('dir') || parsedDoc.body?.getAttribute('dir') || undefined;
+
 		const defuddle = new Defuddle(parsedDoc, { url, fetch: proxyFetchAsResponse });
 		const result = await defuddle.parseAsync();
 
@@ -62,6 +66,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 			domain: getDomain(url),
 			wordCount: result.wordCount,
 			parseTime: result.parseTime,
+			language: result.language,
+			dir: sourceDir,
 		};
 
 		Reader.isReaderPage = true;
@@ -219,6 +225,10 @@ async function loadArticle(newUrl: string) {
 		const parsedDoc = parser.parseFromString(html, 'text/html');
 		Object.defineProperty(parsedDoc, 'URL', { value: newUrl, configurable: true });
 
+		// Capture the source document's declared direction to mirror correctly on
+		// in-reader navigation, even when the page omits a lang. (#864)
+		const sourceDir = parsedDoc.documentElement.getAttribute('dir') || parsedDoc.body?.getAttribute('dir') || undefined;
+
 		const defuddle = new Defuddle(parsedDoc, { url: newUrl, fetch: proxyFetchAsResponse });
 		const result = await defuddle.parseAsync();
 
@@ -244,6 +254,8 @@ async function loadArticle(newUrl: string) {
 			domain: getDomain(newUrl),
 			wordCount: result.wordCount,
 			parseTime: result.parseTime,
+			language: result.language,
+			dir: sourceDir,
 		});
 
 		setupReaderPageMessageHandler(newUrl, result);

--- a/src/utils/i18n.test.ts
+++ b/src/utils/i18n.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'vitest';
+import { isRTLLanguage } from './i18n';
+
+// The reading view derives its text direction from the article language via
+// isRTLLanguage (see Reader.apply / updateReaderContent), so the RTL language
+// set is part of the reader's contract. (#864)
+describe('isRTLLanguage', () => {
+	test('detects right-to-left languages', () => {
+		for (const code of ['ar', 'fa', 'he', 'ur', 'ps', 'sd', 'dv', 'yi', 'ckb', 'syr']) {
+			expect(isRTLLanguage(code)).toBe(true);
+		}
+	});
+
+	test('normalizes case and ignores region subtags', () => {
+		expect(isRTLLanguage('AR')).toBe(true);
+		expect(isRTLLanguage('ar-EG')).toBe(true);
+		expect(isRTLLanguage('fa-IR')).toBe(true);
+		expect(isRTLLanguage('he-IL')).toBe(true);
+	});
+
+	test('treats left-to-right and unknown languages as non-RTL', () => {
+		for (const code of ['en', 'en-US', 'fr', 'de', 'es', 'ja', 'zh', 'ru', 'tr', '']) {
+			expect(isRTLLanguage(code)).toBe(false);
+		}
+	});
+});

--- a/src/utils/reader.test.ts
+++ b/src/utils/reader.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from 'vitest';
+import { Reader } from './reader';
+
+// Runtime exercise of the reader's text-direction logic (#864). applyReaderDirection
+// is the single shared helper used by every reader path (live page, standalone
+// reader page, and in-reader navigation), so testing it covers the contract for all.
+const applyDir = (doc: Document, sourceDir: string | null | undefined, language: string | null | undefined) =>
+	(Reader as unknown as {
+		applyReaderDirection: (d: Document, s?: string | null, l?: string | null) => void;
+	}).applyReaderDirection(doc, sourceDir, language);
+
+function freshDoc(): Document {
+	return document.implementation.createHTMLDocument('test');
+}
+
+describe('reader direction (applyReaderDirection)', () => {
+	test('derives dir="rtl" from an RTL article language', () => {
+		const doc = freshDoc();
+		applyDir(doc, undefined, 'ar');
+		expect(doc.documentElement.getAttribute('dir')).toBe('rtl');
+	});
+
+	test('handles other RTL languages and region subtags', () => {
+		for (const lang of ['fa', 'he', 'ur', 'ar-EG']) {
+			const doc = freshDoc();
+			applyDir(doc, undefined, lang);
+			expect(doc.documentElement.getAttribute('dir')).toBe('rtl');
+		}
+	});
+
+	test('leaves no dir for an LTR language', () => {
+		const doc = freshDoc();
+		applyDir(doc, undefined, 'en');
+		expect(doc.documentElement.getAttribute('dir')).toBeNull();
+	});
+
+	test('honors an explicit source dir even when the page declares no language', () => {
+		const doc = freshDoc();
+		applyDir(doc, 'rtl', undefined);
+		expect(doc.documentElement.getAttribute('dir')).toBe('rtl');
+	});
+
+	test('an explicit source dir takes precedence over the language', () => {
+		const doc = freshDoc();
+		applyDir(doc, 'ltr', 'ar');
+		expect(doc.documentElement.getAttribute('dir')).toBe('ltr');
+	});
+
+	test('resets a stale direction when navigating to an LTR article', () => {
+		const doc = freshDoc();
+		applyDir(doc, undefined, 'ar');
+		expect(doc.documentElement.getAttribute('dir')).toBe('rtl');
+		applyDir(doc, undefined, 'en');
+		expect(doc.documentElement.getAttribute('dir')).toBeNull();
+	});
+});

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -5,6 +5,7 @@ import { flattenShadowDom as flattenShadowDomUtil } from './flatten-shadow-dom';
 import { getLocalStorage, setLocalStorage } from './storage-utils';
 import hljs from 'highlight.js';
 import { getDomain } from './string-utils';
+import { isRTLLanguage } from './i18n';
 import type { HighlighterAPI } from './highlighter';
 import * as localHighlighter from './highlighter';
 import { removeExistingHighlights as localRemoveExistingHighlights } from './highlighter-overlays';
@@ -47,6 +48,8 @@ interface ReaderContent {
 	wordCount?: number;
 	parseTime?: number;
 	extractorType?: string;
+	language?: string;
+	dir?: string;
 }
 
 export class Reader {
@@ -71,6 +74,8 @@ export class Reader {
 		wordCount?: number;
 		parseTime?: number;
 		extractorType?: string;
+		language?: string;
+		dir?: string;
 	} | null = null;
 
 	/**
@@ -881,8 +886,23 @@ export class Reader {
 			published: defuddled.published,
 			domain: getDomain(doc.URL),
 			wordCount: defuddled.wordCount,
-			parseTime: defuddled.parseTime
+			parseTime: defuddled.parseTime,
+			language: defuddled.language
 		};
+	}
+
+	// Apply the reader's text direction (#864). Honors an explicit source
+	// direction when known, otherwise derives RTL from the article language via
+	// isRTLLanguage. Shared by every reader path (live page, standalone reader,
+	// in-reader navigation) so they cannot drift, and clears any stale direction
+	// left by a previously rendered article.
+	private static applyReaderDirection(doc: Document, sourceDir?: string | null, language?: string | null): void {
+		const dir = sourceDir || (language && isRTLLanguage(language) ? 'rtl' : null);
+		if (dir) {
+			doc.documentElement.setAttribute('dir', dir);
+		} else {
+			doc.documentElement.removeAttribute('dir');
+		}
 	}
 
 	private static generateOutline(doc: Document, title?: string) {
@@ -2069,9 +2089,9 @@ export class Reader {
 				htmlElement.removeAttribute(htmlElement.attributes[0].name);
 			}
 
-			// Restore lang and dir if they existed
+			// Restore lang if it existed. Direction is applied below via
+			// applyReaderDirection once the article language is known. (#864)
 			if (lang) htmlElement.setAttribute('lang', lang);
-			if (dir) htmlElement.setAttribute('dir', dir);
 
 			// Clean up head - remove unwanted elements but keep meta tags and non-stylesheet links
 			const head = doc.head;
@@ -2247,10 +2267,15 @@ export class Reader {
 			}
 
 			// Now await content extraction and populate the page
-			const { content, title, author, published, domain, extractorType, wordCount, parseTime } = await contentPromise;
+			const { content, title, author, published, domain, extractorType, wordCount, parseTime, language, dir: contentDir } = await contentPromise;
 
 			// If reader was toggled off while waiting, abort
 			if (!this.isActive) return;
+
+			// Apply the reader's text direction now that the article is known (#864).
+			// Prefer an explicit source dir (the page's own on the live path, or the
+			// fetched article's on the reader page), then derive RTL from the language.
+			this.applyReaderDirection(doc, contentDir || dir, language);
 
 			// Remove loading spinner
 			spinner.remove();
@@ -2693,6 +2718,9 @@ export class Reader {
 	static async updateReaderContent(doc: Document, content: ReaderContent): Promise<void> {
 		const main = doc.querySelector('.obsidian-reader-content main') as HTMLElement | null;
 		if (!main) return;
+
+		// Keep the reader direction in sync when navigating between articles. (#864)
+		this.applyReaderDirection(doc, content.dir, content.language);
 
 		this.teardownContent(doc);
 		main.textContent = '';


### PR DESCRIPTION
## Summary
The reading view stayed left-aligned for right-to-left articles (Arabic, Persian, Hebrew, and others), which makes them hard to read. This derives the reader's text direction from the article so RTL pages mirror correctly. Closes #864.

## Root cause
`Reader.apply()` only re-applied a `dir` that the source `<html>` already carried. Many RTL pages declare `lang` but omit an explicit `dir`, so the reader kept the default LTR direction. The standalone `reader.html` and in-reader navigation paths never carried the source direction at all, since there `<html>` belongs to `reader.html` (`lang="en"`), not to the article.

## Changes
Defuddle already reports the article language (`result.language`). This threads it through `ReaderContent` and centralizes direction in one helper, `applyReaderDirection`, shared by all three reader paths (live page, standalone reader page, in-reader navigation). Resolution order: honor an explicit source `dir` if present, otherwise derive `rtl` from the language via the existing `isRTLLanguage()` helper, otherwise clear any stale direction.

## Design notes
- Direction is derived from the article language, not `dir="auto"`. `auto` infers base direction from the first strong character, so an Arabic paragraph starting with a Latin word (for example "Google هي شركة ...") would flip to LTR. Deriving from the language avoids that. Inline mixed runs are still handled by the browser bidi algorithm.
- No CSS changes: the reader styles already use logical properties (`padding-inline-*`, `text-align: start`), so setting `dir` mirrors alignment.
- An author-declared `dir` is always respected and never overridden.

## Tests
Added `i18n.test.ts` (`isRTLLanguage`) and `reader.test.ts` (`applyReaderDirection`: RTL languages and region subtags, LTR untouched, explicit `dir` precedence, stale reset on navigation).

## Known limitation
A page declaring neither a language nor a `dir`, and whose language cannot be detected, still renders LTR (no signal to infer direction). Unchanged from current behavior and out of scope here.
