### PR TITLE
Import highlights

### DIFF
--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "التمييزات"
 	},
+	"highlightsImportSuccess": {
+		"message": "تم استيراد $1 من التمييزات.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "لم يتم العثور على تمييزات في المقالة"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "فشل الاستيراد. يرجى التحقق من وحدة التحكم لمزيد من التفاصيل."
+	},
+	"importHighlights": {
+		"message": "استيراد التمييزات"
+	},
+	"importHighlightsDescription": {
+		"message": "استورد التمييزات من ملف. سيتم الاحتفاظ بالتمييزات الحالية."
 	},
 	"importModalTitle": {
 		"message": "استيراد"

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "হাইলাইট"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1টি হাইলাইট আমদানি করা হয়েছে।",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "আর্টিকেলে হাইলাইট পাওয়া যায়নি"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "ইম্পোর্ট ব্যর্থ হয়েছে। আরও বিস্তারিত জানার জন্য কনসোলটি চেক করুন।"
+	},
+	"importHighlights": {
+		"message": "হাইলাইট আমদানি করুন"
+	},
+	"importHighlightsDescription": {
+		"message": "একটি ফাইল থেকে হাইলাইট আমদানি করুন। বিদ্যমান হাইলাইটগুলো রাখা হবে।"
 	},
 	"importModalTitle": {
 		"message": "ইম্পোর্ট"

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Ressaltats"
 	},
+	"highlightsImportSuccess": {
+		"message": "S'han importat $1 destacats.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "No s'han trobat ressaltats a l'article"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "La importació ha fallat. Consulti la consola per obtenir més detalls."
+	},
+	"importHighlights": {
+		"message": "Importa destacats"
+	},
+	"importHighlightsDescription": {
+		"message": "Importa destacats des d'un fitxer. Es conserven els destacats existents."
 	},
 	"importModalTitle": {
 		"message": "Importar"

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Zvýrazněné pasáže"
 	},
+	"highlightsImportSuccess": {
+		"message": "Importováno $1 zvýraznění.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "V článku nebyly nalezeny žádné zvýrazněné pasáže"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import selhal. Zkontrolujte konzoli pro více informací."
+	},
+	"importHighlights": {
+		"message": "Importovat zvýraznění"
+	},
+	"importHighlightsDescription": {
+		"message": "Importujte zvýraznění ze souboru. Existující zvýraznění se zachovají."
 	},
 	"importModalTitle": {
 		"message": "Importovat"

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Markeringer"
 	},
+	"highlightsImportSuccess": {
+		"message": "Importerede $1 fremhævninger.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Markeringer blev ikke fundet i artiklen"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import mislykkedes. Tjek konsollen for detaljer."
+	},
+	"importHighlights": {
+		"message": "Importér fremhævninger"
+	},
+	"importHighlightsDescription": {
+		"message": "Importér fremhævninger fra en fil. Eksisterende fremhævninger bevares."
 	},
 	"importModalTitle": {
 		"message": "Importér"

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Hervorhebungen"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 Highlights importiert.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Keine Hervorhebungen im Artikel gefunden"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import fehlgeschlagen. Bitte überprüfe die Konsole für weitere Details."
+	},
+	"importHighlights": {
+		"message": "Highlights importieren"
+	},
+	"importHighlightsDescription": {
+		"message": "Highlights aus einer Datei importieren. Vorhandene Highlights bleiben erhalten."
 	},
 	"importModalTitle": {
 		"message": "Importieren"

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Επισημάνσεις"
 	},
+	"highlightsImportSuccess": {
+		"message": "Εισήχθησαν $1 επισημάνσεις.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Δεν βρέθηκαν επισημάνσεις στο άρθρο"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Η εισαγωγή απέτυχε. Ελέγξτε την κονσόλα για περισσότερες πληροφορίες."
+	},
+	"importHighlights": {
+		"message": "Εισαγωγή επισημάνσεων"
+	},
+	"importHighlightsDescription": {
+		"message": "Εισαγωγή επισημάνσεων από αρχείο. Οι υπάρχουσες επισημάνσεις διατηρούνται."
 	},
 	"importModalTitle": {
 		"message": "Εισαγωγή"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Highlights"
 	},
+	"highlightsImportSuccess": {
+		"message": "Imported $1 highlights.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Highlights not found in article"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import failed. Please check the console for more details."
+	},
+	"importHighlights": {
+		"message": "Import highlights"
+	},
+	"importHighlightsDescription": {
+		"message": "Import highlights from a file. Existing highlights are kept."
 	},
 	"importModalTitle": {
 		"message": "Import"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Resaltados"
 	},
+	"highlightsImportSuccess": {
+		"message": "Se importaron $1 resaltados.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "No se encontraron resaltados en el artículo"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "La importación falló. Por favor, consulte la consola para más detalles."
+	},
+	"importHighlights": {
+		"message": "Importar resaltados"
+	},
+	"importHighlightsDescription": {
+		"message": "Importa resaltados desde un archivo. Los resaltados existentes se conservan."
 	},
 	"importModalTitle": {
 		"message": "Importar"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "هایلایت‌ها"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 هایلایت وارد شد.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "هایلایت‌ها در مقاله پیدا نشدند"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "وارد کردن با شکست مواجه شد. لطفا برای جزئیات بیشتر، کنسول را بررسی کنید."
+	},
+	"importHighlights": {
+		"message": "وارد کردن هایلایت‌ها"
+	},
+	"importHighlightsDescription": {
+		"message": "هایلایت‌ها را از یک فایل وارد کنید. هایلایت‌های موجود حفظ می‌شوند."
 	},
 	"importModalTitle": {
 		"message": "وارد کردن"

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Korostukset"
 	},
+	"highlightsImportSuccess": {
+		"message": "Tuotiin $1 korostusta.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Artikkelista ei löytynyt korostuksia"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Tuonti epäonnistui. Tarkista konsoli lisätietoja varten."
+	},
+	"importHighlights": {
+		"message": "Tuo korostukset"
+	},
+	"importHighlightsDescription": {
+		"message": "Tuo korostukset tiedostosta. Olemassa olevat korostukset säilytetään."
 	},
 	"importModalTitle": {
 		"message": "Tuo"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Surlignages"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 surlignages importés.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Surlignages introuvables dans l’article"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "L'importation a échoué. Veuillez vérifier la console pour plus de détails."
+	},
+	"importHighlights": {
+		"message": "Importer des surlignages"
+	},
+	"importHighlightsDescription": {
+		"message": "Importer des surlignages depuis un fichier. Les surlignages existants sont conservés."
 	},
 	"importModalTitle": {
 		"message": "Importer"

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "הדגשות"
 	},
+	"highlightsImportSuccess": {
+		"message": "יובאו $1 הדגשות.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "לא נמצאו הדגשות במאמר"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "הייבוא נכשל. בדוק את המסוף למידע נוסף."
+	},
+	"importHighlights": {
+		"message": "ייבוא הדגשות"
+	},
+	"importHighlightsDescription": {
+		"message": "ייבוא הדגשות מקובץ. הדגשות קיימות יישמרו."
 	},
 	"importModalTitle": {
 		"message": "ייבא"

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "हाइलाइट्स"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 हाइलाइट्स आयात किए गए।",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "लेख में हाइलाइट्स नहीं मिले"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import fail. Details ke liye console check karein."
+	},
+	"importHighlights": {
+		"message": "हाइलाइट्स आयात करें"
+	},
+	"importHighlightsDescription": {
+		"message": "फ़ाइल से हाइलाइट्स आयात करें। मौजूदा हाइलाइट्स रखे जाते हैं।"
 	},
 	"importModalTitle": {
 		"message": "Import"

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Kiemelések"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 kiemelés importálva.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Nem találhatók kiemelések a cikkben"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Az importálás sikertelen. További részletekért ellenőrizd a konzolt."
+	},
+	"importHighlights": {
+		"message": "Kiemelések importálása"
+	},
+	"importHighlightsDescription": {
+		"message": "Kiemelések importálása fájlból. A meglévő kiemelések megmaradnak."
 	},
 	"importModalTitle": {
 		"message": "Importálás"

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Sorotan"
 	},
+	"highlightsImportSuccess": {
+		"message": "Berhasil mengimpor $1 sorotan.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Sorotan tidak ditemukan dalam artikel"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Impor gagal. Silakan periksa konsol untuk detail lebih lanjut."
+	},
+	"importHighlights": {
+		"message": "Impor sorotan"
+	},
+	"importHighlightsDescription": {
+		"message": "Impor sorotan dari file. Sorotan yang sudah ada akan tetap disimpan."
 	},
 	"importModalTitle": {
 		"message": "Impor"

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Evidenziazioni"
 	},
+	"highlightsImportSuccess": {
+		"message": "Importati $1 evidenziazioni.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Evidenziazioni non trovate nell’articolo"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Importazione fallita. Controlla la console per maggiori dettagli."
+	},
+	"importHighlights": {
+		"message": "Importa evidenziazioni"
+	},
+	"importHighlightsDescription": {
+		"message": "Importa evidenziazioni da un file. Le evidenziazioni esistenti vengono mantenute."
 	},
 	"importModalTitle": {
 		"message": "Importa"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "ハイライト"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1件のハイライトをインポートしました。",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "記事内にハイライトが見つかりません"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "\"インポートに失敗しました。詳細はコンソールを確認してください。\""
+	},
+	"importHighlights": {
+		"message": "ハイライトをインポート"
+	},
+	"importHighlightsDescription": {
+		"message": "ファイルからハイライトをインポートします。既存のハイライトは保持されます。"
 	},
 	"importModalTitle": {
 		"message": "\"インポート\""

--- a/src/_locales/km/messages.json
+++ b/src/_locales/km/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "ការរំលេច"
 	},
+	"highlightsImportSuccess": {
+		"message": "បាននាំចូលការរំលេច $1។",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "រកមិនឃើញការរំលេចនៅក្នុងអត្ថបទ"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "ការនាំចូលបានបរាជ័យ។ សូមពិនិត្យ console សម្រាប់ព័ត៌មានលម្អិតបន្ថែម។"
+	},
+	"importHighlights": {
+		"message": "នាំចូលការរំលេច"
+	},
+	"importHighlightsDescription": {
+		"message": "នាំចូលការរំលេចពីឯកសារ។ ការរំលេចដែលមានស្រាប់នឹងត្រូវរក្សាទុក។"
 	},
 	"importModalTitle": {
 		"message": "នាំចូល"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "하이라이트"
 	},
+	"highlightsImportSuccess": {
+		"message": "하이라이트 $1개를 가져왔습니다.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "문서에서 하이라이트를 찾을 수 없습니다"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "가져오기 실패했습니다. 자세한 내용은 콘솔을 확인해 주세요."
+	},
+	"importHighlights": {
+		"message": "하이라이트 가져오기"
+	},
+	"importHighlightsDescription": {
+		"message": "파일에서 하이라이트를 가져옵니다. 기존 하이라이트는 유지됩니다."
 	},
 	"importModalTitle": {
 		"message": "수입"

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Markeringen"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 highlights geïmporteerd.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Geen markeringen gevonden in artikel"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Importeren mislukt. Controleer de console voor meer details."
+	},
+	"importHighlights": {
+		"message": "Highlights importeren"
+	},
+	"importHighlightsDescription": {
+		"message": "Importeer highlights uit een bestand. Bestaande highlights blijven behouden."
 	},
 	"importModalTitle": {
 		"message": "Importeren"

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Uthevinger"
 	},
+	"highlightsImportSuccess": {
+		"message": "Importerte $1 markeringer.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Fant ingen uthevinger i artikkelen"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import mislyktes. Sjekk konsollen for detaljer."
+	},
+	"importHighlights": {
+		"message": "Importer markeringer"
+	},
+	"importHighlightsDescription": {
+		"message": "Importer markeringer fra en fil. Eksisterende markeringer beholdes."
 	},
 	"importModalTitle": {
 		"message": "Importer"

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Wyróżnienia"
 	},
+	"highlightsImportSuccess": {
+		"message": "Zaimportowano $1 wyróżnień.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Nie znaleziono wyróżnień w artykule"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import nie powiódł się. Sprawdź konsolę, aby uzyskać więcej informacji."
+	},
+	"importHighlights": {
+		"message": "Importuj wyróżnienia"
+	},
+	"importHighlightsDescription": {
+		"message": "Importuj wyróżnienia z pliku. Istniejące wyróżnienia zostaną zachowane."
 	},
 	"importModalTitle": {
 		"message": "Importuj"

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Destaques"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 destaques importados.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Destaques não encontrados no artigo"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Falha na importação. Consulte a consola para mais detalhes."
+	},
+	"importHighlights": {
+		"message": "Importar destaques"
+	},
+	"importHighlightsDescription": {
+		"message": "Importe destaques de um ficheiro. Os destaques existentes são mantidos."
 	},
 	"importModalTitle": {
 		"message": "Importar"

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Destaques"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 destaques importados.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Destaques não encontrados no artigo"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Importação falhou. Por favor, verifique o console para mais detalhes."
+	},
+	"importHighlights": {
+		"message": "Importar destaques"
+	},
+	"importHighlightsDescription": {
+		"message": "Importe destaques de um arquivo. Os destaques existentes são mantidos."
 	},
 	"importModalTitle": {
 		"message": "Importar"

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Evidențieri"
 	},
+	"highlightsImportSuccess": {
+		"message": "S-au importat $1 evidențieri.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Evidențierile nu au fost găsite în articol"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Importul a eșuat. Verifică consola pentru detalii."
+	},
+	"importHighlights": {
+		"message": "Importă evidențieri"
+	},
+	"importHighlightsDescription": {
+		"message": "Importă evidențieri dintr-un fișier. Evidențierile existente sunt păstrate."
 	},
 	"importModalTitle": {
 		"message": "Importă"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Выделения"
 	},
+	"highlightsImportSuccess": {
+		"message": "Импортировано $1 выделений.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "В статье не найдены выделения"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Импорт не удался. Пожалуйста, проверьте консоль для получения дополнительной информации."
+	},
+	"importHighlights": {
+		"message": "Импортировать выделения"
+	},
+	"importHighlightsDescription": {
+		"message": "Импортируйте выделения из файла. Существующие выделения сохраняются."
 	},
 	"importModalTitle": {
 		"message": "Импорт"

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Zvýraznenia"
 	},
+	"highlightsImportSuccess": {
+		"message": "Importovaných zvýraznení: $1.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "V článku sa nenašli zvýraznenia"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Import zlyhal. Ďalšie podrobnosti nájdete v konzole."
+	},
+	"importHighlights": {
+		"message": "Importovať zvýraznenia"
+	},
+	"importHighlightsDescription": {
+		"message": "Importujte zvýraznenia zo súboru. Existujúce zvýraznenia sa zachovajú."
 	},
 	"importModalTitle": {
 		"message": "Importovať"

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Markeringar"
 	},
+	"highlightsImportSuccess": {
+		"message": "Importerade $1 markeringar.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Inga markeringar hittades i artikeln"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Importen misslyckades. Kontrollera konsolen för mer information."
+	},
+	"importHighlights": {
+		"message": "Importera markeringar"
+	},
+	"importHighlightsDescription": {
+		"message": "Importera markeringar från en fil. Befintliga markeringar behålls."
 	},
 	"importModalTitle": {
 		"message": "Importera"

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "ไฮไลต์"
 	},
+	"highlightsImportSuccess": {
+		"message": "นำเข้าไฮไลต์แล้ว $1 รายการ",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "ไม่พบไฮไลต์ในบทความ"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "การนำเข้าล้มเหลว ตรวจสอบคอนโซลสำหรับข้อมูลเพิ่มเติม"
+	},
+	"importHighlights": {
+		"message": "นำเข้าไฮไลต์"
+	},
+	"importHighlightsDescription": {
+		"message": "นำเข้าไฮไลต์จากไฟล์ ไฮไลต์ที่มีอยู่จะถูกเก็บไว้"
 	},
 	"importModalTitle": {
 		"message": "นำเข้า"

--- a/src/_locales/tl/messages.json
+++ b/src/_locales/tl/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Mga highlight"
 	},
+	"highlightsImportSuccess": {
+		"message": "Na-import ang $1 highlight.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Walang nakitang mga highlight sa artikulo"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Nabigo ang pag-import. Tingnan ang console para sa mga detalye."
+	},
+	"importHighlights": {
+		"message": "Mag-import ng mga highlight"
+	},
+	"importHighlightsDescription": {
+		"message": "Mag-import ng mga highlight mula sa isang file. Pinananatili ang mga umiiral na highlight."
 	},
 	"importModalTitle": {
 		"message": "I-import"

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Vurgular"
 	},
+	"highlightsImportSuccess": {
+		"message": "$1 vurgu içe aktarıldı.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Makalede vurgular bulunamadı"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "İçe aktarma başarısız. Daha fazla ayrıntı için konsolu kontrol edin."
+	},
+	"importHighlights": {
+		"message": "Vurguları içe aktar"
+	},
+	"importHighlightsDescription": {
+		"message": "Bir dosyadan vurguları içe aktarın. Mevcut vurgular korunur."
 	},
 	"importModalTitle": {
 		"message": "İçe aktar"

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Виділення"
 	},
+	"highlightsImportSuccess": {
+		"message": "Імпортовано $1 виділень.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "У статті не знайдено виділень"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Імпорт не вдався. Перевірте консоль для деталей."
+	},
+	"importHighlights": {
+		"message": "Імпортувати виділення"
+	},
+	"importHighlightsDescription": {
+		"message": "Імпортуйте виділення з файлу. Наявні виділення буде збережено."
 	},
 	"importModalTitle": {
 		"message": "Імпорт"

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "Đoạn tô sáng"
 	},
+	"highlightsImportSuccess": {
+		"message": "Đã nhập $1 highlight.",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "Không tìm thấy đoạn tô sáng trong bài viết"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "Nhập thất bại. Vui lòng kiểm tra bảng điều khiển để biết thêm chi tiết."
+	},
+	"importHighlights": {
+		"message": "Nhập highlight"
+	},
+	"importHighlightsDescription": {
+		"message": "Nhập highlight từ tệp. Các highlight hiện có sẽ được giữ lại."
 	},
 	"importModalTitle": {
 		"message": "Nhập"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "高亮"
 	},
+	"highlightsImportSuccess": {
+		"message": "已导入 $1 条高亮。",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "文章中未找到高亮"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "导入失败。请检查控制台以获取更多详细信息。"
+	},
+	"importHighlights": {
+		"message": "导入高亮"
+	},
+	"importHighlightsDescription": {
+		"message": "从文件导入高亮。将保留现有高亮。"
 	},
 	"importModalTitle": {
 		"message": "导入"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -381,6 +381,14 @@
 	"highlights": {
 		"message": "螢光標記"
 	},
+	"highlightsImportSuccess": {
+		"message": "已匯入 $1 則螢光標記。",
+		"placeholders": {
+			"1": {
+				"content": "$1"
+			}
+		}
+	},
 	"highlightsNotFound": {
 		"message": "文章中找不到螢光標記"
 	},
@@ -401,6 +409,12 @@
 	},
 	"importFailed": {
 		"message": "匯入失敗。請檢查控制台以獲得更多詳細資訊。"
+	},
+	"importHighlights": {
+		"message": "匯入螢光標記"
+	},
+	"importHighlightsDescription": {
+		"message": "從檔案匯入螢光標記。現有的螢光標記會保留。"
 	},
 	"importModalTitle": {
 		"message": "匯入"

--- a/src/core/highlights.ts
+++ b/src/core/highlights.ts
@@ -1,5 +1,5 @@
 import browser from '../utils/browser-polyfill';
-import { AnyHighlightData, StoredData, DomainSettings, collapseGroupsForExport, normalizeUrl } from '../utils/highlighter';
+import { AnyHighlightData, StoredData, DomainSettings, buildExportedPage, normalizeUrl } from '../utils/highlighter';
 import { translatePage, getMessage, setupLanguageAndDirection } from '../utils/i18n';
 import { addBrowserClassToHtml, detectBrowser } from '../utils/browser-detection';
 import DOMPurify from 'dompurify';
@@ -957,16 +957,14 @@ async function exportCurrentContext() {
 	if (entries.length === 0) return;
 
 	// Group by URL to match the existing export format
-	const byUrl = new Map<string, HighlightEntry[]>();
-	for (const { entry, pageUrl } of entries) {
-		if (!byUrl.has(pageUrl)) byUrl.set(pageUrl, []);
-		byUrl.get(pageUrl)!.push(entry);
+	const byUrl = new Map<string, { highlights: HighlightEntry[]; title?: string }>();
+	for (const { entry, pageUrl, title } of entries) {
+		if (!byUrl.has(pageUrl)) byUrl.set(pageUrl, { highlights: [], title });
+		byUrl.get(pageUrl)!.highlights.push(entry);
 	}
 
-	const exportData = Array.from(byUrl.entries()).map(([url, highlights]) => ({
-		url,
-		highlights: collapseGroupsForExport(highlights.map(h => h.data)),
-	}));
+	const exportData = Array.from(byUrl.entries()).map(([url, page]) =>
+		buildExportedPage(url, page.highlights.map(h => h.data), page.title));
 
 	const jsonContent = JSON.stringify(exportData, null, 2);
 	const blob = new Blob([jsonContent], { type: 'application/json' });

--- a/src/managers/general-settings.ts
+++ b/src/managers/general-settings.ts
@@ -9,7 +9,7 @@ import { createDefaultTemplate, getTemplates, saveTemplateSettings } from '../ma
 import { updateTemplateList, showTemplateEditor } from '../managers/template-ui';
 import { exportAllSettings, importAllSettings } from '../utils/import-export';
 import { Settings, Template } from '../types/types';
-import { exportHighlights } from './highlights-manager';
+import { exportHighlights, importHighlights } from './highlights-manager';
 import { getMessage, setupLanguageAndDirection } from '../utils/i18n';
 import { debounce } from '../utils/debounce';
 import browser from '../utils/browser-polyfill';
@@ -408,6 +408,11 @@ function initializeExportHighlightsButton(): void {
 	const exportHighlightsBtn = document.getElementById('export-highlights');
 	if (exportHighlightsBtn) {
 		exportHighlightsBtn.addEventListener('click', exportHighlights);
+	}
+
+	const importHighlightsBtn = document.getElementById('import-highlights');
+	if (importHighlightsBtn) {
+		importHighlightsBtn.addEventListener('click', importHighlights);
 	}
 }
 

--- a/src/managers/highlights-manager.test.ts
+++ b/src/managers/highlights-manager.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import browser from '../utils/browser-polyfill';
+import { AnyHighlightData, StoredData, collapseGroupsForExport } from '../utils/highlighter';
+import { importHighlightsFromJson } from './highlights-manager';
+
+// Mirrors what exportHighlights writes, so a round-trip can be asserted.
+function exportedFile(): string {
+	return JSON.stringify(
+		Object.entries(stored).map(([url, data]) => ({
+			url,
+			highlights: collapseGroupsForExport(data.highlights),
+		})),
+	);
+}
+
+function textHighlight(id: string, content: string, groupId?: string): AnyHighlightData {
+	return { id, type: 'text', xpath: `/p[${id}]`, startOffset: 0, endOffset: content.length, content, ...(groupId ? { groupId } : {}) };
+}
+
+let stored: Record<string, StoredData>;
+
+function highlightsFor(url: string): AnyHighlightData[] {
+	return stored[url]?.highlights ?? [];
+}
+
+beforeEach(() => {
+	stored = {};
+	vi.stubGlobal('alert', () => {});
+	browser.storage.local.get = (async () => ({ highlights: stored })) as typeof browser.storage.local.get;
+	browser.storage.local.set = (async (items: { highlights: Record<string, StoredData> }) => {
+		stored = items.highlights;
+	}) as unknown as typeof browser.storage.local.set;
+});
+
+const file = (highlights: unknown[], url = 'https://example.com/page') =>
+	JSON.stringify([{ url, highlights }]);
+
+describe('importHighlightsFromJson', () => {
+	test('imports highlights onto a page that has none', async () => {
+		await importHighlightsFromJson(file([
+			{ text: 'a highlighted sentence', timestamp: '2026-01-01T00:00:00.000Z' },
+		]));
+
+		const highlights = highlightsFor('https://example.com/page');
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0].content).toBe('a highlighted sentence');
+		// Anchoring is re-derived from the text on render, so the xpath is empty.
+		expect(highlights[0].xpath).toBe('');
+		expect(highlights[0].type).toBe('text');
+	});
+
+	test('keeps existing highlights instead of replacing them', async () => {
+		stored['https://example.com/page'] = {
+			url: 'https://example.com/page',
+			title: 'Existing title',
+			highlights: [{ id: '100', type: 'text', xpath: '/p[1]', startOffset: 0, endOffset: 5, content: 'kept' }],
+		};
+
+		await importHighlightsFromJson(file([{ text: 'added', timestamp: '2026-01-01T00:00:00.000Z' }]));
+
+		expect(highlightsFor('https://example.com/page').map(h => h.content)).toEqual(['kept', 'added']);
+		// An untouched page keeps its title — the export format doesn't carry one.
+		expect(stored['https://example.com/page'].title).toBe('Existing title');
+	});
+
+	test('importing the same file twice adds nothing the second time', async () => {
+		const json = file([
+			{ text: 'first', timestamp: '2026-01-01T00:00:00.000Z' },
+			{ text: 'second', timestamp: '2026-01-02T00:00:00.000Z' },
+		]);
+
+		await importHighlightsFromJson(json);
+		await importHighlightsFromJson(json);
+
+		expect(highlightsFor('https://example.com/page')).toHaveLength(2);
+	});
+
+	test('splits a grouped entry back into its members', async () => {
+		await importHighlightsFromJson(file([
+			{ text: 'part one\n\npart two', timestamp: '2026-01-01T00:00:00.000Z', notes: ['a note'] },
+		]));
+
+		const highlights = highlightsFor('https://example.com/page');
+		expect(highlights.map(h => h.content)).toEqual(['part one', 'part two']);
+		// Both members stay grouped, and the merged notes go back on the first.
+		expect(highlights[0].groupId).toBeDefined();
+		expect(highlights[1].groupId).toBe(highlights[0].groupId);
+		expect(highlights[0].notes).toEqual(['a note']);
+		expect(highlights[1].notes).toBeUndefined();
+	});
+
+	test('normalizes the url so tracking params do not create a second entry', async () => {
+		await importHighlightsFromJson(file([{ text: 'one' }], 'https://example.com/page?utm_source=news'));
+
+		expect(Object.keys(stored)).toEqual(['https://example.com/page']);
+	});
+
+	test('derives the highlight id from the exported timestamp', async () => {
+		const timestamp = '2026-01-01T00:00:00.000Z';
+		await importHighlightsFromJson(file([{ text: 'one', timestamp }]));
+
+		expect(highlightsFor('https://example.com/page')[0].id).toBe(String(Date.parse(timestamp)));
+	});
+
+	test('re-importing an unmodified export is a no-op', async () => {
+		stored['https://example.com/page'] = {
+			url: 'https://example.com/page',
+			highlights: [
+				textHighlight('100', 'a plain highlight'),
+				// A single highlight whose own content contains a blank line — this
+				// must not be mistaken for a group separator and re-split on import.
+				textHighlight('200', 'first line\n\nsecond line'),
+				// A real group, which the export collapses into one entry.
+				textHighlight('300', 'group part one', 'g1'),
+				textHighlight('400', 'group part two', 'g1'),
+			],
+		};
+
+		await importHighlightsFromJson(exportedFile());
+
+		expect(highlightsFor('https://example.com/page').map(h => h.content)).toEqual([
+			'a plain highlight',
+			'first line\n\nsecond line',
+			'group part one',
+			'group part two',
+		]);
+	});
+
+	test('folds in highlights still stored under a pre-normalization url', async () => {
+		// loadHighlights only migrates a raw key to its normalized form when the
+		// page is opened, so an export can still contain the raw key.
+		stored['https://example.com/page?utm_source=news'] = {
+			url: 'https://example.com/page?utm_source=news',
+			title: 'Legacy title',
+			highlights: [textHighlight('100', 'saved before normalization')],
+		};
+
+		await importHighlightsFromJson(exportedFile());
+
+		// Not duplicated, and not left behind under two keys.
+		expect(Object.keys(stored)).toEqual(['https://example.com/page']);
+		expect(highlightsFor('https://example.com/page').map(h => h.content)).toEqual([
+			'saved before normalization',
+		]);
+		expect(stored['https://example.com/page'].title).toBe('Legacy title');
+	});
+
+	test('reconciles a page split across the raw and normalized url', async () => {
+		const rawUrl = 'https://example.com/page?utm_source=news';
+		// The state left by an earlier import that wrote to the normalized key
+		// without noticing the originals under the raw one.
+		stored['https://example.com/page'] = {
+			url: 'https://example.com/page',
+			highlights: [{ id: '500', type: 'text', xpath: '', startOffset: 0, endOffset: 0, content: 'the same text' }],
+		};
+		stored[rawUrl] = {
+			url: rawUrl,
+			highlights: [textHighlight('100', 'the same text')],
+		};
+
+		await importHighlightsFromJson(exportedFile());
+
+		const highlights = highlightsFor('https://example.com/page');
+		expect(Object.keys(stored)).toEqual(['https://example.com/page']);
+		expect(highlights.map(h => h.content)).toEqual(['the same text']);
+		// The copy that kept its DOM anchor wins.
+		expect(highlights[0].xpath).toBe('/p[100]');
+	});
+
+	test('rejects a malformed file without writing anything', async () => {
+		stored['https://example.com/page'] = {
+			url: 'https://example.com/page',
+			highlights: [{ id: '100', type: 'text', xpath: '/p[1]', startOffset: 0, endOffset: 5, content: 'kept' }],
+		};
+
+		await expect(importHighlightsFromJson('{"not":"an array"}')).rejects.toThrow();
+		await expect(importHighlightsFromJson(file([{ timestamp: '2026-01-01T00:00:00.000Z' }]))).rejects.toThrow();
+		await expect(importHighlightsFromJson('not json at all')).rejects.toThrow();
+
+		expect(highlightsFor('https://example.com/page').map(h => h.content)).toEqual(['kept']);
+	});
+});

--- a/src/managers/highlights-manager.test.ts
+++ b/src/managers/highlights-manager.test.ts
@@ -1,11 +1,18 @@
 // @vitest-environment jsdom
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import browser from '../utils/browser-polyfill';
-import { AnyHighlightData, StoredData, collapseGroupsForExport } from '../utils/highlighter';
+import { AnyHighlightData, StoredData, TextHighlightData, buildExportedPage, collapseGroupsForExport } from '../utils/highlighter';
 import { importHighlightsFromJson } from './highlights-manager';
 
-// Mirrors what exportHighlights writes, so a round-trip can be asserted.
+// What the exports write today, full records included.
 function exportedFile(): string {
+	return JSON.stringify(
+		Object.entries(stored).map(([url, data]) => buildExportedPage(url, data.highlights, data.title)),
+	);
+}
+
+// The format as it was before it carried `data`, which imports must still take.
+function legacyExportedFile(): string {
 	return JSON.stringify(
 		Object.entries(stored).map(([url, data]) => ({
 			url,
@@ -60,7 +67,6 @@ describe('importHighlightsFromJson', () => {
 		await importHighlightsFromJson(file([{ text: 'added', timestamp: '2026-01-01T00:00:00.000Z' }]));
 
 		expect(highlightsFor('https://example.com/page').map(h => h.content)).toEqual(['kept', 'added']);
-		// An untouched page keeps its title — the export format doesn't carry one.
 		expect(stored['https://example.com/page'].title).toBe('Existing title');
 	});
 
@@ -103,19 +109,17 @@ describe('importHighlightsFromJson', () => {
 		expect(highlightsFor('https://example.com/page')[0].id).toBe(String(Date.parse(timestamp)));
 	});
 
+	const mixedPage = (): AnyHighlightData[] => [
+		textHighlight('100', 'a plain highlight'),
+		// Content with a blank line, not to be mistaken for a group separator.
+		textHighlight('200', 'first line\n\nsecond line'),
+		// A real group, which the readable view collapses into one entry.
+		textHighlight('300', 'group part one', 'g1'),
+		textHighlight('400', 'group part two', 'g1'),
+	];
+
 	test('re-importing an unmodified export is a no-op', async () => {
-		stored['https://example.com/page'] = {
-			url: 'https://example.com/page',
-			highlights: [
-				textHighlight('100', 'a plain highlight'),
-				// A single highlight whose own content contains a blank line — this
-				// must not be mistaken for a group separator and re-split on import.
-				textHighlight('200', 'first line\n\nsecond line'),
-				// A real group, which the export collapses into one entry.
-				textHighlight('300', 'group part one', 'g1'),
-				textHighlight('400', 'group part two', 'g1'),
-			],
-		};
+		stored['https://example.com/page'] = { url: 'https://example.com/page', highlights: mixedPage() };
 
 		await importHighlightsFromJson(exportedFile());
 
@@ -125,6 +129,72 @@ describe('importHighlightsFromJson', () => {
 			'group part one',
 			'group part two',
 		]);
+	});
+
+	test('re-importing an export written before the data field is a no-op', async () => {
+		stored['https://example.com/page'] = { url: 'https://example.com/page', highlights: mixedPage() };
+
+		await importHighlightsFromJson(legacyExportedFile());
+
+		expect(highlightsFor('https://example.com/page').map(h => h.content)).toEqual([
+			'a plain highlight',
+			'first line\n\nsecond line',
+			'group part one',
+			'group part two',
+		]);
+	});
+
+	test('restores an element highlight instead of flattening it to text', async () => {
+		// Element highlights render only via xpath, so without the full record an
+		// image highlight would vanish on import.
+		stored['https://example.com/page'] = {
+			url: 'https://example.com/page',
+			title: 'A page',
+			highlights: [{ id: '100', type: 'element', xpath: '/figure[1]/img[1]', content: '<img src="x.png">' }],
+		};
+		const json = exportedFile();
+		stored = {};
+
+		await importHighlightsFromJson(json);
+
+		const highlights = highlightsFor('https://example.com/page');
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0].type).toBe('element');
+		expect(highlights[0].xpath).toBe('/figure[1]/img[1]');
+		expect(stored['https://example.com/page'].title).toBe('A page');
+	});
+
+	test('restores group structure and anchors rather than re-deriving them', async () => {
+		stored['https://example.com/page'] = {
+			url: 'https://example.com/page',
+			highlights: [
+				{ id: '300', type: 'text', xpath: '/p[3]', startOffset: 4, endOffset: 18, content: 'group part one', groupId: 'g1', textQuote: { prefix: 'before ', suffix: ' after' } },
+				textHighlight('400', 'group part two', 'g1'),
+			],
+		};
+		const json = exportedFile();
+		stored = {};
+
+		await importHighlightsFromJson(json);
+
+		const highlights = highlightsFor('https://example.com/page') as TextHighlightData[];
+		expect(highlights.map(h => h.content)).toEqual(['group part one', 'group part two']);
+		// Grouping survives as recorded, not inferred from blank-line splitting.
+		expect(highlights.map(h => h.groupId)).toEqual(['g1', 'g1']);
+		expect(highlights[0].xpath).toBe('/p[3]');
+		expect(highlights[0].startOffset).toBe(4);
+		expect(highlights[0].textQuote).toEqual({ prefix: 'before ', suffix: ' after' });
+	});
+
+	test('rejects a malformed record in the data field', async () => {
+		const withBadRecord = JSON.stringify([{
+			url: 'https://example.com/page',
+			highlights: [{ text: 'one', timestamp: '2026-01-01T00:00:00.000Z' }],
+			data: [{ id: '100', type: 'sideways', xpath: '/p[1]', content: 'one' }],
+		}]);
+
+		await expect(importHighlightsFromJson(withBadRecord)).rejects.toThrow();
+		expect(stored).toEqual({});
 	});
 
 	test('folds in highlights still stored under a pre-normalization url', async () => {

--- a/src/managers/highlights-manager.ts
+++ b/src/managers/highlights-manager.ts
@@ -1,6 +1,6 @@
 import browser from '../utils/browser-polyfill';
 import { detectBrowser } from '../utils/browser-detection';
-import { AnyHighlightData, HighlightsStorage, TextQuoteAnchor, buildExportedPage, collapseGroupsForExport, expandExportedEntries, normalizeUrl, reconcileLegacyUrlKey } from '../utils/highlighter';
+import { AnyHighlightData, ElementHighlightData, HighlightsStorage, TextHighlightData, TextQuoteAnchor, buildExportedPage, collapseGroupsForExport, expandExportedEntries, normalizeUrl, reconcileLegacyUrlKey } from '../utils/highlighter';
 import { showImportModal } from '../utils/import-modal';
 import dayjs from 'dayjs';
 import { getMessage } from '../utils/i18n';
@@ -72,6 +72,17 @@ function parseNotes(value: unknown, where: string): string[] | undefined {
 	}
 	return value as string[];
 }
+
+// parseHighlightRecords below rebuilds each record from an allowlist, so a field
+// added to the highlight types would be dropped on import without these. They
+// fail to compile until the new field is handled there as well.
+const _textFieldsAreImported: Record<keyof TextHighlightData, true> = {
+	id: true, type: true, xpath: true, content: true, notes: true,
+	groupId: true, startOffset: true, endOffset: true, textQuote: true,
+};
+const _elementFieldsAreImported: Record<keyof ElementHighlightData, true> = {
+	id: true, type: true, xpath: true, content: true, notes: true, groupId: true,
+};
 
 // Validated field by field rather than trusted, since this lands in storage and
 // is later fed straight to the renderer.

--- a/src/managers/highlights-manager.ts
+++ b/src/managers/highlights-manager.ts
@@ -1,11 +1,9 @@
 import browser from '../utils/browser-polyfill';
 import { detectBrowser } from '../utils/browser-detection';
-import { AnyHighlightData, StoredData, TextHighlightData, TextQuoteAnchor, buildExportedPage, collapseGroupsForExport, normalizeUrl } from '../utils/highlighter';
+import { AnyHighlightData, HighlightsStorage, TextQuoteAnchor, buildExportedPage, collapseGroupsForExport, expandExportedEntries, normalizeUrl, reconcileLegacyUrlKey } from '../utils/highlighter';
 import { showImportModal } from '../utils/import-modal';
 import dayjs from 'dayjs';
 import { getMessage } from '../utils/i18n';
-
-type HighlightsStorage = Record<string, StoredData>;
 
 export async function exportHighlights(): Promise<void> {
 	try {
@@ -67,6 +65,14 @@ interface ImportedPage {
 	data?: AnyHighlightData[];
 }
 
+function parseNotes(value: unknown, where: string): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value) || value.some(note => typeof note !== 'string')) {
+		throw new Error(`${where} has invalid notes`);
+	}
+	return value as string[];
+}
+
 // Validated field by field rather than trusted, since this lands in storage and
 // is later fed straight to the renderer.
 function parseHighlightRecords(value: unknown, pageIndex: number): AnyHighlightData[] | undefined {
@@ -80,17 +86,15 @@ function parseHighlightRecords(value: unknown, pageIndex: number): AnyHighlightD
 		if (!record || typeof record !== 'object') {
 			throw new Error(`${where} is not an object`);
 		}
-		const { id, type, xpath, content, notes, groupId } = record as Record<string, unknown>;
+		const { id, type, xpath, content, groupId } = record as Record<string, unknown>;
 		if (typeof id !== 'string' || !id) throw new Error(`${where} is missing an id`);
 		if (type !== 'text' && type !== 'element') throw new Error(`${where} has an unknown type`);
 		if (typeof xpath !== 'string') throw new Error(`${where} is missing an xpath`);
 		if (typeof content !== 'string' || !content) throw new Error(`${where} is missing content`);
-		if (notes !== undefined && (!Array.isArray(notes) || notes.some(note => typeof note !== 'string'))) {
-			throw new Error(`${where} has invalid notes`);
-		}
 		if (groupId !== undefined && typeof groupId !== 'string') {
 			throw new Error(`${where} has an invalid groupId`);
 		}
+		const notes = parseNotes((record as Record<string, unknown>).notes, where);
 
 		const base = { id, xpath, content, ...(notes ? { notes } : {}), ...(groupId ? { groupId } : {}) };
 		if (type === 'element') return { ...base, type };
@@ -146,27 +150,16 @@ function parseImportedHighlights(json: string): ImportedPage[] {
 				if (!highlight || typeof highlight !== 'object') {
 					throw new Error(`Highlight ${index} of entry ${pageIndex} is not an object`);
 				}
+				const where = `Highlight ${index} of entry ${pageIndex}`;
 				const { text, timestamp, notes } = highlight as Partial<ImportedHighlight>;
-				if (typeof text !== 'string' || !text) {
-					throw new Error(`Highlight ${index} of entry ${pageIndex} is missing text`);
-				}
+				if (typeof text !== 'string' || !text) throw new Error(`${where} is missing text`);
 				if (timestamp !== undefined && typeof timestamp !== 'string') {
-					throw new Error(`Highlight ${index} of entry ${pageIndex} has an invalid timestamp`);
+					throw new Error(`${where} has an invalid timestamp`);
 				}
-				if (notes !== undefined && (!Array.isArray(notes) || notes.some(note => typeof note !== 'string'))) {
-					throw new Error(`Highlight ${index} of entry ${pageIndex} has invalid notes`);
-				}
-				return { text, timestamp, notes };
+				return { text, timestamp, notes: parseNotes(notes, where) };
 			}),
 		};
 	});
-}
-
-// Highlight ids double as their creation time, so a timestamp maps back to one.
-// A hand written file may omit it, in which case the highlight counts as new.
-function timestampToMs(timestamp: string | undefined): number {
-	const parsed = timestamp ? dayjs(timestamp) : null;
-	return parsed && parsed.isValid() ? parsed.valueOf() : Date.now();
 }
 
 // Ids must be unique within a page, so a taken one is bumped by a millisecond.
@@ -180,103 +173,57 @@ function reserveId(ms: number, usedIds: Set<string>): string {
 	return id;
 }
 
+// Merge one page of an import into the store, returning how many were added.
+function mergePage(page: ImportedPage, allHighlights: HighlightsStorage): number {
+	// Exports write the raw key verbatim, so an un-normalized entry has to be
+	// folded in first or this would miss it and split the page across two keys.
+	reconcileLegacyUrlKey(allHighlights, page.url);
+
+	const url = normalizeUrl(page.url);
+	const existing = allHighlights[url];
+	const merged: AnyHighlightData[] = [...(existing?.highlights ?? [])];
+
+	// Dedupe on content so re-importing the same file is a no-op. This also
+	// collapses two highlights of identical text on one page.
+	const seenContent = new Set(merged.map(highlight => highlight.content));
+	const usedIds = new Set(merged.map(highlight => highlight.id));
+
+	// Full records restore the page exactly. Older files carry only the readable
+	// view, which has to be expanded back into records first.
+	let records = page.data;
+	if (!records) {
+		// Content can itself contain a blank line, which the expansion would
+		// mistake for a group separator. Comparing against what these highlights
+		// would export as catches that.
+		const seenEntries = new Set(collapseGroupsForExport(merged).map(entry => entry.text));
+		records = expandExportedEntries(page.highlights.filter(entry => !seenEntries.has(entry.text)));
+	}
+
+	let added = 0;
+	for (const record of records) {
+		if (seenContent.has(record.content)) continue;
+		seenContent.add(record.content);
+		merged.push({ ...record, id: reserveId(Number(record.id) || Date.now(), usedIds) });
+		added++;
+	}
+
+	if (merged.length > 0) {
+		// A title already on record wins. The imported one only fills an empty title.
+		allHighlights[url] = { highlights: merged, url, title: existing?.title ?? page.title };
+	}
+	return added;
+}
+
 // Merge imported highlights into what's already stored, never removing any.
 export async function importHighlightsFromJson(json: string): Promise<void> {
 	const pages = parseImportedHighlights(json);
 
 	const result = await browser.storage.local.get('highlights') as { highlights?: HighlightsStorage };
 	const allHighlights: HighlightsStorage = result.highlights || {};
+
 	let importedCount = 0;
-
 	for (const page of pages) {
-		const url = normalizeUrl(page.url);
-		const existing = allHighlights[url];
-		// Highlights saved before URLs were normalized sit under the raw key until
-		// their page is next opened, and exports write that key verbatim. Fold such
-		// an entry in, or re-importing would miss it and split the page across two
-		// keys. The same highlight can appear under both, so match on content and
-		// keep whichever copy still has an xpath.
-		const legacy = page.url !== url ? allHighlights[page.url] : undefined;
-		const merged: AnyHighlightData[] = [...(existing?.highlights ?? [])];
-
-		const positionByContent = new Map<string, number>();
-		merged.forEach((highlight, index) => {
-			if (!positionByContent.has(highlight.content)) positionByContent.set(highlight.content, index);
-		});
-		for (const highlight of legacy?.highlights ?? []) {
-			const at = positionByContent.get(highlight.content);
-			if (at === undefined) {
-				positionByContent.set(highlight.content, merged.length);
-				merged.push(highlight);
-			} else if (!merged[at].xpath && highlight.xpath) {
-				merged[at] = highlight;
-			}
-		}
-
-		// Dedupe on content so re-importing the same file is a no-op. This also
-		// collapses two highlights of identical text on one page.
-		const seenContent = new Set(merged.map(highlight => highlight.content));
-		const usedIds = new Set(merged.map(highlight => highlight.id));
-		// Content can itself contain a blank line, which the text fallback below
-		// would mistake for a group separator. Comparing against what these
-		// highlights would export as catches that.
-		const seenEntries = new Set(collapseGroupsForExport(merged).map(entry => entry.text));
-
-		const writePage = () => {
-			if (merged.length === 0) return;
-			// A title already on record wins. The imported one only fills an empty title.
-			allHighlights[url] = { highlights: merged, url, title: existing?.title ?? legacy?.title ?? page.title };
-			if (legacy) delete allHighlights[page.url];
-		};
-
-		// Full records restore the page exactly. Files written before the format
-		// carried `data` fall through to re-anchoring by text below.
-		if (page.data) {
-			for (const record of page.data) {
-				if (seenContent.has(record.content)) continue;
-				seenContent.add(record.content);
-				merged.push({ ...record, id: reserveId(Number(record.id) || Date.now(), usedIds) });
-				importedCount++;
-			}
-
-			writePage();
-			continue;
-		}
-
-		for (const entry of page.highlights) {
-			if (seenEntries.has(entry.text)) continue;
-
-			// A group exports as one entry with its members joined by a blank line.
-			// Split them apart so each re-anchors on its own, still grouped. One
-			// timestamp covers the group, so later members offset from it to keep
-			// their order.
-			const parts = entry.text.split('\n\n').filter(part => part.length > 0);
-			const baseMs = timestampToMs(entry.timestamp);
-			const ids = parts.map((_, index) => reserveId(baseMs + index, usedIds));
-			const groupId = parts.length > 1 ? `import-${ids[0]}` : undefined;
-
-			parts.forEach((part, index) => {
-				if (seenContent.has(part)) return;
-				seenContent.add(part);
-
-				const highlight: TextHighlightData = {
-					id: ids[index],
-					type: 'text',
-					xpath: '',
-					startOffset: 0,
-					endOffset: 0,
-					content: part,
-					...(groupId ? { groupId } : {}),
-					// Notes merge across a group on export, so they go back on the first.
-					...(index === 0 && entry.notes?.length ? { notes: entry.notes } : {}),
-				};
-
-				merged.push(highlight);
-				importedCount++;
-			});
-		}
-
-		writePage();
+		importedCount += mergePage(page, allHighlights);
 	}
 
 	await browser.storage.local.set({ highlights: allHighlights });

--- a/src/managers/highlights-manager.ts
+++ b/src/managers/highlights-manager.ts
@@ -1,6 +1,6 @@
 import browser from '../utils/browser-polyfill';
 import { detectBrowser } from '../utils/browser-detection';
-import { AnyHighlightData, StoredData, TextHighlightData, collapseGroupsForExport, normalizeUrl } from '../utils/highlighter';
+import { AnyHighlightData, StoredData, TextHighlightData, TextQuoteAnchor, buildExportedPage, collapseGroupsForExport, normalizeUrl } from '../utils/highlighter';
 import { showImportModal } from '../utils/import-modal';
 import dayjs from 'dayjs';
 import { getMessage } from '../utils/i18n';
@@ -9,13 +9,11 @@ type HighlightsStorage = Record<string, StoredData>;
 
 export async function exportHighlights(): Promise<void> {
 	try {
-		const result = await browser.storage.local.get('highlights');
-		const allHighlights = result.highlights || {};
+		const result = await browser.storage.local.get('highlights') as { highlights?: HighlightsStorage };
+		const allHighlights: HighlightsStorage = result.highlights || {};
 
-		const exportData = Object.entries(allHighlights).map(([url, data]) => ({
-			url,
-			highlights: collapseGroupsForExport(data.highlights as AnyHighlightData[]),
-		}));
+		const exportData = Object.entries(allHighlights).map(([url, data]) =>
+			buildExportedPage(url, data.highlights, data.title));
 
 		const jsonContent = JSON.stringify(exportData, null, 2);
 		const blob = new Blob([jsonContent], { type: 'application/json' });
@@ -64,7 +62,57 @@ interface ImportedHighlight {
 
 interface ImportedPage {
 	url: string;
+	title?: string;
 	highlights: ImportedHighlight[];
+	data?: AnyHighlightData[];
+}
+
+// Validated field by field rather than trusted, since this lands in storage and
+// is later fed straight to the renderer.
+function parseHighlightRecords(value: unknown, pageIndex: number): AnyHighlightData[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) {
+		throw new Error(`Entry ${pageIndex} has an invalid data array`);
+	}
+
+	return value.map((record: unknown, index: number): AnyHighlightData => {
+		const where = `Record ${index} of entry ${pageIndex}`;
+		if (!record || typeof record !== 'object') {
+			throw new Error(`${where} is not an object`);
+		}
+		const { id, type, xpath, content, notes, groupId } = record as Record<string, unknown>;
+		if (typeof id !== 'string' || !id) throw new Error(`${where} is missing an id`);
+		if (type !== 'text' && type !== 'element') throw new Error(`${where} has an unknown type`);
+		if (typeof xpath !== 'string') throw new Error(`${where} is missing an xpath`);
+		if (typeof content !== 'string' || !content) throw new Error(`${where} is missing content`);
+		if (notes !== undefined && (!Array.isArray(notes) || notes.some(note => typeof note !== 'string'))) {
+			throw new Error(`${where} has invalid notes`);
+		}
+		if (groupId !== undefined && typeof groupId !== 'string') {
+			throw new Error(`${where} has an invalid groupId`);
+		}
+
+		const base = { id, xpath, content, ...(notes ? { notes } : {}), ...(groupId ? { groupId } : {}) };
+		if (type === 'element') return { ...base, type };
+
+		const { startOffset, endOffset, textQuote } = record as Record<string, unknown>;
+		if (typeof startOffset !== 'number' || typeof endOffset !== 'number') {
+			throw new Error(`${where} is missing text offsets`);
+		}
+		return {
+			...base,
+			type,
+			startOffset,
+			endOffset,
+			...(isTextQuoteAnchor(textQuote) ? { textQuote } : {}),
+		};
+	});
+}
+
+function isTextQuoteAnchor(value: unknown): value is TextQuoteAnchor {
+	if (!value || typeof value !== 'object') return false;
+	const { prefix, suffix } = value as Record<string, unknown>;
+	return typeof prefix === 'string' && typeof suffix === 'string';
 }
 
 // Validate up front and throw on the first problem, so a malformed file is
@@ -79,9 +127,12 @@ function parseImportedHighlights(json: string): ImportedPage[] {
 		if (!page || typeof page !== 'object') {
 			throw new Error(`Entry ${pageIndex} is not an object`);
 		}
-		const { url, highlights } = page as Partial<ImportedPage>;
+		const { url, title, highlights, data } = page as Partial<ImportedPage>;
 		if (typeof url !== 'string' || !url.trim()) {
 			throw new Error(`Entry ${pageIndex} is missing a url`);
+		}
+		if (title !== undefined && typeof title !== 'string') {
+			throw new Error(`Entry ${pageIndex} has an invalid title`);
 		}
 		if (!Array.isArray(highlights)) {
 			throw new Error(`Entry ${pageIndex} is missing a highlights array`);
@@ -89,6 +140,8 @@ function parseImportedHighlights(json: string): ImportedPage[] {
 
 		return {
 			url,
+			title,
+			data: parseHighlightRecords(data, pageIndex),
 			highlights: highlights.map((highlight: unknown, index: number): ImportedHighlight => {
 				if (!highlight || typeof highlight !== 'object') {
 					throw new Error(`Highlight ${index} of entry ${pageIndex} is not an object`);
@@ -109,9 +162,8 @@ function parseImportedHighlights(json: string): ImportedPage[] {
 	});
 }
 
-// Highlight ids double as their creation time, so the exported timestamp maps
-// straight back to one. A file written by hand may omit it, in which case the
-// highlight is treated as new.
+// Highlight ids double as their creation time, so a timestamp maps back to one.
+// A hand written file may omit it, in which case the highlight counts as new.
 function timestampToMs(timestamp: string | undefined): number {
 	const parsed = timestamp ? dayjs(timestamp) : null;
 	return parsed && parsed.isValid() ? parsed.valueOf() : Date.now();
@@ -128,14 +180,7 @@ function reserveId(ms: number, usedIds: Set<string>): string {
 	return id;
 }
 
-// Merge imported highlights into what's already stored — an import never
-// removes existing highlights.
-//
-// The export format is lossy: it keeps text, timestamp and notes but drops the
-// xpath and character offsets that anchor a highlight to the DOM. That is
-// recoverable, because renderTextHighlight re-anchors by text whenever the
-// xpath fails to resolve, so imported highlights are stored with an empty xpath
-// and find their place the next time the page is opened.
+// Merge imported highlights into what's already stored, never removing any.
 export async function importHighlightsFromJson(json: string): Promise<void> {
 	const pages = parseImportedHighlights(json);
 
@@ -146,17 +191,14 @@ export async function importHighlightsFromJson(json: string): Promise<void> {
 	for (const page of pages) {
 		const url = normalizeUrl(page.url);
 		const existing = allHighlights[url];
-		// Highlights saved before URLs were normalized still sit under the raw URL
-		// until their page is next opened, and the export writes that raw key
-		// verbatim. Fold such an entry in here, or re-importing an export of those
-		// highlights would miss them all and duplicate the page under two keys.
+		// Highlights saved before URLs were normalized sit under the raw key until
+		// their page is next opened, and exports write that key verbatim. Fold such
+		// an entry in, or re-importing would miss it and split the page across two
+		// keys. The same highlight can appear under both, so match on content and
+		// keep whichever copy still has an xpath.
 		const legacy = page.url !== url ? allHighlights[page.url] : undefined;
 		const merged: AnyHighlightData[] = [...(existing?.highlights ?? [])];
 
-		// Fold the pre-normalization entry in. A highlight can legitimately appear
-		// under both keys, so match on content rather than stacking them up, and
-		// keep whichever copy still has a real xpath — an imported copy has none
-		// and would have to re-anchor by text.
 		const positionByContent = new Map<string, number>();
 		merged.forEach((highlight, index) => {
 			if (!positionByContent.has(highlight.content)) positionByContent.set(highlight.content, index);
@@ -172,26 +214,43 @@ export async function importHighlightsFromJson(json: string): Promise<void> {
 		}
 
 		// Dedupe on content so re-importing the same file is a no-op. This also
-		// collapses two highlights of identical text on the same page, which is
-		// the better trade for keeping repeat imports from stacking up.
+		// collapses two highlights of identical text on one page.
 		const seenContent = new Set(merged.map(highlight => highlight.content));
 		const usedIds = new Set(merged.map(highlight => highlight.id));
-		// A highlight's own content can contain a blank line, which would survive
-		// the export and be mistaken for a group separator below. Comparing against
-		// what these highlights would themselves export as catches that case, and
-		// makes "re-importing an unmodified export changes nothing" true by
-		// construction rather than by coincidence.
+		// Content can itself contain a blank line, which the text fallback below
+		// would mistake for a group separator. Comparing against what these
+		// highlights would export as catches that.
 		const seenEntries = new Set(collapseGroupsForExport(merged).map(entry => entry.text));
+
+		const writePage = () => {
+			if (merged.length === 0) return;
+			// A title already on record wins. The imported one only fills an empty title.
+			allHighlights[url] = { highlights: merged, url, title: existing?.title ?? legacy?.title ?? page.title };
+			if (legacy) delete allHighlights[page.url];
+		};
+
+		// Full records restore the page exactly. Files written before the format
+		// carried `data` fall through to re-anchoring by text below.
+		if (page.data) {
+			for (const record of page.data) {
+				if (seenContent.has(record.content)) continue;
+				seenContent.add(record.content);
+				merged.push({ ...record, id: reserveId(Number(record.id) || Date.now(), usedIds) });
+				importedCount++;
+			}
+
+			writePage();
+			continue;
+		}
 
 		for (const entry of page.highlights) {
 			if (seenEntries.has(entry.text)) continue;
 
-			// A group of highlights is exported as a single entry with its members
-			// joined by a blank line. Split them back apart so each part re-anchors
-			// independently, and keep them grouped via a shared groupId.
+			// A group exports as one entry with its members joined by a blank line.
+			// Split them apart so each re-anchors on its own, still grouped. One
+			// timestamp covers the group, so later members offset from it to keep
+			// their order.
 			const parts = entry.text.split('\n\n').filter(part => part.length > 0);
-			// The export records one timestamp per group, so later members are
-			// offset from it to keep the group in its original order.
 			const baseMs = timestampToMs(entry.timestamp);
 			const ids = parts.map((_, index) => reserveId(baseMs + index, usedIds));
 			const groupId = parts.length > 1 ? `import-${ids[0]}` : undefined;
@@ -208,8 +267,7 @@ export async function importHighlightsFromJson(json: string): Promise<void> {
 					endOffset: 0,
 					content: part,
 					...(groupId ? { groupId } : {}),
-					// Notes are merged across a group on export, so they go back on
-					// the first member.
+					// Notes merge across a group on export, so they go back on the first.
 					...(index === 0 && entry.notes?.length ? { notes: entry.notes } : {}),
 				};
 
@@ -218,12 +276,7 @@ export async function importHighlightsFromJson(json: string): Promise<void> {
 			});
 		}
 
-		if (merged.length > 0) {
-			allHighlights[url] = { highlights: merged, url, title: existing?.title ?? legacy?.title };
-			// Having folded the pre-normalization entry in, retire its key the same
-			// way loadHighlights would have.
-			if (legacy) delete allHighlights[page.url];
-		}
+		writePage();
 	}
 
 	await browser.storage.local.set({ highlights: allHighlights });

--- a/src/managers/highlights-manager.ts
+++ b/src/managers/highlights-manager.ts
@@ -1,8 +1,11 @@
 import browser from '../utils/browser-polyfill';
 import { detectBrowser } from '../utils/browser-detection';
-import { AnyHighlightData, collapseGroupsForExport } from '../utils/highlighter';
+import { AnyHighlightData, StoredData, TextHighlightData, collapseGroupsForExport, normalizeUrl } from '../utils/highlighter';
+import { showImportModal } from '../utils/import-modal';
 import dayjs from 'dayjs';
 import { getMessage } from '../utils/i18n';
+
+type HighlightsStorage = Record<string, StoredData>;
 
 export async function exportHighlights(): Promise<void> {
 	try {
@@ -51,4 +54,188 @@ export async function exportHighlights(): Promise<void> {
 		console.error('Error exporting highlights:', error);
 		alert(getMessage('failedToExportHighlights'));
 	}
+}
+
+interface ImportedHighlight {
+	text: string;
+	timestamp?: string;
+	notes?: string[];
+}
+
+interface ImportedPage {
+	url: string;
+	highlights: ImportedHighlight[];
+}
+
+// Validate up front and throw on the first problem, so a malformed file is
+// rejected before anything is written to storage rather than applied halfway.
+function parseImportedHighlights(json: string): ImportedPage[] {
+	const parsed = JSON.parse(json);
+	if (!Array.isArray(parsed)) {
+		throw new Error('Expected the file to contain an array of pages');
+	}
+
+	return parsed.map((page: unknown, pageIndex: number): ImportedPage => {
+		if (!page || typeof page !== 'object') {
+			throw new Error(`Entry ${pageIndex} is not an object`);
+		}
+		const { url, highlights } = page as Partial<ImportedPage>;
+		if (typeof url !== 'string' || !url.trim()) {
+			throw new Error(`Entry ${pageIndex} is missing a url`);
+		}
+		if (!Array.isArray(highlights)) {
+			throw new Error(`Entry ${pageIndex} is missing a highlights array`);
+		}
+
+		return {
+			url,
+			highlights: highlights.map((highlight: unknown, index: number): ImportedHighlight => {
+				if (!highlight || typeof highlight !== 'object') {
+					throw new Error(`Highlight ${index} of entry ${pageIndex} is not an object`);
+				}
+				const { text, timestamp, notes } = highlight as Partial<ImportedHighlight>;
+				if (typeof text !== 'string' || !text) {
+					throw new Error(`Highlight ${index} of entry ${pageIndex} is missing text`);
+				}
+				if (timestamp !== undefined && typeof timestamp !== 'string') {
+					throw new Error(`Highlight ${index} of entry ${pageIndex} has an invalid timestamp`);
+				}
+				if (notes !== undefined && (!Array.isArray(notes) || notes.some(note => typeof note !== 'string'))) {
+					throw new Error(`Highlight ${index} of entry ${pageIndex} has invalid notes`);
+				}
+				return { text, timestamp, notes };
+			}),
+		};
+	});
+}
+
+// Highlight ids double as their creation time, so the exported timestamp maps
+// straight back to one. A file written by hand may omit it, in which case the
+// highlight is treated as new.
+function timestampToMs(timestamp: string | undefined): number {
+	const parsed = timestamp ? dayjs(timestamp) : null;
+	return parsed && parsed.isValid() ? parsed.valueOf() : Date.now();
+}
+
+// Ids must be unique within a page, so a taken one is bumped by a millisecond.
+function reserveId(ms: number, usedIds: Set<string>): string {
+	let candidate = ms;
+	while (usedIds.has(String(candidate))) {
+		candidate++;
+	}
+	const id = String(candidate);
+	usedIds.add(id);
+	return id;
+}
+
+// Merge imported highlights into what's already stored — an import never
+// removes existing highlights.
+//
+// The export format is lossy: it keeps text, timestamp and notes but drops the
+// xpath and character offsets that anchor a highlight to the DOM. That is
+// recoverable, because renderTextHighlight re-anchors by text whenever the
+// xpath fails to resolve, so imported highlights are stored with an empty xpath
+// and find their place the next time the page is opened.
+export async function importHighlightsFromJson(json: string): Promise<void> {
+	const pages = parseImportedHighlights(json);
+
+	const result = await browser.storage.local.get('highlights') as { highlights?: HighlightsStorage };
+	const allHighlights: HighlightsStorage = result.highlights || {};
+	let importedCount = 0;
+
+	for (const page of pages) {
+		const url = normalizeUrl(page.url);
+		const existing = allHighlights[url];
+		// Highlights saved before URLs were normalized still sit under the raw URL
+		// until their page is next opened, and the export writes that raw key
+		// verbatim. Fold such an entry in here, or re-importing an export of those
+		// highlights would miss them all and duplicate the page under two keys.
+		const legacy = page.url !== url ? allHighlights[page.url] : undefined;
+		const merged: AnyHighlightData[] = [...(existing?.highlights ?? [])];
+
+		// Fold the pre-normalization entry in. A highlight can legitimately appear
+		// under both keys, so match on content rather than stacking them up, and
+		// keep whichever copy still has a real xpath — an imported copy has none
+		// and would have to re-anchor by text.
+		const positionByContent = new Map<string, number>();
+		merged.forEach((highlight, index) => {
+			if (!positionByContent.has(highlight.content)) positionByContent.set(highlight.content, index);
+		});
+		for (const highlight of legacy?.highlights ?? []) {
+			const at = positionByContent.get(highlight.content);
+			if (at === undefined) {
+				positionByContent.set(highlight.content, merged.length);
+				merged.push(highlight);
+			} else if (!merged[at].xpath && highlight.xpath) {
+				merged[at] = highlight;
+			}
+		}
+
+		// Dedupe on content so re-importing the same file is a no-op. This also
+		// collapses two highlights of identical text on the same page, which is
+		// the better trade for keeping repeat imports from stacking up.
+		const seenContent = new Set(merged.map(highlight => highlight.content));
+		const usedIds = new Set(merged.map(highlight => highlight.id));
+		// A highlight's own content can contain a blank line, which would survive
+		// the export and be mistaken for a group separator below. Comparing against
+		// what these highlights would themselves export as catches that case, and
+		// makes "re-importing an unmodified export changes nothing" true by
+		// construction rather than by coincidence.
+		const seenEntries = new Set(collapseGroupsForExport(merged).map(entry => entry.text));
+
+		for (const entry of page.highlights) {
+			if (seenEntries.has(entry.text)) continue;
+
+			// A group of highlights is exported as a single entry with its members
+			// joined by a blank line. Split them back apart so each part re-anchors
+			// independently, and keep them grouped via a shared groupId.
+			const parts = entry.text.split('\n\n').filter(part => part.length > 0);
+			// The export records one timestamp per group, so later members are
+			// offset from it to keep the group in its original order.
+			const baseMs = timestampToMs(entry.timestamp);
+			const ids = parts.map((_, index) => reserveId(baseMs + index, usedIds));
+			const groupId = parts.length > 1 ? `import-${ids[0]}` : undefined;
+
+			parts.forEach((part, index) => {
+				if (seenContent.has(part)) return;
+				seenContent.add(part);
+
+				const highlight: TextHighlightData = {
+					id: ids[index],
+					type: 'text',
+					xpath: '',
+					startOffset: 0,
+					endOffset: 0,
+					content: part,
+					...(groupId ? { groupId } : {}),
+					// Notes are merged across a group on export, so they go back on
+					// the first member.
+					...(index === 0 && entry.notes?.length ? { notes: entry.notes } : {}),
+				};
+
+				merged.push(highlight);
+				importedCount++;
+			});
+		}
+
+		if (merged.length > 0) {
+			allHighlights[url] = { highlights: merged, url, title: existing?.title ?? legacy?.title };
+			// Having folded the pre-normalization entry in, retire its key the same
+			// way loadHighlights would have.
+			if (legacy) delete allHighlights[page.url];
+		}
+	}
+
+	await browser.storage.local.set({ highlights: allHighlights });
+	alert(getMessage('highlightsImportSuccess', String(importedCount)));
+}
+
+export function importHighlights(): void {
+	showImportModal(
+		'import-modal',
+		importHighlightsFromJson,
+		'.json',
+		false,
+		'importHighlights'
+	);
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -301,6 +301,18 @@
 											<button type="button" id="export-highlights" data-i18n="export">Export</button>
 										</div>
 									</div>
+
+									<div class="setting-item mod-horizontal">
+										<div class="setting-item-info">
+											<label for="import-highlights" data-i18n="importHighlights">Import highlights</label>
+											<div class="setting-item-description" data-i18n="importHighlightsDescription">
+												Import highlights from a file. Existing highlights are kept.
+											</div>
+										</div>
+										<div class="setting-item-control">
+											<button type="button" id="import-highlights" data-i18n="import">Import</button>
+										</div>
+									</div>
 								</div>
 							</div>
 						</form>

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -1139,6 +1139,29 @@ export function collapseGroupsForExport(
 	});
 }
 
+export interface ExportedPage {
+	url: string;
+	title?: string;
+	highlights: ExportedHighlight[];
+	data: AnyHighlightData[];
+}
+
+// One page of a highlights export file. `highlights` is the readable view and
+// must keep the same shape as the {{highlights}} template variable, so DOM
+// internals go in `data`, which lets an import restore the page exactly.
+export function buildExportedPage(
+	url: string,
+	highlights: AnyHighlightData[],
+	title?: string,
+): ExportedPage {
+	return {
+		url,
+		...(title ? { title } : {}),
+		highlights: collapseGroupsForExport(highlights),
+		data: highlights,
+	};
+}
+
 // Cross-tab sync: when another tab/extension page (e.g. highlights.html)
 // deletes or modifies highlights for this URL, pick up the change.
 // The bridge check ensures only the owning module instance acts: if the

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -233,7 +233,39 @@ export interface StoredData {
 	title?: string;
 }
 
-type HighlightsStorage = Record<string, StoredData>;
+export type HighlightsStorage = Record<string, StoredData>;
+
+// Highlights saved before URLs were normalized sit under the raw key until their
+// page is next opened. Fold that entry into the normalized one, matching on
+// content and keeping whichever copy still has an xpath.
+export function reconcileLegacyUrlKey(all: HighlightsStorage, rawUrl: string): void {
+	const url = normalizeUrl(rawUrl);
+	const legacy = all[rawUrl];
+	if (url === rawUrl || !legacy) return;
+
+	const existing = all[url];
+	if (!existing) {
+		all[url] = { ...legacy, url };
+		delete all[rawUrl];
+		return;
+	}
+
+	const positionByContent = new Map<string, number>();
+	existing.highlights.forEach((highlight, index) => {
+		if (!positionByContent.has(highlight.content)) positionByContent.set(highlight.content, index);
+	});
+	for (const highlight of legacy.highlights) {
+		const at = positionByContent.get(highlight.content);
+		if (at === undefined) {
+			positionByContent.set(highlight.content, existing.highlights.length);
+			existing.highlights.push(highlight);
+		} else if (!existing.highlights[at].xpath && highlight.xpath) {
+			existing.highlights[at] = highlight;
+		}
+	}
+	existing.title = existing.title ?? legacy.title;
+	delete all[rawUrl];
+}
 
 export function updateHighlights(newHighlights: AnyHighlightData[]) {
 	const oldHighlights = [...highlights];
@@ -1137,6 +1169,39 @@ export function collapseGroupsForExport(
 		if (mergedNotes.length > 0) entry.notes = mergedNotes;
 		return entry;
 	});
+}
+
+// Inverse of collapseGroupsForExport, for files written before exports carried
+// full records. A group arrives as one entry with its members joined by a blank
+// line, so split them apart and regroup. Ids come from the entry timestamp, with
+// later members offset to keep their order.
+export function expandExportedEntries(
+	entries: { text: string; timestamp?: string; notes?: string[] }[],
+): TextHighlightData[] {
+	const records: TextHighlightData[] = [];
+
+	entries.forEach((entry, entryIndex) => {
+		const parsed = entry.timestamp ? dayjs(entry.timestamp) : null;
+		const baseMs = parsed && parsed.isValid() ? parsed.valueOf() : Date.now();
+		const parts = entry.text.split('\n\n').filter(part => part.length > 0);
+		const groupId = parts.length > 1 ? `import-${baseMs}-${entryIndex}` : undefined;
+
+		parts.forEach((part, index) => {
+			records.push({
+				id: String(baseMs + index),
+				type: 'text',
+				xpath: '',
+				startOffset: 0,
+				endOffset: 0,
+				content: part,
+				...(groupId ? { groupId } : {}),
+				// Notes merge across a group on export, so they go back on the first.
+				...(index === 0 && entry.notes?.length ? { notes: entry.notes } : {}),
+			});
+		});
+	});
+
+	return records;
 }
 
 export interface ExportedPage {


### PR DESCRIPTION
Adds an **Import highlights** button in Settings under Highlighter. Closes #111 

- Imports a highlights JSON file and merges it into what is already stored.
- Validates the whole file before writing anything, so a malformed file is rejected rather than half applied.

### Export format

Exports now carry the full highlight records alongside the readable view:

```json
[{ "url": "...", "title": "...", "highlights": [...], "data": [...] }]
```

`highlights` is unchanged and still matches the `{{highlights}}` template variable, so clipped notes are unaffected. `data` holds the complete records so an import can restore a page exactly, including element highlights, group structure and text anchors.

Files exported before this change still import. They fall back to re-anchoring by text, which is enough for text highlights but cannot restore element highlights.

### Notes

- Highlights stored under a pre-normalization URL key are folded into the normalized key on import, so an export of older data does not duplicate on re-import.
- Duplicates are detected by content, so two highlights with identical text on the same page collapse into one.