### PR TITLE
Tokenize regex literals in filter arguments, add root_domain filter

### DIFF
--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -80,6 +80,7 @@ Regex is supported using JavaScript regex syntax:
 - Case-insensitive: `"HELLO world"|replace:"/hello/i":"hi"` → `"hi world".`
 - Multiple regex: `"hello world"|replace:("/[aeiou]/g":"*","/\s+/":"-")` → `"h*ll*-w*rld"`.
 - Available flags: `g` (global), `i` (case-insensitive), `m` (multiline), `s` (dotAll), `u` (unicode), `y` (sticky).
+- The quotes around the pattern are optional: `replace:/[aeiou]/g:"*"` works the same way.
 
 ### `safe_name`
 

--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -82,6 +82,15 @@ Regex is supported using JavaScript regex syntax:
 - Available flags: `g` (global), `i` (case-insensitive), `m` (multiline), `s` (dotAll), `u` (unicode), `y` (sticky).
 - The quotes around the pattern are optional: `replace:/[aeiou]/g:"*"` works the same way.
 
+### `root_domain`
+
+Reduces a hostname or URL to the registrable domain, dropping any subdomains.
+
+- `"news.ycombinator.com"|root_domain` returns `"ycombinator.com"`.
+- `"https://www.bbc.co.uk/news"|root_domain` returns `"bbc.co.uk"`, keeping two-part country suffixes intact.
+- Hosts without a dot and IP addresses are returned unchanged.
+- To get just the site name, chain it: `"news.ycombinator.com"|root_domain|split:"."|first` returns `"ycombinator"`.
+
 ### `safe_name`
 
 Converts text to a safe file name.

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -35,6 +35,7 @@ import { remove_html } from './filters/remove_html';
 import { remove_tags } from './filters/remove_tags';
 import { replace, validateReplaceParams } from './filters/replace';
 import { replace_tags } from './filters/replace_tags';
+import { root_domain } from './filters/root_domain';
 import { round, validateRoundParams } from './filters/round';
 import { safe_name, validateSafeNameParams } from './filters/safe_name';
 import { slice, validateSliceParams } from './filters/slice';
@@ -110,6 +111,7 @@ export const filterMetadata: Record<string, FilterMetadata> = {
 	remove_tags: {},
 	replace_tags: {},
 	reverse: {},
+	root_domain: {},
 	round: { example: 'round:2', validateParams: validateRoundParams },
 	safe_name: { example: 'safe_name:windows', validateParams: validateSafeNameParams },
 	snake: {},
@@ -165,6 +167,7 @@ export const filters: { [key: string]: FilterFunction } = {
 	remove_tags,
 	replace,
 	replace_tags,
+	root_domain,
 	round,
 	safe_name,
 	slice,

--- a/src/utils/filters/root_domain.test.ts
+++ b/src/utils/filters/root_domain.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest';
+import { root_domain } from './root_domain';
+
+describe('root_domain filter', () => {
+	test('leaves a bare registrable domain untouched', () => {
+		expect(root_domain('github.com')).toBe('github.com');
+	});
+
+	test('strips a subdomain', () => {
+		expect(root_domain('news.ycombinator.com')).toBe('ycombinator.com');
+	});
+
+	test('strips several subdomain levels', () => {
+		expect(root_domain('a.b.c.example.com')).toBe('example.com');
+	});
+
+	test('keeps a two-part country suffix', () => {
+		expect(root_domain('www.bbc.co.uk')).toBe('bbc.co.uk');
+		expect(root_domain('example.com.au')).toBe('example.com.au');
+		expect(root_domain('blog.example.co.jp')).toBe('example.co.jp');
+	});
+
+	test('does not over-trim a country TLD without a known second level', () => {
+		expect(root_domain('example.de')).toBe('example.de');
+		expect(root_domain('www.example.de')).toBe('example.de');
+	});
+
+	test('accepts a full URL', () => {
+		expect(root_domain('https://news.ycombinator.com/item?id=1')).toBe('ycombinator.com');
+		expect(root_domain('http://www.bbc.co.uk/news')).toBe('bbc.co.uk');
+	});
+
+	test('returns hosts without a dot unchanged', () => {
+		expect(root_domain('localhost')).toBe('localhost');
+	});
+
+	test('ignores port and trailing dot', () => {
+		expect(root_domain('www.example.com:8080')).toBe('example.com');
+		expect(root_domain('www.example.com.')).toBe('example.com');
+	});
+
+	test('leaves an IPv4 address alone', () => {
+		expect(root_domain('192.168.1.10')).toBe('192.168.1.10');
+	});
+
+	test('lowercases the result', () => {
+		expect(root_domain('WWW.Example.COM')).toBe('example.com');
+	});
+
+	test('returns empty input unchanged', () => {
+		expect(root_domain('')).toBe('');
+	});
+});

--- a/src/utils/filters/root_domain.ts
+++ b/src/utils/filters/root_domain.ts
@@ -1,0 +1,46 @@
+// Second-level labels that act as a public suffix under a country TLD, so that
+// bbc.co.uk keeps three labels while example.de keeps two. This is a heuristic
+// rather than the full public suffix list, covering the registries people
+// actually clip from.
+const COUNTRY_SECOND_LEVEL = new Set([
+	'ac', 'co', 'com', 'edu', 'go', 'gov', 'in', 'me', 'mil', 'ne', 'net',
+	'nom', 'or', 'org', 'sch',
+]);
+
+const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/**
+ * Reduces a hostname or URL to its registrable domain: the name that was
+ * actually registered, without subdomains.
+ *
+ * news.ycombinator.com -> ycombinator.com
+ * www.bbc.co.uk        -> bbc.co.uk
+ */
+export const root_domain = (str: string): string => {
+	if (!str) return str;
+
+	let host = str.trim();
+
+	// Accept a full URL as well as a bare hostname
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(host)) {
+		try {
+			host = new URL(host).hostname;
+		} catch (error) {
+			// Fall through and treat the input as a hostname
+		}
+	}
+
+	// Drop credentials, port, path and a fully-qualified trailing dot
+	host = host.replace(/^[^/@]*@/, '').split('/')[0].split(':')[0].replace(/\.$/, '').toLowerCase();
+
+	if (!host || IPV4.test(host)) return host;
+
+	const labels = host.split('.');
+	if (labels.length <= 2) return host;
+
+	const tld = labels[labels.length - 1];
+	const secondLevel = labels[labels.length - 2];
+	const keep = tld.length === 2 && COUNTRY_SECOND_LEVEL.has(secondLevel) ? 3 : 2;
+
+	return labels.slice(-keep).join('.');
+};

--- a/src/utils/template-compiler.test.ts
+++ b/src/utils/template-compiler.test.ts
@@ -42,4 +42,12 @@ describe('compileTemplate', () => {
 		});
 	});
 
+	describe('root_domain Filter', () => {
+		test('resolves the registrable domain in a path', async () => {
+			const output = await compile('Clippings/{{domain|root_domain|split:"."|first}}', {
+				'{{domain}}': 'news.ycombinator.com',
+			});
+			expect(output).toBe('Clippings/ycombinator');
+		});
+	});
 });

--- a/src/utils/template-compiler.test.ts
+++ b/src/utils/template-compiler.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'vitest';
+import { compileTemplate } from './template-compiler';
+
+const URL = 'https://www.bbc.co.uk/news/article';
+
+function compile(template: string, variables: Record<string, string>) {
+	return compileTemplate(0, template, variables, URL);
+}
+
+describe('compileTemplate', () => {
+	describe('Regex Filter Arguments', () => {
+		test('applies an unquoted regex literal', async () => {
+			const output = await compile('{{domain|replace:/^www\\./:""}}', { '{{domain}}': 'www.bbc.co.uk' });
+			expect(output).toBe('bbc.co.uk');
+		});
+
+		test('applies a quoted regex literal the same way', async () => {
+			const output = await compile('{{domain|replace:"/^www\\./":""}}', { '{{domain}}': 'www.bbc.co.uk' });
+			expect(output).toBe('bbc.co.uk');
+		});
+
+		test('honours regex flags', async () => {
+			const output = await compile('{{title|replace:/hello/gi:"hi"}}', { '{{title}}': 'Hello hello' });
+			expect(output).toBe('hi hi');
+		});
+
+		test('supports alternation inside the literal', async () => {
+			const output = await compile('{{domain|replace:/^(www|m)\\./:""}}', { '{{domain}}': 'm.example.com' });
+			expect(output).toBe('example.com');
+		});
+
+		test('keeps surrounding text when a regex literal is used in a path', async () => {
+			const output = await compile('Clippings/{{domain|replace:/^www\\./:""|split:"."|first}}', {
+				'{{domain}}': 'www.bbc.co.uk',
+			});
+			expect(output).toBe('Clippings/bbc');
+		});
+
+		test('still treats a bare slash as a separator argument', async () => {
+			const output = await compile('{{path|split:/|join:"-"}}', { '{{path}}': 'a/b/c' });
+			expect(output).toBe('a-b-c');
+		});
+	});
+
+});

--- a/src/utils/tokenizer.test.ts
+++ b/src/utils/tokenizer.test.ts
@@ -339,6 +339,51 @@ describe('Tokenizer', () => {
 		});
 	});
 
+	describe('Regex Literal Filter Arguments', () => {
+		test('tokenizes an unquoted regex literal as a string token', () => {
+			const result = tokenize('{{domain|replace:/^www\\./:""}}');
+			expect(result.errors).toHaveLength(0);
+			const strings = result.tokens.filter(t => t.type === 'string');
+			expect(strings[0].value).toBe('/^www\\./');
+			expect(strings[1].value).toBe('');
+		});
+
+		test('keeps regex flags with the literal', () => {
+			const result = tokenize('{{title|replace:/hello/gi:"hi"}}');
+			expect(result.errors).toHaveLength(0);
+			const strings = result.tokens.filter(t => t.type === 'string');
+			expect(strings[0].value).toBe('/hello/gi');
+		});
+
+		test('does not end the literal at a slash inside a character class', () => {
+			const result = tokenize('{{url|replace:/[/:]/g:"-"}}');
+			expect(result.errors).toHaveLength(0);
+			const strings = result.tokens.filter(t => t.type === 'string');
+			expect(strings[0].value).toBe('/[/:]/g');
+		});
+
+		test('keeps alternation inside the literal instead of ending at the pipe', () => {
+			const result = tokenize('{{domain|replace:/^(www|m)\\./:""}}');
+			expect(result.errors).toHaveLength(0);
+			const strings = result.tokens.filter(t => t.type === 'string');
+			expect(strings[0].value).toBe('/^(www|m)\\./');
+		});
+
+		test('still tokenizes a bare slash separator as a slash token', () => {
+			const result = tokenize('{{path|split:/|join:"-"}}');
+			expect(result.errors).toHaveLength(0);
+			expect(getTypes(result.tokens)).toContain('slash');
+			expect(result.tokens.some(t => t.type === 'string' && t.value.startsWith('/'))).toBe(false);
+		});
+
+		test('does not treat a slash in a text node as a regex', () => {
+			const result = tokenize('Clippings/{{domain}}');
+			expect(result.errors).toHaveLength(0);
+			expect(result.tokens[0].type).toBe('text');
+			expect(result.tokens[0].value).toBe('Clippings/');
+		});
+	});
+
 	describe('Filter Arguments with Empty String', () => {
 		test('tokenizes filter with empty string argument', () => {
 			const result = tokenize('{{"test"|replace:"%":""}}');

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -490,6 +490,17 @@ function tokenizeExpression(state: TokenizerState, mode: 'variable' | 'tag'): vo
 		return;
 	}
 
+	// Regex literal in filter argument position, e.g. replace:/^www\./:""
+	// Emitted as a string token so the parser and the filters see the same
+	// /pattern/flags form they already accept when it is written in quotes.
+	if (char === '/') {
+		const regexLiteral = tryTokenizeRegexLiteral(state);
+		if (regexLiteral !== null) {
+			state.tokens.push({ type: 'string', value: regexLiteral, line: startLine, column: startColumn });
+			return;
+		}
+	}
+
 	// Single-character operators and punctuation
 	switch (char) {
 		case '>':
@@ -586,6 +597,68 @@ function tokenizeExpression(state: TokenizerState, mode: 'variable' | 'tag'): vo
 // ============================================================================
 // Literal Tokenization
 // ============================================================================
+
+/**
+ * Try to read a regex literal (/pattern/flags) starting at the current slash.
+ *
+ * Returns the raw literal including its delimiters and flags and advances past it,
+ * or null when this slash does not start a well-formed regex literal — in which case
+ * the caller falls back to emitting a plain slash token, so a bare separator such as
+ * `split:/` keeps working.
+ */
+function tryTokenizeRegexLiteral(state: TokenizerState): string | null {
+	// A regex literal only makes sense where a filter argument is expected.
+	const prev = state.tokens[state.tokens.length - 1];
+	if (!prev || (prev.type !== 'colon' && prev.type !== 'comma')) return null;
+
+	let pos = state.pos + 1;
+	let inCharClass = false;
+	let closed = false;
+	let pattern = '';
+
+	while (pos < state.input.length) {
+		const char = state.input[pos];
+
+		if (char === '\\') {
+			const next = state.input[pos + 1];
+			if (next === undefined || next === '\n') return null;
+			pattern += char + next;
+			pos += 2;
+			continue;
+		}
+
+		// Bail out rather than swallowing the rest of the expression. Quotes and the
+		// closing delimiters mean this slash was punctuation, not a regex opener.
+		if (char === '\n' || char === '"' || char === "'") return null;
+		if (char === '}' && state.input[pos + 1] === '}') return null;
+		if (char === '%' && state.input[pos + 1] === '}') return null;
+
+		if (char === '[') inCharClass = true;
+		else if (char === ']') inCharClass = false;
+		else if (char === '/' && !inCharClass) {
+			closed = true;
+			break;
+		}
+
+		pattern += char;
+		pos++;
+	}
+
+	if (!closed || pattern.length === 0) return null;
+
+	pos++; // Consume the closing slash
+
+	let flags = '';
+	while (pos < state.input.length && REGEX_FLAGS.includes(state.input[pos])) {
+		flags += state.input[pos];
+		pos++;
+	}
+
+	advance(state, pos - state.pos);
+	return `/${pattern}/${flags}`;
+}
+
+const REGEX_FLAGS = 'gimsuy';
 
 function tokenizeString(state: TokenizerState): void {
 	const quote = state.input[state.pos];


### PR DESCRIPTION
Two related template-engine fixes that came up while building a `Clippings/{{domain}}` style path.

### Tokenize regex literals in filter arguments

An unquoted regex argument such as `replace:/^www\./:""` could not be lexed: inside an expression a `/` only ever produced a `slash` token, so the regex body was tokenized as ordinary tokens and metacharacters like `^` raised "Unexpected character" errors. Since a parse error makes the renderer return an empty string for the whole template, a path of `Clippings/{{domain|replace:/^www\./:""}}` compiled to `""` — losing the literal text too.

A `/pattern/flags` literal is now scanned where a filter argument is expected and emitted as a string token, which is the form the parser and filters already accept when the pattern is quoted. Slashes inside a character class do not end the literal, and anything that isn't a well-formed literal falls back to a slash token, so a bare separator like `split:/` keeps working.

### Add `root_domain` filter

Splitting a hostname on `.` to build a folder name buckets by the leftmost label, so `news.ycombinator.com` lands under `news` rather than `ycombinator`. The new filter reduces a hostname or URL to its registrable domain, and chains with `split:"."|first` when only the site name is wanted.

Two-part country suffixes are recognised from a list of common second-level labels rather than the full public suffix list, so `bbc.co.uk` keeps three labels while `example.de` keeps two. IP addresses and hosts without a dot pass through unchanged.

### Testing

`npm test` — 60 files, 624 tests passing, including new unit tests for the tokenizer change and the filter.
