### PR TITLE
Fix error with interpreter by simplifying finding elements to remove for the remove_html filter

### DIFF
--- a/src/utils/filters/remove_html.ts
+++ b/src/utils/filters/remove_html.ts
@@ -25,17 +25,7 @@ export const remove_html = (html: string, params: string = ''): string => {
 	const doc = parser.parseFromString(html, 'text/html');
 
 	elementsToRemove.forEach(elem => {
-		let elements: NodeListOf<Element> | HTMLCollectionOf<Element>;
-		if (elem.startsWith('.')) {
-			// Class selector
-			elements = doc.querySelectorAll(`[class*="${elem.slice(1)}"]`);
-		} else if (elem.startsWith('#')) {
-			// ID selector
-			elements = doc.querySelectorAll(`[id="${elem.slice(1)}"]`);
-		} else {
-			// Tag selector
-			elements = doc.getElementsByTagName(elem);
-		}
+    	let elements: NodeListOf<Element> | HTMLCollectionOf<Element> = doc.querySelectorAll(elem);
 
 		// Convert HTMLCollection to Array if necessary
 		Array.from(elements).forEach(el => el.parentNode?.removeChild(el));

--- a/src/utils/filters/remove_html.ts
+++ b/src/utils/filters/remove_html.ts
@@ -25,7 +25,7 @@ export const remove_html = (html: string, params: string = ''): string => {
 	const doc = parser.parseFromString(html, 'text/html');
 
 	elementsToRemove.forEach(elem => {
-    	let elements: NodeListOf<Element> | HTMLCollectionOf<Element> = doc.querySelectorAll(elem);
+		let elements: NodeListOf<Element> | HTMLCollectionOf<Element> = doc.querySelectorAll(elem);
 
 		// Convert HTMLCollection to Array if necessary
 		Array.from(elements).forEach(el => el.parentNode?.removeChild(el));


### PR DESCRIPTION
The default filter sent to remove_html for interpreter includes `.footer`. The implementation for removing elements by class used ```doc.querySelectorAll(`[class*="${elem.slice(1)}"]`);``` This selected any element that had any class with the word `footer` within the class name. 

Very commonly, wordpress sites have the class `footer-on-bottom` on the body element. This lead to the body element being removed and the exception "Cannot read properties of null (reading 'childNodes')" as well as the failed use of the interpreter because it received no content.

I do not know whether this was intentional behavior. Selecting any element via `.classname`, which looks like a DOM selector but also matching `.my-classname` or `.some-classnameshere` seems unexpected. 

I noticed when editing this to narrow that filter that the entire filter could be simplified to use `querySelectorAll`. I manually tested in browser. The only change in behavior is that fewer elements will be removed than before when using class based selectors. The tag selector always fell through to `querySelectorAll` and so any selector that did not start with `.` or `#` could be used.

I started to add a test for `remove_html` but quickly realized there are not tests for it because it uses `DOMParser`. If interested, I'd be happy to set up tests that run in-browser so such things can be tested. 

Fixes #618 

Edited to add: No LLM was used in the creation of this PR. I just write verbose PR descriptions. I've been a member of the [Ember.js core team](https://emberjs.com/teams/) for over a decade and so hopefully can be trusted with DOM apis. 