### PR TITLE
Fix CLI document and async extraction

### DIFF
--- a/src/api.integration.test.ts
+++ b/src/api.integration.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { clip, DocumentParser } from './api';
+import { Template } from './types/types';
+
+const documentParser: DocumentParser = {
+	parseFromString(html: string) {
+		return new DOMParser().parseFromString(html, 'text/html');
+	},
+};
+
+const articleTemplate: Template = {
+	id: 'article',
+	name: 'Article',
+	behavior: 'create',
+	noteNameFormat: '{{title}}',
+	path: 'Clippings',
+	noteContentFormat: '{{title}}\n\n{{content}}',
+	properties: [],
+};
+
+const transcriptTemplate: Template = {
+	id: 'youtube-transcript',
+	name: 'YouTube transcript',
+	behavior: 'create',
+	noteNameFormat: '{{title}}',
+	path: 'Clippings',
+	noteContentFormat: '{{transcript}}',
+	properties: [
+		{ name: 'source', value: '{{url}}', type: 'text' },
+	],
+};
+
+const captionUrl = 'https://www.youtube.com/api/timedtext?v=abc123&lang=en';
+const youtubeHtml = `<!doctype html>
+<html>
+<head>
+	<title>Async transcript fixture</title>
+	<meta property="og:url" content="https://www.youtube.com/watch?v=abc123">
+	<meta property="og:title" content="Async transcript fixture">
+	<script type="application/ld+json">{
+		"@type": "VideoObject",
+		"@id": "https://www.youtube.com/watch?v=abc123",
+		"name": "Async transcript fixture",
+		"description": "A video with captions",
+		"author": "Fixture channel"
+	}</script>
+	<script>var ytInitialPlayerResponse = ${JSON.stringify({
+		videoDetails: { videoId: 'abc123', author: 'Fixture channel' },
+		captions: {
+			playerCaptionsTracklistRenderer: {
+				captionTracks: [{
+					baseUrl: captionUrl,
+					languageCode: 'en',
+					name: { simpleText: 'English' },
+				}],
+			},
+		},
+	})};</script>
+</head>
+<body><main><p>A video with captions</p></main></body>
+</html>`;
+
+function createFetchMock() {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = String(input);
+		if (url === captionUrl) {
+			return new Response(
+				'<transcript><text start="0" dur="2">Hello from the transcript.</text><text start="2" dur="2">The second caption is here.</text></transcript>',
+				{ status: 200, headers: { 'Content-Type': 'text/xml' } }
+			);
+		}
+		return new Response('{}', {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('clip API integration', () => {
+	test('extracts document metadata and article content without unnecessary requests', async () => {
+		const fetchMock = createFetchMock();
+		vi.stubGlobal('fetch', fetchMock);
+		const html = readFileSync(join(__dirname, 'utils', 'fixtures', 'templates', 'schema-rich.html'), 'utf8');
+		const result = await clip({
+			html,
+			url: 'https://example.com/recipe/chocolate-cake',
+			template: articleTemplate,
+			documentParser,
+		});
+
+		expect(result.noteName).toBe('Best Chocolate Cake Recipe');
+		expect(result.content).toContain('Best Chocolate Cake Recipe');
+		expect(result.content).toContain("This is the most amazing chocolate cake you'll ever make.");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test('uses a supplied parsed document without invoking the parser', async () => {
+		const html = readFileSync(join(__dirname, 'utils', 'fixtures', 'templates', 'schema-rich.html'), 'utf8');
+		const parsedDocument = documentParser.parseFromString(html, 'text/html');
+		const unusedParser: DocumentParser = {
+			parseFromString: vi.fn(() => {
+				throw new Error('The parser should not be called');
+			}),
+		};
+
+		const result = await clip({
+			html,
+			url: 'https://example.com/recipe/chocolate-cake',
+			template: articleTemplate,
+			documentParser: unusedParser,
+			parsedDocument,
+		});
+
+		expect(unusedParser.parseFromString).not.toHaveBeenCalled();
+		expect(result.content).toContain("This is the most amazing chocolate cake you'll ever make.");
+	});
+
+	test('automatically resolves transcript variables with the matching extractor', async () => {
+		const fetchMock = createFetchMock();
+		vi.stubGlobal('fetch', fetchMock);
+		const result = await clip({
+			html: youtubeHtml,
+			url: 'https://www.youtube.com/watch?v=abc123',
+			template: transcriptTemplate,
+			documentParser,
+		});
+
+		expect(result.noteName).toBe('Async transcript fixture');
+		expect(result.content).toContain('Hello from the transcript.');
+		expect(result.content).toContain('The second caption is here.');
+		expect(fetchMock.mock.calls.some(([input]) => String(input) === captionUrl)).toBe(true);
+	});
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,7 +25,7 @@ export interface ClipOptions {
 	template: Template;
 	documentParser: DocumentParser;
 	propertyTypes?: Record<string, string>;
-	/** Pre-parsed document to skip re-parsing (e.g. when already parsed for trigger matching). */
+	/** A complete, unmodified document that can be reused instead of parsing html. */
 	parsedDocument?: any;
 }
 
@@ -175,15 +175,12 @@ export function matchTemplate(templates: Template[], url: string, schemaOrgData?
  */
 export async function clip(options: ClipOptions): Promise<ClipResult> {
 	const { html, url, template, documentParser, propertyTypes, parsedDocument } = options;
-
-	// Use pre-parsed document if provided, otherwise parse
 	const doc = parsedDocument ?? documentParser.parseFromString(html, 'text/html');
-	const documentElement = doc.documentElement || doc;
 
 	// Extract content with defuddle
 	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
-	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
-	const defuddleResult = defuddle.parse();
+	const defuddle = new DefuddleClass(doc as unknown as Document, { url });
+	const defuddleResult = await defuddle.parseAsync();
 
 	// Convert to markdown
 	const markdownContent = createMarkdownContent(defuddleResult.content, url);

--- a/src/cli.integration.test.ts
+++ b/src/cli.integration.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const projectRoot = resolve(__dirname, '..');
+const cliPath = join(projectRoot, 'dist', 'cli.cjs');
+let testDirectory = '';
+
+beforeAll(() => {
+	execFileSync(process.execPath, [join(projectRoot, 'scripts', 'build-cli.mjs')], {
+		cwd: projectRoot,
+		stdio: 'pipe',
+	});
+	testDirectory = mkdtempSync(join(tmpdir(), 'obsidian-clipper-cli-test-'));
+});
+
+afterAll(() => {
+	if (testDirectory) {
+		rmSync(testDirectory, { recursive: true, force: true });
+	}
+});
+
+describe('CLI integration', () => {
+	test('automatically performs required follow-up requests in URL and HTML modes', () => {
+		const sourceUrl = 'https://www.youtube.com/watch?v=abc123';
+		const captionUrl = 'https://www.youtube.com/api/timedtext?v=abc123&lang=en';
+		const htmlPath = join(testDirectory, 'youtube.html');
+		const templatePath = join(testDirectory, 'youtube-template.json');
+		const preloadPath = join(testDirectory, 'mock-fetch.cjs');
+		const playerResponse = JSON.stringify({
+			videoDetails: { videoId: 'abc123', author: 'Fixture channel' },
+			captions: {
+				playerCaptionsTracklistRenderer: {
+					captionTracks: [{
+						baseUrl: captionUrl,
+						languageCode: 'en',
+						name: { simpleText: 'English' },
+					}],
+				},
+			},
+		});
+
+		writeFileSync(htmlPath, `<!doctype html>
+<html>
+<head>
+	<title>Automatic extraction fixture</title>
+	<meta property="og:url" content="${sourceUrl}">
+	<meta property="og:title" content="Automatic extraction fixture">
+	<script type="application/ld+json">{
+		"@type": "VideoObject",
+		"@id": "${sourceUrl}",
+		"name": "Automatic extraction fixture",
+		"description": "A video with captions"
+	}</script>
+	<script>var ytInitialPlayerResponse = ${playerResponse};</script>
+</head>
+<body><main><p>A video with captions</p></main></body>
+</html>`);
+		writeFileSync(templatePath, JSON.stringify({
+			id: 'youtube-transcript',
+			name: 'YouTube transcript',
+			behavior: 'create',
+			noteNameFormat: '{{title}}',
+			path: 'Clippings',
+			noteContentFormat: '{{transcript}}',
+			properties: [],
+		}, null, 2));
+		writeFileSync(preloadPath, `
+const fs = require('fs');
+globalThis.fetch = async (input) => {
+	const url = String(input);
+	fs.appendFileSync(process.env.FETCH_LOG, url + '\\n');
+	if (url === process.env.SOURCE_URL) {
+		return new Response(fs.readFileSync(process.env.MOCK_HTML, 'utf8'), {
+			status: 200,
+			headers: { 'Content-Type': 'text/html' },
+		});
+	}
+	if (url === process.env.CAPTION_URL) {
+		return new Response('<transcript><text start="0" dur="2">Automatically extracted transcript.</text></transcript>', {
+			status: 200,
+			headers: { 'Content-Type': 'text/xml' },
+		});
+	}
+	return new Response('{}', {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+};
+`);
+
+		const runCli = (name: string, args: string[]) => {
+			const outputPath = join(testDirectory, `${name}.md`);
+			const fetchLogPath = join(testDirectory, `${name}.requests`);
+			const processResult = spawnSync(process.execPath, [
+				'--require', preloadPath,
+				cliPath,
+				...args,
+				'--template', templatePath,
+				'--output', outputPath,
+			], {
+				cwd: projectRoot,
+				encoding: 'utf8',
+				env: {
+					...process.env,
+					CAPTION_URL: captionUrl,
+					FETCH_LOG: fetchLogPath,
+					MOCK_HTML: htmlPath,
+					SOURCE_URL: sourceUrl,
+				},
+			});
+			const requests = existsSync(fetchLogPath)
+				? readFileSync(fetchLogPath, 'utf8').split('\n').filter(Boolean)
+				: [];
+			const output = existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : '';
+			return { processResult, requests, output };
+		};
+
+		const htmlResult = runCli('html', [sourceUrl, '--html', htmlPath]);
+		expect(htmlResult.processResult.status).toBe(0);
+		expect(htmlResult.requests).toContain(captionUrl);
+		expect(htmlResult.output).toContain('Automatically extracted transcript.');
+
+		const urlResult = runCli('url', [sourceUrl]);
+		expect(urlResult.processResult.status).toBe(0);
+		expect(urlResult.requests).toContain(sourceUrl);
+		expect(urlResult.requests).toContain(captionUrl);
+		expect(urlResult.output).toContain('Automatically extracted transcript.');
+	});
+
+	test('matches a schema template and extracts the article', () => {
+		const templatesDirectory = join(testDirectory, 'templates');
+		const htmlPath = join(testDirectory, 'article.html');
+		const outputPath = join(testDirectory, 'article.md');
+		mkdirSync(templatesDirectory);
+
+		writeFileSync(join(templatesDirectory, 'article.json'), JSON.stringify({
+			id: 'article',
+			name: 'Article',
+			behavior: 'create',
+			noteNameFormat: '{{title}}',
+			path: 'Clippings',
+			noteContentFormat: '# {{title}}\n\n{{content}}',
+			properties: [
+				{ name: 'source', value: '{{url}}', type: 'text' },
+			],
+			triggers: ['schema:@Article'],
+		}, null, 2));
+
+		writeFileSync(htmlPath, `<!doctype html>
+<html>
+<head>
+	<title>Schema matched article</title>
+	<meta name="description" content="A controlled article for CLI extraction.">
+	<script type="application/ld+json">{
+		"@type": "Article",
+		"headline": "Schema matched article"
+	}</script>
+</head>
+<body>
+	<main>
+		<article>
+			<h1>Schema matched article</h1>
+			<p>This controlled article verifies that schema template matching and content extraction both receive a complete document. It contains enough readable prose for the extractor to identify the article body and preserve it in the generated Markdown note. The test invokes the built command line bundle with a local HTML file, a template directory, and a real output path. A successful run preserves headings, paragraphs, metadata, and links instead of returning an empty document with a successful exit status.</p>
+			<p>The generated note must retain this second paragraph after schema matching completes. Additional prose keeps the fixture above article detection thresholds without relying on remote pages, authentication, browser state, or changing third-party layouts. This integration test protects the observable command line contract while the separate end-to-end validation exercises live websites.</p>
+		</article>
+	</main>
+</body>
+</html>`);
+
+		const processResult = spawnSync(process.execPath, [
+			cliPath,
+			'https://example.com/schema-article',
+			'--template', templatesDirectory,
+			'--html', htmlPath,
+			'--output', outputPath,
+		], {
+			cwd: projectRoot,
+			encoding: 'utf8',
+		});
+
+		expect(processResult.status).toBe(0);
+		expect(processResult.stderr).toContain('Matched template:');
+		expect(processResult.stderr).toContain('Written to');
+
+		const output = readFileSync(outputPath, 'utf8');
+		expect(output).toContain('# Schema matched article');
+		expect(output).toContain('This controlled article verifies');
+		expect(output).toContain('The generated note must retain this second paragraph');
+	});
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 // Browser globals (DOMParser, window, document) are provided by the esbuild
 // banner in scripts/build-cli.mjs. They must run before any bundled module code.
 import { parseHTML } from 'linkedom';
+import DefuddleClass from 'defuddle';
 import { clip, matchTemplate, DocumentParser } from './api';
 import { openInObsidian } from './utils/cli-utils';
 import { Template } from './types/types';
@@ -196,7 +197,6 @@ async function main(): Promise<void> {
 
 	// If using a template directory, match template by triggers.
 	// Try URL triggers first (no parsing needed). Only parse for schema if required.
-	let parsedDocument: any;
 	if (templates) {
 		// First try URL-only matching (no HTML parsing needed)
 		let matched = matchTemplate(templates, args.url);
@@ -205,9 +205,8 @@ async function main(): Promise<void> {
 		if (!matched) {
 			const hasSchemaTrigs = templates.some(t => t.triggers?.some(tr => tr.startsWith('schema:')));
 			if (hasSchemaTrigs) {
-				const DefuddleClass = (await import('defuddle')).default;
-				parsedDocument = linkedomParser.parseFromString(html, 'text/html');
-				const defuddle = new DefuddleClass((parsedDocument.documentElement || parsedDocument) as unknown as Document, { url: args.url });
+				const matchingDocument = linkedomParser.parseFromString(html, 'text/html');
+				const defuddle = new DefuddleClass(matchingDocument as unknown as Document, { url: args.url });
 				const defuddleResult = defuddle.parse();
 				matched = matchTemplate(templates, args.url, defuddleResult.schemaOrgData);
 			}
@@ -227,14 +226,13 @@ async function main(): Promise<void> {
 		process.exit(1);
 	}
 
-	// Call the API (reuse pre-parsed document if available)
+	// Call the API
 	const result = await clip({
 		html,
 		url: args.url,
 		template,
 		documentParser: linkedomParser,
 		propertyTypes,
-		parsedDocument,
 	});
 
 	// Output


### PR DESCRIPTION
## Summary

Pass a full `Document` to Defuddle, reparse after schema trigger matching, and await async extractors. This fixes blank CLI output and makes variables such as YouTube transcripts available without adding CLI flags. Includes the root fix proposed in #795.

## Before / after

| Input | Before | After |
| --- | --- | --- |
| [Wikipedia](https://en.wikipedia.org/wiki/Web_scraping) | 0 words | 4,153 words |
| [Kaggle](https://www.kaggle.com/datasets/uciml/iris), rendered HTML | 0 words | 1,275 words, including Iris dataset content |
| [X](https://twitter.com/jack/status/20) | Blank | `just setting up my twttr` |
| [YouTube](https://www.youtube.com/watch?v=iQyg-KypKAA), rendered HTML | No transcript | 9,283 words, 510 timestamps from 0:00 to 45:43 |

## Tests

- `TZ=America/Los_Angeles npm test` - 605 passed
- `npx tsc --noEmit`
- `npm run build:cli && npm run build:api`
