### PR TITLE
feat(i18n): Add i18n for context menu items

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -17,6 +17,9 @@
 	"addProviderTitle": {
 		"message": "Add provider"
 	},
+	"addToHighlights": {
+		"message": "Add to highlights"
+	},
 	"addToObsidian": {
 		"message": "Add to Obsidian"
 	},
@@ -925,6 +928,9 @@
 	},
 	"saveFile": {
 		"message": "Save file..."
+	},
+	"saveThisPage": {
+		"message": "Save this page"
 	},
 	"searchHighlightsPlaceholder": {
 		"message": "Search highlights…"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -17,6 +17,9 @@
 	"addProviderTitle": {
 		"message": "제공자 추가"
 	},
+	"addToHighlights": {
+		"message": "하이라이트 추가"
+	},
 	"addToObsidian": {
 		"message": "Obsidian에 추가하기"
 	},
@@ -925,6 +928,9 @@
 	},
 	"saveFile": {
 		"message": "파일 저장..."
+	},
+	"saveThisPage": {
+		"message": "페이지 저장"
 	},
 	"searchHighlightsPlaceholder": {
 		"message": "하이라이트 검색…"

--- a/src/background.ts
+++ b/src/background.ts
@@ -799,7 +799,7 @@ const debouncedUpdateContextMenu = debounce(async (tabId: number) => {
 		}[] = [
 				{
 					id: "open-obsidian-clipper",
-					title: "Save this page",
+					title: browser.i18n.getMessage('saveThisPage'),
 					contexts: ["page", "selection", "image", "video", "audio"]
 				},
 				{
@@ -819,12 +819,12 @@ const debouncedUpdateContextMenu = debounce(async (tabId: number) => {
 				},
 				{
 					id: "highlight-selection",
-					title: "Add to highlights",
+					title: browser.i18n.getMessage('addToHighlights'),
 					contexts: ["selection"]
 				},
 				{
 					id: "highlight-element",
-					title: "Add to highlights",
+					title: browser.i18n.getMessage('addToHighlights'),
 					contexts: ["image", "video", "audio"]
 				},
 				{


### PR DESCRIPTION
Improve internationalization support for context menu items.

## Code changes

* Added `saveThisPage` and `addToHighlights` message keys to `src/background.ts`.

* Updated `src/_locales/en/messages.json` and `src/_locales/ko/messages.json`.

### Before
Some items in the context menu are not translated.
<img width="354" height="216" alt="screenshot_2026-08-08_02-25-02" src="https://github.com/user-attachments/assets/d0871a2d-717a-41b5-bd39-c17dc99db444" />

### After
<img width="254" height="226" alt="screenshot_2026-08-08_03-37-06" src="https://github.com/user-attachments/assets/2f1f810f-96e4-47cc-8f7e-c848b4b1ad88" />
