### PR TITLE
Fix CLI document and async extraction

### DIFF
--- a/src/api.integration.test.ts
+++ b/src/api.integration.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { clip, DocumentParser } from './api';
+import { Template } from './types/types';
+
+const documentParser: DocumentParser = {
+	parseFromString(html: string) {
+		return new DOMParser().parseFromString(html, 'text/html');
+	},
+};
+
+const articleTemplate: Template = {
+	id: 'article',
+	name: 'Article',
+	behavior: 'create',
+	noteNameFormat: '{{title}}',
+	path: 'Clippings',
+	noteContentFormat: '{{title}}\n\n{{content}}',
+	properties: [],
+};
+
+const transcriptTemplate: Template = {
+	id: 'youtube-transcript',
+	name: 'YouTube transcript',
+	behavior: 'create',
+	noteNameFormat: '{{title}}',
+	path: 'Clippings',
+	noteContentFormat: '{{transcript}}',
+	properties: [
+		{ name: 'source', value: '{{url}}', type: 'text' },
+	],
+};
+
+const captionUrl = 'https://www.youtube.com/api/timedtext?v=abc123&lang=en';
+const youtubeHtml = `<!doctype html>
+<html>
+<head>
+	<title>Async transcript fixture</title>
+	<meta property="og:url" content="https://www.youtube.com/watch?v=abc123">
+	<meta property="og:title" content="Async transcript fixture">
+	<script type="application/ld+json">{
+		"@type": "VideoObject",
+		"@id": "https://www.youtube.com/watch?v=abc123",
+		"name": "Async transcript fixture",
+		"description": "A video with captions",
+		"author": "Fixture channel"
+	}</script>
+	<script>var ytInitialPlayerResponse = ${JSON.stringify({
+		videoDetails: { videoId: 'abc123', author: 'Fixture channel' },
+		captions: {
+			playerCaptionsTracklistRenderer: {
+				captionTracks: [{
+					baseUrl: captionUrl,
+					languageCode: 'en',
+					name: { simpleText: 'English' },
+				}],
+			},
+		},
+	})};</script>
+</head>
+<body><main><p>A video with captions</p></main></body>
+</html>`;
+
+function createFetchMock() {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = String(input);
+		if (url === captionUrl) {
+			return new Response(
+				'<transcript><text start="0" dur="2">Hello from the transcript.</text><text start="2" dur="2">The second caption is here.</text></transcript>',
+				{ status: 200, headers: { 'Content-Type': 'text/xml' } }
+			);
+		}
+		return new Response('{}', {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('clip API integration', () => {
+	test('extracts document metadata and article content without unnecessary requests', async () => {
+		const fetchMock = createFetchMock();
+		vi.stubGlobal('fetch', fetchMock);
+		const html = readFileSync(join(__dirname, 'utils', 'fixtures', 'templates', 'schema-rich.html'), 'utf8');
+		const result = await clip({
+			html,
+			url: 'https://example.com/recipe/chocolate-cake',
+			template: articleTemplate,
+			documentParser,
+		});
+
+		expect(result.noteName).toBe('Best Chocolate Cake Recipe');
+		expect(result.content).toContain('Best Chocolate Cake Recipe');
+		expect(result.content).toContain("This is the most amazing chocolate cake you'll ever make.");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test('automatically resolves transcript variables with the matching extractor', async () => {
+		const fetchMock = createFetchMock();
+		vi.stubGlobal('fetch', fetchMock);
+		const result = await clip({
+			html: youtubeHtml,
+			url: 'https://www.youtube.com/watch?v=abc123',
+			template: transcriptTemplate,
+			documentParser,
+		});
+
+		expect(result.noteName).toBe('Async transcript fixture');
+		expect(result.content).toContain('Hello from the transcript.');
+		expect(result.content).toContain('The second caption is here.');
+		expect(fetchMock.mock.calls.some(([input]) => String(input) === captionUrl)).toBe(true);
+	});
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -175,15 +175,12 @@ export function matchTemplate(templates: Template[], url: string, schemaOrgData?
  */
 export async function clip(options: ClipOptions): Promise<ClipResult> {
 	const { html, url, template, documentParser, propertyTypes, parsedDocument } = options;
-
-	// Use pre-parsed document if provided, otherwise parse
 	const doc = parsedDocument ?? documentParser.parseFromString(html, 'text/html');
-	const documentElement = doc.documentElement || doc;
 
 	// Extract content with defuddle
 	// Cast through unknown: linkedom's Document is structurally compatible but not nominally typed as DOM Document
-	const defuddle = new DefuddleClass(documentElement as unknown as Document, { url });
-	const defuddleResult = defuddle.parse();
+	const defuddle = new DefuddleClass(doc as unknown as Document, { url });
+	const defuddleResult = await defuddle.parseAsync();
 
 	// Convert to markdown
 	const markdownContent = createMarkdownContent(defuddleResult.content, url);

--- a/src/cli.integration.test.ts
+++ b/src/cli.integration.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const projectRoot = resolve(__dirname, '..');
+const cliPath = join(projectRoot, 'dist', 'cli.cjs');
+let testDirectory = '';
+
+beforeAll(() => {
+	execFileSync(process.execPath, [join(projectRoot, 'scripts', 'build-cli.mjs')], {
+		cwd: projectRoot,
+		stdio: 'pipe',
+	});
+	testDirectory = mkdtempSync(join(tmpdir(), 'obsidian-clipper-cli-test-'));
+});
+
+afterAll(() => {
+	if (testDirectory) {
+		rmSync(testDirectory, { recursive: true, force: true });
+	}
+});
+
+describe('CLI integration', () => {
+	test('matches a schema template and extracts the article', () => {
+		const templatesDirectory = join(testDirectory, 'templates');
+		const htmlPath = join(projectRoot, 'src', 'utils', 'fixtures', 'templates', 'schema-rich.html');
+		const outputPath = join(testDirectory, 'article.md');
+		mkdirSync(templatesDirectory);
+
+		writeFileSync(join(templatesDirectory, 'recipe.json'), JSON.stringify({
+			id: 'recipe',
+			name: 'Recipe',
+			behavior: 'create',
+			noteNameFormat: '{{title}}',
+			path: 'Clippings',
+			noteContentFormat: '# {{title}}\n\n{{content}}',
+			properties: [
+				{ name: 'source', value: '{{url}}', type: 'text' },
+			],
+			triggers: ['schema:@Recipe'],
+		}, null, 2));
+
+		const processResult = spawnSync(process.execPath, [
+			cliPath,
+			'https://example.com/recipe/chocolate-cake',
+			'--template', templatesDirectory,
+			'--html', htmlPath,
+			'--output', outputPath,
+		], {
+			cwd: projectRoot,
+			encoding: 'utf8',
+		});
+
+		expect(processResult.status).toBe(0);
+		expect(processResult.stderr).toContain('Matched template:');
+
+		const output = readFileSync(outputPath, 'utf8');
+		expect(output).toContain('# Best Chocolate Cake Recipe');
+		expect(output).toContain("This is the most amazing chocolate cake you'll ever make.");
+	});
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 // Browser globals (DOMParser, window, document) are provided by the esbuild
 // banner in scripts/build-cli.mjs. They must run before any bundled module code.
 import { parseHTML } from 'linkedom';
+import DefuddleClass from 'defuddle';
 import { clip, matchTemplate, DocumentParser } from './api';
 import { openInObsidian } from './utils/cli-utils';
 import { Template } from './types/types';
@@ -205,9 +206,8 @@ async function main(): Promise<void> {
 		if (!matched) {
 			const hasSchemaTrigs = templates.some(t => t.triggers?.some(tr => tr.startsWith('schema:')));
 			if (hasSchemaTrigs) {
-				const DefuddleClass = (await import('defuddle')).default;
 				parsedDocument = linkedomParser.parseFromString(html, 'text/html');
-				const defuddle = new DefuddleClass((parsedDocument.documentElement || parsedDocument) as unknown as Document, { url: args.url });
+				const defuddle = new DefuddleClass(parsedDocument as unknown as Document, { url: args.url });
 				const defuddleResult = defuddle.parse();
 				matched = matchTemplate(templates, args.url, defuddleResult.schemaOrgData);
 			}


### PR DESCRIPTION
## Summary

The CLI passed an HTML element to Defuddle, causing blank output, and used synchronous parsing, so extractors such as YouTube transcripts never ran. This passes the full `Document` in both API and schema-trigger paths and awaits async extraction without adding CLI flags.

This includes the root fix from #795 and extends it to schema-trigger matching and async variables.

## Before / after

| Input | Before | After |
| --- | --- | --- |
| [Wikipedia](https://en.wikipedia.org/wiki/Web_scraping) | 0 words | 4,153 words |
| [Kaggle](https://www.kaggle.com/datasets/uciml/iris), rendered HTML | 0 words | 1,275 words with Iris dataset content |
| [X](https://twitter.com/jack/status/20) | Blank | `just setting up my twttr` |
| [YouTube](https://www.youtube.com/watch?v=iQyg-KypKAA), rendered HTML | No transcript | 9,283 words, 510 timestamps from 0:00 to 45:43 |

## Tests

- `TZ=America/Los_Angeles npm test` - 603 passed
- `npx tsc --noEmit`
- `npm run build:cli && npm run build:api`
