### PR TITLE
fix(popup): keep Add button visible when content is long

### DIFF
--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -103,6 +103,8 @@
 	height: 100%;
 	max-height: 100%;
 	overflow: hidden;
+	// Let middle sections shrink so the footer (Add / clip) stays visible (#921).
+	min-height: 0;
 
 	#note-name-field {
 		border: none;
@@ -115,6 +117,7 @@
 		min-height: 2rem;
 		max-height: 6rem;
 		overflow-y: auto;
+		flex-shrink: 0;
 		&:active,
 		&:focus {
 			box-shadow: none;
@@ -128,12 +131,19 @@
 		border-top: 1px solid var(--divider-color);
 		display: flex;
 		flex-grow: 1;
+		// Classic flex min-size: allow the content pane to shrink under long text
+		// so .clipper-footer is not pushed below the fixed popup height (#921).
+		min-height: 0;
+		overflow: hidden;
 		#note-content-field {
 			background-color: transparent;
 			border-radius: 0;
 			border: none;
 			padding: 10px var(--popup-padding);
 			resize: none;
+			min-height: 0;
+			width: 100%;
+			overflow-y: auto;
 			&:active,
 			&:focus {
 				box-shadow: none;
@@ -149,6 +159,8 @@
 		padding: 0.625rem;
 		border-top: 1px solid var(--divider-color);
 		background-color: var(--background-primary);
+		// Keep Add / path controls visible when note content or properties grow.
+		flex-shrink: 0;
 		button {
 			font-weight: var(--clipper-button-font-weight);
 			font-size: var(--clipper-button-font-size);

--- a/src/styles/properties.scss
+++ b/src/styles/properties.scss
@@ -6,6 +6,7 @@
 	color: var(--text-muted);
 	user-select: none;
 	-webkit-user-select: none;
+	flex-shrink: 0;
 
 	display: flex;
 	flex-direction: row;
@@ -33,9 +34,12 @@
 	display: flex;
 	flex-direction: column;
 	flex-shrink: 1;
+	// Cap property list height so long descriptions cannot push the Add button
+	// out of the fixed-height browser popup (#921).
+	min-height: 0;
 	gap: var(--metadata-gap);
-	max-height: 46%;
-	overflow-y: scroll;
+	max-height: 40%;
+	overflow-y: auto;
 	&:empty {
 		display: none;
 	}


### PR DESCRIPTION
### Summary
Long note content or many properties can push the popup footer (Add/clip) below the fixed popup height.

- Let note content and metadata shrink and scroll (min-height: 0)
- Cap properties list height; overflow-y: auto
- Footer flex-shrink: 0 so the primary action stays visible

### Validation
- CSS-only; layout review of popup.scss / properties.scss

Fixes #921

### AI disclosure
AI tools helped draft code and this description. I reviewed the change before submitting.
